### PR TITLE
fix(widget): clamp popup inside viewport when rect leaves no room above or below

### DIFF
--- a/packages/widget/__tests__/widget/popup.test.ts
+++ b/packages/widget/__tests__/widget/popup.test.ts
@@ -148,6 +148,17 @@ describe("Popup", () => {
       expect(dialog.style.top).toBe("272px");
     });
 
+    it("clamps to viewport bottom when rect is too tall to fit popup above or below", () => {
+      // Tall rect that spans most of the viewport (jsdom default 1024x768)
+      // — neither below (rect.bottom + 8 + 220 > 768) nor above
+      // (rect.top - 220 - 8 < 8) leaves room.
+      popup.show(makeBounds({ top: 50, bottom: 750 }));
+
+      const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!;
+      // top = innerHeight - popupH - 8 = 768 - 220 - 8 = 540
+      expect(dialog.style.top).toBe("540px");
+    });
+
     it("resolves to null when cancelled (via cancel button)", async () => {
       const promise = popup.show(makeBounds());
 

--- a/packages/widget/src/popup.ts
+++ b/packages/widget/src/popup.ts
@@ -230,16 +230,25 @@ export class Popup {
       this.previouslyFocused = document.activeElement as HTMLElement | null;
 
       // Position: bottom-left of rect, 8px below
+      const popupH = 220;
+      const popupW = 300;
       let top = rectBounds.bottom + 8;
       let left = rectBounds.left;
 
-      // Collision: flip up if not enough space below
-      if (top + 220 > window.innerHeight) {
-        top = rectBounds.top - 220 - 8;
+      // Vertical: prefer below; fall back to above; otherwise clamp inside viewport
+      if (top + popupH > window.innerHeight) {
+        const aboveTop = rectBounds.top - popupH - 8;
+        if (aboveTop >= 8) {
+          top = aboveTop;
+        } else {
+          // Rect is taller than the viewport allows on either side —
+          // clamp to keep the popup fully visible.
+          top = window.innerHeight - popupH - 8;
+        }
       }
       // Collision: flip right if not enough space on left
-      if (left + 300 > window.innerWidth) {
-        left = rectBounds.right - 300;
+      if (left + popupW > window.innerWidth) {
+        left = rectBounds.right - popupW;
       }
       left = Math.max(8, left);
       top = Math.max(8, top);


### PR DESCRIPTION
## Summary

When the drawn annotation rect spans most of the viewport, neither positioning the popup below nor above the rect gives it enough room. Previously the popup ended up clamped to `top: 8px` (overlapping the rect's top portion). Now it clamps to a position that keeps the popup fully visible within the viewport.

Inspired by [Trade-su/SitePing@87dddb7](https://github.com/Trade-su/SitePing/commit/87dddb7) (adapted: drops the fork-specific 52px bottom toolbar offset since upstream has no bottom toolbar).

## Test plan

- [x] `bun run test:run` — 1245/1245 passing (+1 new clamp test)
- [x] `bun run check` — type-check OK
- [x] `bun run lint` — biome clean
- [ ] Manually: resize browser to small viewport, draw a rect spanning most of the height, verify popup stays fully visible