### PR TITLE
feat(widget): add German (de) locale

### DIFF
--- a/packages/widget/__tests__/i18n/i18n.test.ts
+++ b/packages/widget/__tests__/i18n/i18n.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { de } from "../../src/i18n/de.js";
 import { en } from "../../src/i18n/en.js";
 import { fr } from "../../src/i18n/fr.js";
 import { createT, getTypeLabel } from "../../src/i18n/index.js";
@@ -30,6 +31,13 @@ describe("createT", () => {
     expect(t("popup.submit")).toBe("Отправить");
   });
 
+  it("returns German translations for 'de' and 'de-DE'", () => {
+    const t = createT("de-DE");
+    expect(t("panel.close")).toBe("Panel schließen");
+    expect(t("popup.submit")).toBe("Senden");
+    expect(t("type.question")).toBe("Frage");
+  });
+
   it("resolves language prefix from full locale tag (e.g. 'fr-FR')", () => {
     const t = createT("fr-FR");
     expect(t("panel.close")).toBe("Fermer le panneau");
@@ -41,7 +49,7 @@ describe("createT", () => {
   });
 
   it("falls back to English for unknown locale", () => {
-    const t = createT("de");
+    const t = createT("es");
     expect(t("panel.close")).toBe("Close panel");
   });
 
@@ -97,11 +105,16 @@ describe("getTypeLabel", () => {
 
 describe("translation completeness", () => {
   const enKeys = Object.keys(en).sort();
+  const deKeys = Object.keys(de).sort();
   const frKeys = Object.keys(fr).sort();
   const ruKeys = Object.keys(ru).sort();
 
   it("en.ts and fr.ts have the same set of keys", () => {
     expect(enKeys).toEqual(frKeys);
+  });
+
+  it("en.ts and de.ts have the same set of keys", () => {
+    expect(enKeys).toEqual(deKeys);
   });
 
   it("en.ts and ru.ts have the same set of keys", () => {
@@ -111,6 +124,12 @@ describe("translation completeness", () => {
   it("no translation value is an empty string in fr.ts", () => {
     for (const [key, value] of Object.entries(fr)) {
       expect(value, `fr.ts key "${key}" is empty`).not.toBe("");
+    }
+  });
+
+  it("no translation value is an empty string in de.ts", () => {
+    for (const [key, value] of Object.entries(de)) {
+      expect(value, `de.ts key "${key}" is empty`).not.toBe("");
     }
   });
 
@@ -135,6 +154,12 @@ describe("translation completeness", () => {
   it("all keys in fr.ts exist in en.ts", () => {
     for (const key of frKeys) {
       expect(en).toHaveProperty(key);
+    }
+  });
+
+  it("all keys in en.ts exist in de.ts", () => {
+    for (const key of enKeys) {
+      expect(de).toHaveProperty(key);
     }
   });
 

--- a/packages/widget/src/i18n/de.ts
+++ b/packages/widget/src/i18n/de.ts
@@ -1,0 +1,82 @@
+import type { Translations } from "./types.js";
+
+export const de: Translations = {
+  // Panel
+  "panel.title": "Feedbacks",
+  "panel.ariaLabel": "Siteping-Feedback-Panel",
+  "panel.feedbackList": "Feedbackliste",
+  "panel.loading": "Feedbacks werden geladen",
+  "panel.close": "Panel schließen",
+  "panel.deleteAll": "Alle löschen",
+  "panel.deleteAllConfirmTitle": "Alle löschen",
+  "panel.deleteAllConfirmMessage":
+    "Alle Feedbacks für dieses Projekt löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+  "panel.search": "Suchen...",
+  "panel.searchAria": "Feedbacks suchen",
+  "panel.filterAll": "Alle",
+  "panel.loadError": "Laden fehlgeschlagen",
+  "panel.retry": "Erneut versuchen",
+  "panel.empty": "Noch kein Feedback",
+  "panel.showMore": "Mehr anzeigen",
+  "panel.showLess": "Weniger anzeigen",
+  "panel.resolve": "Erledigen",
+  "panel.reopen": "Wieder öffnen",
+  "panel.delete": "Löschen",
+  "panel.cancel": "Abbrechen",
+  "panel.confirmDelete": "Löschen",
+  "panel.loadMore": "Mehr laden ({remaining} verbleibend)",
+
+  // Status filter labels
+  "panel.statusAll": "Alle",
+  "panel.statusOpen": "Offen",
+  "panel.statusResolved": "Erledigt",
+
+  // Feedback type labels
+  "type.question": "Frage",
+  "type.change": "Änderung",
+  "type.bug": "Fehler",
+  "type.other": "Sonstiges",
+
+  // FAB menu
+  "fab.aria": "Siteping — Feedback-Menü",
+  "fab.messages": "Nachrichten",
+  "fab.annotate": "Kommentieren",
+  "fab.annotations": "Anmerkungen",
+
+  // Annotator
+  "annotator.instruction": "Zeichne ein Rechteck um den Bereich, den du kommentieren möchtest",
+  "annotator.cancel": "Abbrechen",
+
+  // Popup
+  "popup.ariaLabel": "Feedbackformular",
+  "popup.placeholder": "Beschreibe dein Feedback...",
+  "popup.textareaAria": "Feedbacknachricht",
+  "popup.submitHintMac": "⌘+Enter zum Senden",
+  "popup.submitHintOther": "Strg+Enter zum Senden",
+  "popup.cancel": "Abbrechen",
+  "popup.submit": "Senden",
+
+  // Identity modal
+  "identity.title": "Identifiziere dich",
+  "identity.nameLabel": "Name",
+  "identity.namePlaceholder": "Dein Name",
+  "identity.emailLabel": "E-Mail",
+  "identity.emailPlaceholder": "deine@email.de",
+  "identity.cancel": "Abbrechen",
+  "identity.submit": "Fortfahren",
+
+  // Markers
+  "marker.approximate": "Ungefähre Position (Konfidenz: {confidence}%)",
+  "marker.aria": "Feedback #{number}: {type} — {message}",
+
+  // FAB badge
+  "fab.badge": "{count} unerledigte Feedbacks",
+
+  // Accessibility — screen reader announcements
+  "feedback.sent.confirmation": "Feedback erfolgreich gesendet",
+  "feedback.error.message": "Feedback konnte nicht gesendet werden",
+  "feedback.deleted.confirmation": "Feedback gelöscht",
+
+  // Badge
+  "badge.count": "{count} unerledigte Feedbacks",
+};

--- a/packages/widget/src/i18n/index.ts
+++ b/packages/widget/src/i18n/index.ts
@@ -2,13 +2,14 @@ import type { TFunction, Translations } from "./types.js";
 
 export type { TFunction, Translations } from "./types.js";
 
+import { de } from "./de.js";
 // Static imports — bundler (tsup) will include both.
 // For tree-shaking in consumer apps, use dynamic import() with a bundler plugin.
 import { en } from "./en.js";
 import { fr } from "./fr.js";
 import { ru } from "./ru.js";
 
-const LOCALES: Record<string, Translations> = { fr, en, ru };
+const LOCALES: Record<string, Translations> = { en, fr, de, ru };
 
 /** Register a custom locale at runtime. */
 export function registerLocale(code: string, translations: Translations): void {


### PR DESCRIPTION
## Summary
- add the German (`de`) widget locale with the full translation key set
- register `de` for locale-prefix resolution (`de-DE` -> `de`)
- cover German lookup, key parity, and non-empty translation values in i18n tests

Closes #32

## Verification
- `bun x vitest run packages/widget/__tests__/i18n/i18n.test.ts`
- `bun run lint`
- `bun run test:run`
- `bun run check`
