### PR TITLE
feat(widget): add Russian (ru) locale

### DIFF
--- a/packages/widget/__tests__/i18n/i18n.test.ts
+++ b/packages/widget/__tests__/i18n/i18n.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { en } from "../../src/i18n/en.js";
 import { fr } from "../../src/i18n/fr.js";
 import { createT, getTypeLabel } from "../../src/i18n/index.js";
+import { ru } from "../../src/i18n/ru.js";
 
 // ---------------------------------------------------------------------------
 // createT — locale resolution
@@ -20,6 +21,13 @@ describe("createT", () => {
     expect(t("panel.title")).toBe("Feedbacks");
     expect(t("panel.close")).toBe("Close panel");
     expect(t("popup.submit")).toBe("Send");
+  });
+
+  it("returns Russian translations for 'ru'", () => {
+    const t = createT("ru");
+    expect(t("panel.title")).toBe("Обратная связь");
+    expect(t("panel.close")).toBe("Закрыть панель");
+    expect(t("popup.submit")).toBe("Отправить");
   });
 
   it("resolves language prefix from full locale tag (e.g. 'fr-FR')", () => {
@@ -90,9 +98,14 @@ describe("getTypeLabel", () => {
 describe("translation completeness", () => {
   const enKeys = Object.keys(en).sort();
   const frKeys = Object.keys(fr).sort();
+  const ruKeys = Object.keys(ru).sort();
 
   it("en.ts and fr.ts have the same set of keys", () => {
     expect(enKeys).toEqual(frKeys);
+  });
+
+  it("en.ts and ru.ts have the same set of keys", () => {
+    expect(enKeys).toEqual(ruKeys);
   });
 
   it("no translation value is an empty string in fr.ts", () => {
@@ -107,6 +120,12 @@ describe("translation completeness", () => {
     }
   });
 
+  it("no translation value is an empty string in ru.ts", () => {
+    for (const [key, value] of Object.entries(ru)) {
+      expect(value, `ru.ts key "${key}" is empty`).not.toBe("");
+    }
+  });
+
   it("all keys in en.ts exist in fr.ts", () => {
     for (const key of enKeys) {
       expect(fr).toHaveProperty(key);
@@ -116,6 +135,12 @@ describe("translation completeness", () => {
   it("all keys in fr.ts exist in en.ts", () => {
     for (const key of frKeys) {
       expect(en).toHaveProperty(key);
+    }
+  });
+
+  it("all keys in en.ts exist in ru.ts", () => {
+    for (const key of enKeys) {
+      expect(ru).toHaveProperty(key);
     }
   });
 });

--- a/packages/widget/src/i18n/index.ts
+++ b/packages/widget/src/i18n/index.ts
@@ -6,8 +6,9 @@ export type { TFunction, Translations } from "./types.js";
 // For tree-shaking in consumer apps, use dynamic import() with a bundler plugin.
 import { en } from "./en.js";
 import { fr } from "./fr.js";
+import { ru } from "./ru.js";
 
-const LOCALES: Record<string, Translations> = { fr, en };
+const LOCALES: Record<string, Translations> = { fr, en, ru };
 
 /** Register a custom locale at runtime. */
 export function registerLocale(code: string, translations: Translations): void {

--- a/packages/widget/src/i18n/ru.ts
+++ b/packages/widget/src/i18n/ru.ts
@@ -1,0 +1,81 @@
+import type { Translations } from "./types.js";
+
+export const ru: Translations = {
+  // Panel
+  "panel.title": "Обратная связь",
+  "panel.ariaLabel": "Панель обратной связи Siteping",
+  "panel.feedbackList": "Список отзывов",
+  "panel.loading": "Загрузка отзывов",
+  "panel.close": "Закрыть панель",
+  "panel.deleteAll": "Удалить всё",
+  "panel.deleteAllConfirmTitle": "Удалить всё",
+  "panel.deleteAllConfirmMessage": "Удалить все отзывы этого проекта? Это действие необратимо.",
+  "panel.search": "Поиск...",
+  "panel.searchAria": "Поиск по отзывам",
+  "panel.filterAll": "Все",
+  "panel.loadError": "Ошибка загрузки",
+  "panel.retry": "Повторить",
+  "panel.empty": "Пока нет отзывов",
+  "panel.showMore": "Показать больше",
+  "panel.showLess": "Показать меньше",
+  "panel.resolve": "Решено",
+  "panel.reopen": "Открыть заново",
+  "panel.delete": "Удалить",
+  "panel.cancel": "Отмена",
+  "panel.confirmDelete": "Удалить",
+  "panel.loadMore": "Показать ещё ({remaining} осталось)",
+
+  // Status filter labels
+  "panel.statusAll": "Все",
+  "panel.statusOpen": "Открытые",
+  "panel.statusResolved": "Решённые",
+
+  // Feedback type labels
+  "type.question": "Вопрос",
+  "type.change": "Улучшение",
+  "type.bug": "Баг",
+  "type.other": "Другое",
+
+  // FAB menu
+  "fab.aria": "Siteping — Меню обратной связи",
+  "fab.messages": "Сообщения",
+  "fab.annotate": "Аннотация",
+  "fab.annotations": "Аннотации",
+
+  // Annotator
+  "annotator.instruction": "Выделите область для комментария",
+  "annotator.cancel": "Отмена",
+
+  // Popup
+  "popup.ariaLabel": "Форма обратной связи",
+  "popup.placeholder": "Опишите проблему или предложение...",
+  "popup.textareaAria": "Сообщение",
+  "popup.submitHintMac": "⌘+Enter — отправить",
+  "popup.submitHintOther": "Ctrl+Enter — отправить",
+  "popup.cancel": "Отмена",
+  "popup.submit": "Отправить",
+
+  // Identity modal
+  "identity.title": "Представьтесь",
+  "identity.nameLabel": "Имя",
+  "identity.namePlaceholder": "Ваше имя",
+  "identity.emailLabel": "Email",
+  "identity.emailPlaceholder": "ваш@email.com",
+  "identity.cancel": "Отмена",
+  "identity.submit": "Продолжить",
+
+  // Markers
+  "marker.approximate": "Приблизительная позиция (точность: {confidence}%)",
+  "marker.aria": "Отзыв #{number}: {type} — {message}",
+
+  // FAB badge
+  "fab.badge": "Нерешённых отзывов: {count}",
+
+  // Accessibility — screen reader announcements
+  "feedback.sent.confirmation": "Отзыв успешно отправлен",
+  "feedback.error.message": "Не удалось отправить отзыв",
+  "feedback.deleted.confirmation": "Отзыв удалён",
+
+  // Badge
+  "badge.count": "Нерешённых отзывов: {count}",
+};


### PR DESCRIPTION
## Summary

- Adds Russian (`ru`) locale to `@siteping/widget` (81 translation keys, all aligned with the current `Translations` interface)
- Registers `ru` in the static `LOCALES` map alongside `en` and `fr` so it works out-of-the-box (`createT("ru")` / `createT("ru-RU")`)
- Adds completeness tests so any future key added to `en.ts` will fail CI until `ru.ts` is updated too

## Credit

Locale ported from the [Trade-su/SitePing](https://github.com/Trade-su/SitePing) fork by **@grizodubov** — thanks for the contribution! The commit carries a `Co-authored-by:` trailer so GitHub attributes it properly.

## Test plan

- [x] `bun run check` — typecheck clean
- [x] `bun run lint` — biome clean
- [x] `bun run test:run` — 786/786 tests pass (including 5 new RU tests)
- [x] `bun run build` — widget builds successfully