### PR TITLE
feat(widget): add Portuguese (pt) locale

### DIFF
--- a/packages/widget/__tests__/i18n/i18n.test.ts
+++ b/packages/widget/__tests__/i18n/i18n.test.ts
@@ -3,6 +3,7 @@ import { de } from "../../src/i18n/de.js";
 import { en } from "../../src/i18n/en.js";
 import { fr } from "../../src/i18n/fr.js";
 import { createT, getTypeLabel } from "../../src/i18n/index.js";
+import { pt } from "../../src/i18n/pt.js";
 import { ru } from "../../src/i18n/ru.js";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,13 @@ describe("createT", () => {
     expect(t("panel.close")).toBe("Panel schließen");
     expect(t("popup.submit")).toBe("Senden");
     expect(t("type.question")).toBe("Frage");
+  });
+
+  it("returns Brazilian Portuguese translations for 'pt' and 'pt-BR'", () => {
+    const t = createT("pt-BR");
+    expect(t("panel.close")).toBe("Fechar painel");
+    expect(t("popup.submit")).toBe("Enviar");
+    expect(t("type.question")).toBe("Pergunta");
   });
 
   it("resolves language prefix from full locale tag (e.g. 'fr-FR')", () => {
@@ -107,6 +115,7 @@ describe("translation completeness", () => {
   const enKeys = Object.keys(en).sort();
   const deKeys = Object.keys(de).sort();
   const frKeys = Object.keys(fr).sort();
+  const ptKeys = Object.keys(pt).sort();
   const ruKeys = Object.keys(ru).sort();
 
   it("en.ts and fr.ts have the same set of keys", () => {
@@ -115,6 +124,10 @@ describe("translation completeness", () => {
 
   it("en.ts and de.ts have the same set of keys", () => {
     expect(enKeys).toEqual(deKeys);
+  });
+
+  it("en.ts and pt.ts have the same set of keys", () => {
+    expect(enKeys).toEqual(ptKeys);
   });
 
   it("en.ts and ru.ts have the same set of keys", () => {
@@ -139,6 +152,12 @@ describe("translation completeness", () => {
     }
   });
 
+  it("no translation value is an empty string in pt.ts", () => {
+    for (const [key, value] of Object.entries(pt)) {
+      expect(value, `pt.ts key "${key}" is empty`).not.toBe("");
+    }
+  });
+
   it("no translation value is an empty string in ru.ts", () => {
     for (const [key, value] of Object.entries(ru)) {
       expect(value, `ru.ts key "${key}" is empty`).not.toBe("");
@@ -160,6 +179,12 @@ describe("translation completeness", () => {
   it("all keys in en.ts exist in de.ts", () => {
     for (const key of enKeys) {
       expect(de).toHaveProperty(key);
+    }
+  });
+
+  it("all keys in en.ts exist in pt.ts", () => {
+    for (const key of enKeys) {
+      expect(pt).toHaveProperty(key);
     }
   });
 

--- a/packages/widget/src/i18n/index.ts
+++ b/packages/widget/src/i18n/index.ts
@@ -2,14 +2,15 @@ import type { TFunction, Translations } from "./types.js";
 
 export type { TFunction, Translations } from "./types.js";
 
-import { de } from "./de.js";
-// Static imports — bundler (tsup) will include both.
+// Static imports — bundler (tsup) will include them all.
 // For tree-shaking in consumer apps, use dynamic import() with a bundler plugin.
+import { de } from "./de.js";
 import { en } from "./en.js";
 import { fr } from "./fr.js";
+import { pt } from "./pt.js";
 import { ru } from "./ru.js";
 
-const LOCALES: Record<string, Translations> = { en, fr, de, ru };
+const LOCALES: Record<string, Translations> = { de, en, fr, pt, ru };
 
 /** Register a custom locale at runtime. */
 export function registerLocale(code: string, translations: Translations): void {

--- a/packages/widget/src/i18n/pt.ts
+++ b/packages/widget/src/i18n/pt.ts
@@ -1,0 +1,82 @@
+import type { Translations } from "./types.js";
+
+/** Brazilian Portuguese translations (pt-BR). */
+export const pt: Translations = {
+  // Panel
+  "panel.title": "Feedbacks",
+  "panel.ariaLabel": "Painel de feedback do Siteping",
+  "panel.feedbackList": "Lista de feedbacks",
+  "panel.loading": "Carregando feedbacks",
+  "panel.close": "Fechar painel",
+  "panel.deleteAll": "Excluir tudo",
+  "panel.deleteAllConfirmTitle": "Excluir tudo",
+  "panel.deleteAllConfirmMessage": "Excluir todos os feedbacks deste projeto? Esta ação não pode ser desfeita.",
+  "panel.search": "Pesquisar...",
+  "panel.searchAria": "Pesquisar feedbacks",
+  "panel.filterAll": "Todos",
+  "panel.loadError": "Falha ao carregar",
+  "panel.retry": "Tentar novamente",
+  "panel.empty": "Nenhum feedback ainda",
+  "panel.showMore": "Mostrar mais",
+  "panel.showLess": "Mostrar menos",
+  "panel.resolve": "Resolver",
+  "panel.reopen": "Reabrir",
+  "panel.delete": "Excluir",
+  "panel.cancel": "Cancelar",
+  "panel.confirmDelete": "Excluir",
+  "panel.loadMore": "Carregar mais ({remaining} restantes)",
+
+  // Status filter labels
+  "panel.statusAll": "Todos",
+  "panel.statusOpen": "Abertos",
+  "panel.statusResolved": "Resolvidos",
+
+  // Feedback type labels
+  "type.question": "Pergunta",
+  "type.change": "Alteração",
+  "type.bug": "Bug",
+  "type.other": "Outro",
+
+  // FAB menu
+  "fab.aria": "Siteping — Menu de feedback",
+  "fab.messages": "Mensagens",
+  "fab.annotate": "Anotar",
+  "fab.annotations": "Anotações",
+
+  // Annotator
+  "annotator.instruction": "Desenhe um retângulo na área que deseja comentar",
+  "annotator.cancel": "Cancelar",
+
+  // Popup
+  "popup.ariaLabel": "Formulário de feedback",
+  "popup.placeholder": "Descreva seu feedback...",
+  "popup.textareaAria": "Mensagem de feedback",
+  "popup.submitHintMac": "⌘+Enter para enviar",
+  "popup.submitHintOther": "Ctrl+Enter para enviar",
+  "popup.cancel": "Cancelar",
+  "popup.submit": "Enviar",
+
+  // Identity modal
+  "identity.title": "Identifique-se",
+  "identity.nameLabel": "Nome",
+  "identity.namePlaceholder": "Seu nome",
+  "identity.emailLabel": "E-mail",
+  "identity.emailPlaceholder": "seu@email.com",
+  "identity.cancel": "Cancelar",
+  "identity.submit": "Continuar",
+
+  // Markers
+  "marker.approximate": "Posição aproximada (confiança: {confidence}%)",
+  "marker.aria": "Feedback #{number}: {type} — {message}",
+
+  // FAB badge
+  "fab.badge": "{count} feedbacks não resolvidos",
+
+  // Accessibility — screen reader announcements
+  "feedback.sent.confirmation": "Feedback enviado com sucesso",
+  "feedback.error.message": "Falha ao enviar feedback",
+  "feedback.deleted.confirmation": "Feedback excluído",
+
+  // Badge
+  "badge.count": "{count} feedbacks não resolvidos",
+};


### PR DESCRIPTION
## Summary
- add Brazilian Portuguese (`pt`) translations for the widget i18n dictionary
- register the locale so `locale: "pt"` and prefix resolution from `pt-BR` use the new copy
- extend i18n tests to check pt key parity and non-empty values

Targeted variant: Brazilian Portuguese (pt-BR), registered as `pt` per issue #34.

## Verification
- `bun run test:run -- packages/widget/__tests__/i18n/i18n.test.ts`
- `bun run lint`
- `bun run test:run`
- `bun run check`

Closes #34
