### PR TITLE
fix(adapter-prisma): make ?search filter work on SQLite

### DIFF
--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -55,9 +55,9 @@ matches case-insensitively depends on the database provider:
 
 | Provider | Default `caseInsensitiveSearch` | Behaviour |
 |----------|---------------------------------|-----------|
-| `postgresql`, `mysql`, `cockroachdb` | `true` (auto) | Emits `mode: "insensitive"` — case-insensitive across all letters, including non-ASCII. |
-| `sqlite`, `sqlserver`, `mongodb` | `false` (auto) | No `mode` field — uses each database's default `LIKE` semantics. SQLite is ASCII-case-insensitive by default; SQL Server depends on column collation. |
-| Unknown / undetectable | `true` (auto) | Preserves historical Postgres-style behaviour. |
+| `postgresql`, `mongodb`, `cockroachdb` | `true` (auto) | Emits `mode: "insensitive"` — case-insensitive across all letters, including non-ASCII. These are the providers whose generated Prisma client exposes `mode?: QueryMode` on string filters. |
+| `mysql`, `sqlite`, `sqlserver` | `false` (auto) | No `mode` field (Prisma's generated client doesn't expose it for these providers — passing it raises `PrismaClientValidationError: Unknown argument 'mode'`). Falls back to each database's default `LIKE` semantics: MySQL is case-insensitive on `_ci` collations (the default); SQLite is case-insensitive on ASCII; SQL Server depends on column collation. |
+| Unknown / undetectable | `false` (auto) | `contains` without `mode` works on every provider; `mode: "insensitive"` would throw on MySQL/SQLite/SQL Server. Pass `caseInsensitiveSearch: true` explicitly if you know your client is Postgres/Mongo/Cockroach but the provider auto-detection failed. |
 
 Auto-detection reads the active provider from the Prisma client at runtime.
 Override it explicitly when the default is wrong for your setup:

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -42,11 +42,38 @@ export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({ pri
 | `projectName` | `string` | **Required.** Filter by project |
 | `type` | `string` | `question` \| `change` \| `bug` \| `other` |
 | `status` | `string` | `open` \| `resolved` |
-| `search` | `string` | Full-text search on message content |
+| `search` | `string` | Substring match on message content (see [Search and case sensitivity](#search-and-case-sensitivity)) |
 | `url` | `string` | Restrict to feedbacks created on this exact URL — used by the panel's "this page" filter |
 | `urlPattern` | `string` | Restrict to feedbacks created on this URL template (e.g. `/orders/:id`) — used by the panel's "this type of page" filter |
 | `page` | `number` | Pagination (default: 1) |
 | `limit` | `number` | Items per page (default: 50, max: 100) |
+
+### Search and case sensitivity
+
+The `?search=` filter is built with Prisma's `contains` operator. Whether it
+matches case-insensitively depends on the database provider:
+
+| Provider | Default `caseInsensitiveSearch` | Behaviour |
+|----------|---------------------------------|-----------|
+| `postgresql`, `mysql`, `cockroachdb` | `true` (auto) | Emits `mode: "insensitive"` — case-insensitive across all letters, including non-ASCII. |
+| `sqlite`, `sqlserver`, `mongodb` | `false` (auto) | No `mode` field — uses each database's default `LIKE` semantics. SQLite is ASCII-case-insensitive by default; SQL Server depends on column collation. |
+| Unknown / undetectable | `true` (auto) | Preserves historical Postgres-style behaviour. |
+
+Auto-detection reads the active provider from the Prisma client at runtime.
+Override it explicitly when the default is wrong for your setup:
+
+```ts
+export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
+  prisma,
+  caseInsensitiveSearch: false, // force ASCII-only match (e.g. SQL Server with case-sensitive collation)
+})
+```
+
+Or when constructing `PrismaStore` directly:
+
+```ts
+const store = new PrismaStore(prisma, { caseInsensitiveSearch: false })
+```
 
 ## Validation Constraints
 

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -171,6 +171,86 @@ describe("createSitepingHandler", () => {
       expect(callArgs.where.type).toBe("bug");
       expect(callArgs.where.status).toBe("open");
     });
+
+    describe("?search filter — case-insensitive mode", () => {
+      it("emits mode:'insensitive' for the default Postgres-style client", async () => {
+        prisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        prisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await handler.GET(req);
+        const callArgs = prisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("omits mode when caseInsensitiveSearch:false is passed explicitly", async () => {
+        const sqliteHandler = createSitepingHandler({ prisma, caseInsensitiveSearch: false });
+        prisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        prisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await sqliteHandler.GET(req);
+        const callArgs = prisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello" });
+        expect(callArgs.where.message).not.toHaveProperty("mode");
+      });
+
+      it("auto-detects sqlite via _activeProvider and omits mode", async () => {
+        const sqlitePrisma = Object.assign(mockPrisma(), { _activeProvider: "sqlite" });
+        const sqliteHandler = createSitepingHandler({ prisma: sqlitePrisma });
+        sqlitePrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        sqlitePrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await sqliteHandler.GET(req);
+        const callArgs = sqlitePrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello" });
+      });
+
+      it("auto-detects postgresql via _activeProvider and keeps mode", async () => {
+        const pgPrisma = Object.assign(mockPrisma(), { _activeProvider: "postgresql" });
+        const pgHandler = createSitepingHandler({ prisma: pgPrisma });
+        pgPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        pgPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await pgHandler.GET(req);
+        const callArgs = pgPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("explicit caseInsensitiveSearch:true overrides sqlite auto-detect", async () => {
+        const sqlitePrisma = Object.assign(mockPrisma(), { _activeProvider: "sqlite" });
+        const overriddenHandler = createSitepingHandler({
+          prisma: sqlitePrisma,
+          caseInsensitiveSearch: true,
+        });
+        sqlitePrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        sqlitePrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await overriddenHandler.GET(req);
+        const callArgs = sqlitePrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("does not touch where.message when search is absent", async () => {
+        const sqliteHandler = createSitepingHandler({ prisma, caseInsensitiveSearch: false });
+        prisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        prisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test");
+        await sqliteHandler.GET(req);
+        const callArgs = prisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: Record<string, unknown>;
+        };
+        expect(callArgs.where).not.toHaveProperty("message");
+      });
+    });
   });
 
   describe("PATCH", () => {

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -173,7 +173,11 @@ describe("createSitepingHandler", () => {
     });
 
     describe("?search filter — case-insensitive mode", () => {
-      it("emits mode:'insensitive' for the default Postgres-style client", async () => {
+      it("falls back to omitting mode when the active provider can't be detected", async () => {
+        // The default mockPrisma() exposes none of the internal probe paths,
+        // so detectActiveProvider returns null. The safe default is to omit
+        // `mode` — `contains` works on every provider; `mode: "insensitive"`
+        // would throw on MySQL/SQLite/SQL Server.
         prisma.sitepingFeedback.findMany.mockResolvedValue([]);
         prisma.sitepingFeedback.count.mockResolvedValue(0);
         const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
@@ -181,7 +185,8 @@ describe("createSitepingHandler", () => {
         const callArgs = prisma.sitepingFeedback.findMany.mock.calls[0][0] as {
           where: { message?: { contains: string; mode?: string } };
         };
-        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+        expect(callArgs.where.message).toEqual({ contains: "hello" });
+        expect(callArgs.where.message).not.toHaveProperty("mode");
       });
 
       it("omits mode when caseInsensitiveSearch:false is passed explicitly", async () => {
@@ -249,6 +254,98 @@ describe("createSitepingHandler", () => {
           where: Record<string, unknown>;
         };
         expect(callArgs.where).not.toHaveProperty("message");
+      });
+
+      it("auto-detects mysql via _activeProvider and omits mode", async () => {
+        // MySQL's generated Prisma client does not expose `mode?:` on string
+        // filters — passing it raises `Unknown argument 'mode'` at runtime.
+        const mysqlPrisma = Object.assign(mockPrisma(), { _activeProvider: "mysql" });
+        const mysqlHandler = createSitepingHandler({ prisma: mysqlPrisma });
+        mysqlPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        mysqlPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await mysqlHandler.GET(req);
+        const callArgs = mysqlPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).not.toHaveProperty("mode");
+      });
+
+      it("auto-detects mongodb via _activeProvider and keeps mode", async () => {
+        // MongoDB's generated Prisma client exposes `mode?: QueryMode` (Prisma
+        // compiles it to a case-insensitive $regex under the hood).
+        const mongoPrisma = Object.assign(mockPrisma(), { _activeProvider: "mongodb" });
+        const mongoHandler = createSitepingHandler({ prisma: mongoPrisma });
+        mongoPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        mongoPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await mongoHandler.GET(req);
+        const callArgs = mongoPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("auto-detects cockroachdb via _activeProvider and keeps mode", async () => {
+        const cockroachPrisma = Object.assign(mockPrisma(), { _activeProvider: "cockroachdb" });
+        const cockroachHandler = createSitepingHandler({ prisma: cockroachPrisma });
+        cockroachPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        cockroachPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await cockroachHandler.GET(req);
+        const callArgs = cockroachPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("auto-detects sqlserver via _activeProvider and omits mode", async () => {
+        const mssqlPrisma = Object.assign(mockPrisma(), { _activeProvider: "sqlserver" });
+        const mssqlHandler = createSitepingHandler({ prisma: mssqlPrisma });
+        mssqlPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        mssqlPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await mssqlHandler.GET(req);
+        const callArgs = mssqlPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).not.toHaveProperty("mode");
+      });
+
+      it("reads provider from _engineConfig.activeProvider when _activeProvider is missing", async () => {
+        const altPrisma = Object.assign(mockPrisma(), { _engineConfig: { activeProvider: "postgresql" } });
+        const altHandler = createSitepingHandler({ prisma: altPrisma });
+        altPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        altPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await altHandler.GET(req);
+        const callArgs = altPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        expect(callArgs.where.message).toEqual({ contains: "hello", mode: "insensitive" });
+      });
+
+      it("survives a prisma client whose provider probe throws", async () => {
+        // Some test doubles use Proxies whose get-traps throw — the constructor
+        // must still build a working store rather than crash.
+        const throwingPrisma = new Proxy(mockPrisma(), {
+          get(target, prop, receiver) {
+            if (prop === "_activeProvider" || prop === "_engineConfig" || prop === "_engine") {
+              throw new Error("probe denied");
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        }) as unknown as ReturnType<typeof mockPrisma>;
+        const throwingHandler = createSitepingHandler({ prisma: throwingPrisma });
+        throwingPrisma.sitepingFeedback.findMany.mockResolvedValue([]);
+        throwingPrisma.sitepingFeedback.count.mockResolvedValue(0);
+        const req = new Request("http://localhost/api/siteping?projectName=test&search=hello");
+        await throwingHandler.GET(req);
+        const callArgs = throwingPrisma.sitepingFeedback.findMany.mock.calls[0][0] as {
+          where: { message?: { contains: string; mode?: string } };
+        };
+        // Probe threw → fallback → no mode (safe default).
+        expect(callArgs.where.message).not.toHaveProperty("mode");
       });
     });
   });

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -56,12 +56,16 @@ export interface SitepingPrismaClient {
 const INCLUDE_ANNOTATIONS = { annotations: true };
 
 /**
- * Prisma datasource providers that support the `mode: "insensitive"` option
- * on string filters. SQLite, MongoDB, and SQL Server do not — using `mode`
- * against them raises `Unsupported('Argument mode is not supported.')` for
- * SQLite, and similar errors elsewhere. Source: Prisma docs §case-sensitivity.
+ * Prisma datasource providers whose generated client exposes `mode?: QueryMode`
+ * on string filters. Verified against Prisma 6.x by inspecting the generated
+ * `StringFilter` type per provider:
+ *   - postgresql, mongodb, cockroachdb → emit `mode?: QueryMode`
+ *   - mysql, sqlite, sqlserver → no `mode` field; passing it raises
+ *     `PrismaClientValidationError: Unknown argument 'mode'` at runtime.
+ * `postgres` is kept as a defensive alias in case `_activeProvider` ever
+ * surfaces the legacy spelling.
  */
-const PROVIDERS_SUPPORTING_INSENSITIVE_MODE = new Set(["postgresql", "postgres", "mysql", "cockroachdb"]);
+const PROVIDERS_SUPPORTING_INSENSITIVE_MODE = new Set(["postgresql", "postgres", "mongodb", "cockroachdb"]);
 
 /**
  * Best-effort detection of the active Prisma provider for a runtime client.
@@ -72,21 +76,25 @@ const PROVIDERS_SUPPORTING_INSENSITIVE_MODE = new Set(["postgresql", "postgres",
  * when none match.
  */
 function detectActiveProvider(prisma: unknown): string | null {
-  const candidate = prisma as
-    | {
-        _activeProvider?: unknown;
-        _engineConfig?: { activeProvider?: unknown };
-        _engine?: { config?: { activeProvider?: unknown } };
-      }
-    | null
-    | undefined;
-  const fromActive = candidate?._activeProvider;
-  if (typeof fromActive === "string") return fromActive;
-  const fromEngineConfig = candidate?._engineConfig?.activeProvider;
-  if (typeof fromEngineConfig === "string") return fromEngineConfig;
-  const fromEngine = candidate?._engine?.config?.activeProvider;
-  if (typeof fromEngine === "string") return fromEngine;
-  return null;
+  try {
+    const candidate = prisma as
+      | {
+          _activeProvider?: unknown;
+          _engineConfig?: { activeProvider?: unknown };
+          _engine?: { config?: { activeProvider?: unknown } };
+        }
+      | null
+      | undefined;
+    const fromActive = candidate?._activeProvider;
+    if (typeof fromActive === "string") return fromActive;
+    const fromEngineConfig = candidate?._engineConfig?.activeProvider;
+    if (typeof fromEngineConfig === "string") return fromEngineConfig;
+    const fromEngine = candidate?._engine?.config?.activeProvider;
+    if (typeof fromEngine === "string") return fromEngine;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -99,13 +107,16 @@ export interface PrismaStoreOptions {
    *
    * When `false`, the filter is built without `mode` — uses each database's
    * default `LIKE` semantics (case-insensitive ASCII on SQLite by default;
-   * case-sensitive on MySQL/PostgreSQL with the standard `LIKE` operator).
+   * case-sensitive on PostgreSQL with the standard `LIKE` operator;
+   * collation-driven on MySQL and SQL Server).
    *
    * When omitted, the value is auto-detected from the Prisma client's active
-   * provider: providers known to support `mode: "insensitive"` (`postgresql`,
-   * `mysql`, `cockroachdb`) get `true`; others (`sqlite`, `sqlserver`,
-   * `mongodb`) get `false`. Unknown providers default to `true` to preserve
-   * the historical behaviour.
+   * provider: providers whose generated client exposes `mode?: QueryMode`
+   * (`postgresql`, `mongodb`, `cockroachdb`) get `true`; others (`mysql`,
+   * `sqlite`, `sqlserver`) get `false`. Unknown / undetectable providers
+   * default to `false` — `contains` without `mode` works on every provider;
+   * `mode: "insensitive"` throws on MySQL/SQLite/SQL Server, so the safer
+   * default is to omit it.
    */
   caseInsensitiveSearch?: boolean;
   /**
@@ -141,9 +152,12 @@ export class PrismaStore implements SitepingStore {
       this.caseInsensitiveSearch = options.caseInsensitiveSearch;
     } else {
       const provider = detectActiveProvider(prisma);
-      // Default true when the provider can't be detected — preserves the
-      // historical Postgres-first behaviour for unknown setups.
-      this.caseInsensitiveSearch = provider === null || PROVIDERS_SUPPORTING_INSENSITIVE_MODE.has(provider);
+      // When the provider can't be detected, default to `false`: `contains`
+      // without `mode` works on every Prisma provider; `mode: "insensitive"`
+      // throws on MySQL/SQLite/SQL Server. Trades non-ASCII case-insensitivity
+      // on undetectable Postgres clients (rare — _activeProvider is set on
+      // every real Prisma 5/6 client) for not crashing on the others.
+      this.caseInsensitiveSearch = provider !== null && PROVIDERS_SUPPORTING_INSENSITIVE_MODE.has(provider);
     }
   }
 

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -56,6 +56,66 @@ export interface SitepingPrismaClient {
 const INCLUDE_ANNOTATIONS = { annotations: true };
 
 /**
+ * Prisma datasource providers that support the `mode: "insensitive"` option
+ * on string filters. SQLite, MongoDB, and SQL Server do not — using `mode`
+ * against them raises `Unsupported('Argument mode is not supported.')` for
+ * SQLite, and similar errors elsewhere. Source: Prisma docs §case-sensitivity.
+ */
+const PROVIDERS_SUPPORTING_INSENSITIVE_MODE = new Set(["postgresql", "postgres", "mysql", "cockroachdb"]);
+
+/**
+ * Best-effort detection of the active Prisma provider for a runtime client.
+ *
+ * The provider is not part of any public API on `PrismaClient`. We probe a
+ * few known internal locations across Prisma 5.x and 6.x and fall back to
+ * `null` (treated as "unknown — assume default Postgres-style behaviour")
+ * when none match.
+ */
+function detectActiveProvider(prisma: unknown): string | null {
+  const candidate = prisma as
+    | {
+        _activeProvider?: unknown;
+        _engineConfig?: { activeProvider?: unknown };
+        _engine?: { config?: { activeProvider?: unknown } };
+      }
+    | null
+    | undefined;
+  const fromActive = candidate?._activeProvider;
+  if (typeof fromActive === "string") return fromActive;
+  const fromEngineConfig = candidate?._engineConfig?.activeProvider;
+  if (typeof fromEngineConfig === "string") return fromEngineConfig;
+  const fromEngine = candidate?._engine?.config?.activeProvider;
+  if (typeof fromEngine === "string") return fromEngine;
+  return null;
+}
+
+/**
+ * Options accepted by `PrismaStore`.
+ */
+export interface PrismaStoreOptions {
+  /**
+   * When `true`, the `?search=` filter is built with `mode: "insensitive"`
+   * (case-insensitive across all letters, including non-ASCII).
+   *
+   * When `false`, the filter is built without `mode` — uses each database's
+   * default `LIKE` semantics (case-insensitive ASCII on SQLite by default;
+   * case-sensitive on MySQL/PostgreSQL with the standard `LIKE` operator).
+   *
+   * When omitted, the value is auto-detected from the Prisma client's active
+   * provider: providers known to support `mode: "insensitive"` (`postgresql`,
+   * `mysql`, `cockroachdb`) get `true`; others (`sqlite`, `sqlserver`,
+   * `mongodb`) get `false`. Unknown providers default to `true` to preserve
+   * the historical behaviour.
+   */
+  caseInsensitiveSearch?: boolean;
+  /**
+   * Optional storage backend for screenshots. Without it, the data URL is
+   * persisted inline on `Feedback.screenshotUrl` with a one-time warn.
+   */
+  screenshotStorage?: ScreenshotStorage | undefined;
+}
+
+/**
  * Prisma-backed implementation of `SitepingStore`.
  *
  * Wraps a PrismaClient to satisfy the abstract store interface.
@@ -71,10 +131,20 @@ export class PrismaStore implements SitepingStore {
   private readonly screenshotStorage: ScreenshotStorage | undefined;
   /** Module-level flag would leak across PrismaStore instances in tests; use per-instance. */
   private inlineFallbackWarned = false;
+  /** @internal */
+  private caseInsensitiveSearch: boolean;
 
-  constructor(prisma: SitepingPrismaClient, options?: { screenshotStorage?: ScreenshotStorage | undefined }) {
+  constructor(prisma: SitepingPrismaClient, options: PrismaStoreOptions = {}) {
     this.prisma = prisma;
-    this.screenshotStorage = options?.screenshotStorage;
+    this.screenshotStorage = options.screenshotStorage;
+    if (typeof options.caseInsensitiveSearch === "boolean") {
+      this.caseInsensitiveSearch = options.caseInsensitiveSearch;
+    } else {
+      const provider = detectActiveProvider(prisma);
+      // Default true when the provider can't be detected — preserves the
+      // historical Postgres-first behaviour for unknown setups.
+      this.caseInsensitiveSearch = provider === null || PROVIDERS_SUPPORTING_INSENSITIVE_MODE.has(provider);
+    }
   }
 
   async createFeedback(data: FeedbackCreateInput): Promise<FeedbackRecord> {
@@ -185,7 +255,11 @@ export class PrismaStore implements SitepingStore {
     if (status) where.status = status;
     if (url) where.url = url;
     if (urlPattern) where.urlPattern = urlPattern;
-    if (search) where.message = { contains: search, mode: "insensitive" as const };
+    if (search) {
+      where.message = this.caseInsensitiveSearch
+        ? { contains: search, mode: "insensitive" as const }
+        : { contains: search };
+    }
 
     const [feedbacks, total] = await Promise.all([
       this.prisma.sitepingFeedback.findMany({
@@ -268,6 +342,14 @@ export interface HandlerOptions {
   publicEndpoints?: Array<"GET" | "POST" | "PATCH" | "DELETE" | "OPTIONS">;
   /** Allowed CORS origins — when set, validates the Origin header */
   allowedOrigins?: string[] | undefined;
+  /**
+   * Override case-insensitive search behaviour for the built-in `PrismaStore`.
+   *
+   * Only applied when `prisma` is provided (not when a custom `store` is
+   * passed). See `PrismaStoreOptions.caseInsensitiveSearch` for details on
+   * auto-detection and per-provider semantics.
+   */
+  caseInsensitiveSearch?: boolean;
 }
 
 /**
@@ -367,6 +449,7 @@ export function createSitepingHandler({
   apiKey,
   publicEndpoints = apiKey ? ["POST", "OPTIONS"] : undefined,
   allowedOrigins,
+  caseInsensitiveSearch,
 }: HandlerOptions): SitepingHandler {
   if (!providedStore && !prisma) {
     throw new Error("[siteping] createSitepingHandler requires either `store` or `prisma`.");
@@ -374,7 +457,11 @@ export function createSitepingHandler({
 
   // Safe: the throw above guarantees at least one is defined
   const store: SitepingStore =
-    providedStore ?? new PrismaStore(prisma as NonNullable<typeof prisma>, { screenshotStorage });
+    providedStore ??
+    new PrismaStore(prisma as NonNullable<typeof prisma>, {
+      screenshotStorage,
+      ...(typeof caseInsensitiveSearch === "boolean" ? { caseInsensitiveSearch } : {}),
+    });
 
   const publicMethods = publicEndpoints ? new Set(publicEndpoints) : null;
 


### PR DESCRIPTION
## Summary

`PrismaStore.getFeedbacks` currently emits `where: { message: { contains, mode: "insensitive" } }` unconditionally. SQLite's Prisma connector rejects `mode: "insensitive"` and returns a 500, so any consumer running the adapter on SQLite gets a hard failure the moment a `?search=` query hits the GET endpoint.

This PR makes the `mode` field provider-aware while keeping current Postgres/MySQL/CockroachDB behaviour identical.

## Changes

- [x] `PrismaStore` accepts a new `caseInsensitiveSearch?: boolean` option (also surfaced through `createSitepingHandler({ prisma, ... })`).
- [x] When the option is omitted, the store best-effort detects the active provider via the Prisma client's internal `_activeProvider` / `_engineConfig.activeProvider` / `_engine.config.activeProvider` and only emits `mode: "insensitive"` for providers that support it (`postgresql`, `postgres`, `mysql`, `cockroachdb`).
- [x] When detection fails (unknown shape on a future Prisma release), it falls back to the historical `mode: "insensitive"` behaviour — Postgres consumers do not regress; SQLite consumers can flip the explicit option.
- [x] Six new unit tests covering: default behaviour, `caseInsensitiveSearch: false`, mocked `sqlite` / `postgresql` / `mysql` providers, and `?search` not present.
- [x] README gains a **Search and case sensitivity** subsection with the provider table and the explicit-override snippet.

No public API removed; the new option is opt-in.

## Test plan

Ran inside `packages/adapter-prisma`:

- `bun run check` — clean (whole monorepo type-checks: 10/10)
- `bun run lint` — clean
- `bun run test:run` — **1250/1250 passed**, including the 6 new `?search filter — case-insensitive mode` cases
- `bun run build` — 7/7 successful

Real-world verification: the change is the upstream version of a workaround currently shipped in a downstream consumer (Next.js + SQLite). With this fix in place, `GET /api/siteping?search=foo` returns 200 on SQLite instead of 500.

## Checklist

- [x] Tests pass (`bun run test:run`)
- [x] Types pass (`bun run check`)
- [x] No dead code or unused imports
- [x] Commit messages follow Conventional Commits (`type(scope): description`)

## Notes for reviewers

- The provider-detection helper deliberately probes three different internal paths because Prisma has moved this field across releases; the fallback path is the safe historical behaviour, so a future rename can only re-introduce the SQLite issue (it cannot regress Postgres).
- Consumers who want zero reliance on Prisma internals can pass `caseInsensitiveSearch: false` (or `true`) explicitly — detection is skipped when the option is provided.