### PR TITLE
feat(widget): add Italian (it) locale

### DIFF
--- a/packages/widget/__tests__/i18n/i18n.test.ts
+++ b/packages/widget/__tests__/i18n/i18n.test.ts
@@ -3,6 +3,7 @@ import { de } from "../../src/i18n/de.js";
 import { en } from "../../src/i18n/en.js";
 import { fr } from "../../src/i18n/fr.js";
 import { createT, getTypeLabel } from "../../src/i18n/index.js";
+import { it as italian } from "../../src/i18n/it.js";
 import { pt } from "../../src/i18n/pt.js";
 import { ru } from "../../src/i18n/ru.js";
 
@@ -37,6 +38,13 @@ describe("createT", () => {
     expect(t("panel.close")).toBe("Panel schließen");
     expect(t("popup.submit")).toBe("Senden");
     expect(t("type.question")).toBe("Frage");
+  });
+
+  it("returns Italian translations for 'it' and 'it-IT'", () => {
+    const t = createT("it-IT");
+    expect(t("panel.close")).toBe("Chiudi pannello");
+    expect(t("popup.submit")).toBe("Invia");
+    expect(t("type.question")).toBe("Domanda");
   });
 
   it("returns Brazilian Portuguese translations for 'pt' and 'pt-BR'", () => {
@@ -115,6 +123,7 @@ describe("translation completeness", () => {
   const enKeys = Object.keys(en).sort();
   const deKeys = Object.keys(de).sort();
   const frKeys = Object.keys(fr).sort();
+  const itKeys = Object.keys(italian).sort();
   const ptKeys = Object.keys(pt).sort();
   const ruKeys = Object.keys(ru).sort();
 
@@ -124,6 +133,10 @@ describe("translation completeness", () => {
 
   it("en.ts and de.ts have the same set of keys", () => {
     expect(enKeys).toEqual(deKeys);
+  });
+
+  it("en.ts and it.ts have the same set of keys", () => {
+    expect(enKeys).toEqual(itKeys);
   });
 
   it("en.ts and pt.ts have the same set of keys", () => {
@@ -149,6 +162,12 @@ describe("translation completeness", () => {
   it("no translation value is an empty string in en.ts", () => {
     for (const [key, value] of Object.entries(en)) {
       expect(value, `en.ts key "${key}" is empty`).not.toBe("");
+    }
+  });
+
+  it("no translation value is an empty string in it.ts", () => {
+    for (const [key, value] of Object.entries(italian)) {
+      expect(value, `it.ts key "${key}" is empty`).not.toBe("");
     }
   });
 
@@ -179,6 +198,12 @@ describe("translation completeness", () => {
   it("all keys in en.ts exist in de.ts", () => {
     for (const key of enKeys) {
       expect(de).toHaveProperty(key);
+    }
+  });
+
+  it("all keys in en.ts exist in it.ts", () => {
+    for (const key of enKeys) {
+      expect(italian).toHaveProperty(key);
     }
   });
 

--- a/packages/widget/src/i18n/index.ts
+++ b/packages/widget/src/i18n/index.ts
@@ -7,10 +7,11 @@ export type { TFunction, Translations } from "./types.js";
 import { de } from "./de.js";
 import { en } from "./en.js";
 import { fr } from "./fr.js";
+import { it } from "./it.js";
 import { pt } from "./pt.js";
 import { ru } from "./ru.js";
 
-const LOCALES: Record<string, Translations> = { de, en, fr, pt, ru };
+const LOCALES: Record<string, Translations> = { de, en, fr, it, pt, ru };
 
 /** Register a custom locale at runtime. */
 export function registerLocale(code: string, translations: Translations): void {

--- a/packages/widget/src/i18n/it.ts
+++ b/packages/widget/src/i18n/it.ts
@@ -1,0 +1,83 @@
+import type { Translations } from "./types.js";
+
+/** Italian translations (it-IT). */
+export const it: Translations = {
+  // Panel
+  "panel.title": "Feedback",
+  "panel.ariaLabel": "Pannello feedback di Siteping",
+  "panel.feedbackList": "Elenco feedback",
+  "panel.loading": "Caricamento feedback",
+  "panel.close": "Chiudi pannello",
+  "panel.deleteAll": "Elimina tutto",
+  "panel.deleteAllConfirmTitle": "Elimina tutto",
+  "panel.deleteAllConfirmMessage":
+    "Eliminare tutti i feedback per questo progetto? Questa azione non può essere annullata.",
+  "panel.search": "Cerca...",
+  "panel.searchAria": "Cerca feedback",
+  "panel.filterAll": "Tutti",
+  "panel.loadError": "Caricamento non riuscito",
+  "panel.retry": "Riprova",
+  "panel.empty": "Nessun feedback ancora",
+  "panel.showMore": "Mostra di più",
+  "panel.showLess": "Mostra meno",
+  "panel.resolve": "Risolvi",
+  "panel.reopen": "Riapri",
+  "panel.delete": "Elimina",
+  "panel.cancel": "Annulla",
+  "panel.confirmDelete": "Elimina",
+  "panel.loadMore": "Carica altro ({remaining} rimanenti)",
+
+  // Status filter labels
+  "panel.statusAll": "Tutti",
+  "panel.statusOpen": "Aperti",
+  "panel.statusResolved": "Risolti",
+
+  // Feedback type labels
+  "type.question": "Domanda",
+  "type.change": "Modifica",
+  "type.bug": "Bug",
+  "type.other": "Altro",
+
+  // FAB menu
+  "fab.aria": "Siteping — Menu feedback",
+  "fab.messages": "Messaggi",
+  "fab.annotate": "Annota",
+  "fab.annotations": "Annotazioni",
+
+  // Annotator
+  "annotator.instruction": "Disegna un rettangolo sull'area da commentare",
+  "annotator.cancel": "Annulla",
+
+  // Popup
+  "popup.ariaLabel": "Modulo feedback",
+  "popup.placeholder": "Descrivi il tuo feedback...",
+  "popup.textareaAria": "Messaggio di feedback",
+  "popup.submitHintMac": "⌘+Invio per inviare",
+  "popup.submitHintOther": "Ctrl+Invio per inviare",
+  "popup.cancel": "Annulla",
+  "popup.submit": "Invia",
+
+  // Identity modal
+  "identity.title": "Identificati",
+  "identity.nameLabel": "Nome",
+  "identity.namePlaceholder": "Il tuo nome",
+  "identity.emailLabel": "Email",
+  "identity.emailPlaceholder": "tua@email.com",
+  "identity.cancel": "Annulla",
+  "identity.submit": "Continua",
+
+  // Markers
+  "marker.approximate": "Posizione approssimativa (confidenza: {confidence}%)",
+  "marker.aria": "Feedback #{number}: {type} — {message}",
+
+  // FAB badge
+  "fab.badge": "{count} feedback non risolti",
+
+  // Accessibility — screen reader announcements
+  "feedback.sent.confirmation": "Feedback inviato con successo",
+  "feedback.error.message": "Invio del feedback non riuscito",
+  "feedback.deleted.confirmation": "Feedback eliminato",
+
+  // Badge
+  "badge.count": "{count} feedback non risolti",
+};


### PR DESCRIPTION
Adds the Italian widget locale requested in #33.

What changed:
- Added `packages/widget/src/i18n/it.ts` with a full Italian translation set.
- Registered the `it` locale in `createT`, including `it-IT` prefix resolution.
- Added i18n tests for Italian lookup, key parity, and non-empty values.

Verification:
- `bun x vitest run packages/widget/__tests__/i18n/i18n.test.ts` — 24 tests passed
- `bun run lint` — passed
- `bun run test:run` — 790 tests passed
- `bun run check` — passed (10 tasks)

Closes #33.