### PR TITLE
feat(widget): add Spanish (es) locale

### DIFF
--- a/packages/widget/__tests__/i18n/i18n.test.ts
+++ b/packages/widget/__tests__/i18n/i18n.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { de } from "../../src/i18n/de.js";
 import { en } from "../../src/i18n/en.js";
+import { es } from "../../src/i18n/es.js";
 import { fr } from "../../src/i18n/fr.js";
 import { createT, getTypeLabel } from "../../src/i18n/index.js";
 import { it as italian } from "../../src/i18n/it.js";
@@ -24,6 +25,13 @@ describe("createT", () => {
     expect(t("panel.title")).toBe("Feedbacks");
     expect(t("panel.close")).toBe("Close panel");
     expect(t("popup.submit")).toBe("Send");
+  });
+
+  it("returns Spanish translations for 'es' and 'es-MX'", () => {
+    const t = createT("es-MX");
+    expect(t("panel.close")).toBe("Cerrar panel");
+    expect(t("popup.submit")).toBe("Enviar");
+    expect(t("type.question")).toBe("Pregunta");
   });
 
   it("returns Russian translations for 'ru'", () => {
@@ -65,7 +73,7 @@ describe("createT", () => {
   });
 
   it("falls back to English for unknown locale", () => {
-    const t = createT("es");
+    const t = createT("zz");
     expect(t("panel.close")).toBe("Close panel");
   });
 
@@ -122,6 +130,7 @@ describe("getTypeLabel", () => {
 describe("translation completeness", () => {
   const enKeys = Object.keys(en).sort();
   const deKeys = Object.keys(de).sort();
+  const esKeys = Object.keys(es).sort();
   const frKeys = Object.keys(fr).sort();
   const itKeys = Object.keys(italian).sort();
   const ptKeys = Object.keys(pt).sort();
@@ -133,6 +142,10 @@ describe("translation completeness", () => {
 
   it("en.ts and de.ts have the same set of keys", () => {
     expect(enKeys).toEqual(deKeys);
+  });
+
+  it("en.ts and es.ts have the same set of keys", () => {
+    expect(enKeys).toEqual(esKeys);
   });
 
   it("en.ts and it.ts have the same set of keys", () => {
@@ -156,6 +169,12 @@ describe("translation completeness", () => {
   it("no translation value is an empty string in de.ts", () => {
     for (const [key, value] of Object.entries(de)) {
       expect(value, `de.ts key "${key}" is empty`).not.toBe("");
+    }
+  });
+
+  it("no translation value is an empty string in es.ts", () => {
+    for (const [key, value] of Object.entries(es)) {
+      expect(value, `es.ts key "${key}" is empty`).not.toBe("");
     }
   });
 
@@ -186,6 +205,12 @@ describe("translation completeness", () => {
   it("all keys in en.ts exist in fr.ts", () => {
     for (const key of enKeys) {
       expect(fr).toHaveProperty(key);
+    }
+  });
+
+  it("all keys in en.ts exist in es.ts", () => {
+    for (const key of enKeys) {
+      expect(es).toHaveProperty(key);
     }
   });
 

--- a/packages/widget/src/i18n/es.ts
+++ b/packages/widget/src/i18n/es.ts
@@ -1,0 +1,82 @@
+import type { Translations } from "./types.js";
+
+export const es: Translations = {
+  // Panel
+  "panel.title": "Comentarios",
+  "panel.ariaLabel": "Panel de comentarios de Siteping",
+  "panel.feedbackList": "Lista de comentarios",
+  "panel.loading": "Cargando comentarios",
+  "panel.close": "Cerrar panel",
+  "panel.deleteAll": "Eliminar todo",
+  "panel.deleteAllConfirmTitle": "Eliminar todo",
+  "panel.deleteAllConfirmMessage":
+    "¿Eliminar todos los comentarios de este proyecto? Esta acción no se puede deshacer.",
+  "panel.search": "Buscar...",
+  "panel.searchAria": "Buscar comentarios",
+  "panel.filterAll": "Todos",
+  "panel.loadError": "No se pudo cargar",
+  "panel.retry": "Reintentar",
+  "panel.empty": "Aún no hay comentarios",
+  "panel.showMore": "Mostrar más",
+  "panel.showLess": "Mostrar menos",
+  "panel.resolve": "Resolver",
+  "panel.reopen": "Reabrir",
+  "panel.delete": "Eliminar",
+  "panel.cancel": "Cancelar",
+  "panel.confirmDelete": "Eliminar",
+  "panel.loadMore": "Cargar más ({remaining} restantes)",
+
+  // Status filter labels
+  "panel.statusAll": "Todos",
+  "panel.statusOpen": "Abiertos",
+  "panel.statusResolved": "Resueltos",
+
+  // Feedback type labels
+  "type.question": "Pregunta",
+  "type.change": "Cambio",
+  "type.bug": "Error",
+  "type.other": "Otro",
+
+  // FAB menu
+  "fab.aria": "Siteping — Menú de comentarios",
+  "fab.messages": "Mensajes",
+  "fab.annotate": "Anotar",
+  "fab.annotations": "Anotaciones",
+
+  // Annotator
+  "annotator.instruction": "Dibuja un rectángulo sobre el área que quieres comentar",
+  "annotator.cancel": "Cancelar",
+
+  // Popup
+  "popup.ariaLabel": "Formulario de comentarios",
+  "popup.placeholder": "Describe tu comentario...",
+  "popup.textareaAria": "Mensaje de comentario",
+  "popup.submitHintMac": "⌘+Enter para enviar",
+  "popup.submitHintOther": "Ctrl+Enter para enviar",
+  "popup.cancel": "Cancelar",
+  "popup.submit": "Enviar",
+
+  // Identity modal
+  "identity.title": "Identifícate",
+  "identity.nameLabel": "Nombre",
+  "identity.namePlaceholder": "Tu nombre",
+  "identity.emailLabel": "Correo electrónico",
+  "identity.emailPlaceholder": "tu@email.com",
+  "identity.cancel": "Cancelar",
+  "identity.submit": "Continuar",
+
+  // Markers
+  "marker.approximate": "Posición aproximada (confianza: {confidence}%)",
+  "marker.aria": "Comentario #{number}: {type} — {message}",
+
+  // FAB badge
+  "fab.badge": "{count} comentarios sin resolver",
+
+  // Accessibility — screen reader announcements
+  "feedback.sent.confirmation": "Comentario enviado correctamente",
+  "feedback.error.message": "No se pudo enviar el comentario",
+  "feedback.deleted.confirmation": "Comentario eliminado",
+
+  // Badge
+  "badge.count": "{count} comentarios sin resolver",
+};

--- a/packages/widget/src/i18n/index.ts
+++ b/packages/widget/src/i18n/index.ts
@@ -6,12 +6,13 @@ export type { TFunction, Translations } from "./types.js";
 // For tree-shaking in consumer apps, use dynamic import() with a bundler plugin.
 import { de } from "./de.js";
 import { en } from "./en.js";
+import { es } from "./es.js";
 import { fr } from "./fr.js";
 import { it } from "./it.js";
 import { pt } from "./pt.js";
 import { ru } from "./ru.js";
 
-const LOCALES: Record<string, Translations> = { de, en, fr, it, pt, ru };
+const LOCALES: Record<string, Translations> = { de, en, es, fr, it, pt, ru };
 
 /** Register a custom locale at runtime. */
 export function registerLocale(code: string, translations: Translations): void {


### PR DESCRIPTION
## Summary
- add the Spanish (`es`) widget translation with the same key set as English
- register `es` so `es`, `es-ES`, `es-MX`, etc. resolve through the locale prefix logic
- extend i18n tests for Spanish resolution, key parity, and non-empty values

Closes #31.

## Verification
- `bun x vitest run packages/widget/__tests__/i18n/i18n.test.ts`
- `bun run lint`
- `bun run test:run`
- `bun run check`
