### PR TITLE
feat: page-scoped annotations + semantic anchors (data-feedback-anchor)

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -159,7 +159,11 @@ test.describe("Panel", () => {
     await s.click('[data-item-id="chat"]');
     await s.waitFor(".sp-filter-dropdown-btn");
     expect(await s.count(".sp-filter-dropdown-btn")).toBe(1);
-    expect(await s.count(".sp-segmented__btn")).toBe(3);
+    // 3 status buttons + 3 scope buttons (page-scope feature). Use a
+    // scoped selector so adding more segmented controls doesn't break
+    // this assertion.
+    expect(await s.count("[data-status-filter]")).toBe(3);
+    expect(await s.count("[data-scope-filter]")).toBe(3);
   });
 
   test("closes via close button", async ({ page }) => {

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -102,6 +102,7 @@ export class LocalStorageStore implements SitepingStore {
       textSuffix: ann.textSuffix,
       fingerprint: ann.fingerprint,
       neighborText: ann.neighborText,
+      anchorKey: ann.anchorKey ?? null,
       xPct: ann.xPct,
       yPct: ann.yPct,
       wPct: ann.wPct,
@@ -121,6 +122,7 @@ export class LocalStorageStore implements SitepingStore {
       status: data.status,
       projectName: data.projectName,
       url: data.url,
+      urlPattern: data.urlPattern ?? null,
       authorName: data.authorName,
       authorEmail: data.authorEmail,
       viewport: data.viewport,
@@ -142,6 +144,8 @@ export class LocalStorageStore implements SitepingStore {
 
     if (query.type) results = results.filter((f) => f.type === query.type);
     if (query.status) results = results.filter((f) => f.status === query.status);
+    if (query.url) results = results.filter((f) => f.url === query.url);
+    if (query.urlPattern) results = results.filter((f) => f.urlPattern === query.urlPattern);
     if (query.search) {
       const s = query.search.toLowerCase();
       results = results.filter((f) => f.message.toLowerCase().includes(s));

--- a/packages/adapter-memory/src/index.ts
+++ b/packages/adapter-memory/src/index.ts
@@ -59,6 +59,7 @@ export class MemoryStore implements SitepingStore {
       textSuffix: ann.textSuffix,
       fingerprint: ann.fingerprint,
       neighborText: ann.neighborText,
+      anchorKey: ann.anchorKey ?? null,
       xPct: ann.xPct,
       yPct: ann.yPct,
       wPct: ann.wPct,
@@ -78,6 +79,7 @@ export class MemoryStore implements SitepingStore {
       status: data.status,
       projectName: data.projectName,
       url: data.url,
+      urlPattern: data.urlPattern ?? null,
       authorName: data.authorName,
       authorEmail: data.authorEmail,
       viewport: data.viewport,
@@ -98,6 +100,8 @@ export class MemoryStore implements SitepingStore {
 
     if (query.type) results = results.filter((f) => f.type === query.type);
     if (query.status) results = results.filter((f) => f.status === query.status);
+    if (query.url) results = results.filter((f) => f.url === query.url);
+    if (query.urlPattern) results = results.filter((f) => f.urlPattern === query.urlPattern);
     if (query.search) {
       const s = query.search.toLowerCase();
       results = results.filter((f) => f.message.toLowerCase().includes(s));

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -43,6 +43,8 @@ export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({ pri
 | `type` | `string` | `question` \| `change` \| `bug` \| `other` |
 | `status` | `string` | `open` \| `resolved` |
 | `search` | `string` | Full-text search on message content |
+| `url` | `string` | Restrict to feedbacks created on this exact URL — used by the panel's "this page" filter |
+| `urlPattern` | `string` | Restrict to feedbacks created on this URL template (e.g. `/orders/:id`) — used by the panel's "this type of page" filter |
 | `page` | `number` | Pagination (default: 1) |
 | `limit` | `number` | Items per page (default: 50, max: 100) |
 
@@ -63,9 +65,10 @@ All incoming requests are validated with Zod before hitting the database.
 | `authorName` | 1 to **200** characters |
 | `authorEmail` | Valid email format, max **200** characters |
 | `clientId` | Non-empty string (client-generated UUID for deduplication) |
+| `urlPattern` | Optional string (max 2000) or `null` — parameterized route template for cross-instance grouping |
 | `annotations` | Array of annotation objects (see below) |
 
-**Annotation fields:** `cssSelector`, `xpath`, `elementTag` must be non-empty. `wPct`, `hPct` must be positive. `viewportW`, `viewportH` must be positive integers. `devicePixelRatio` must be positive (defaults to `1`).
+**Annotation fields:** `cssSelector`, `xpath`, `elementTag` must be non-empty. `wPct`, `hPct` must be positive. `viewportW`, `viewportH` must be positive integers. `devicePixelRatio` must be positive (defaults to `1`). `anchorKey` is optional (max 200 chars) — semantic anchor identifier from the closest `data-feedback-anchor` ancestor.
 
 ### PATCH — Resolve/unresolve (`feedbackPatchSchema`)
 

--- a/packages/adapter-prisma/__tests__/validation.test.ts
+++ b/packages/adapter-prisma/__tests__/validation.test.ts
@@ -64,6 +64,14 @@ describe("feedbackCreateSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects whitespace-only url (trimmed to empty)", () => {
+    const result = feedbackCreateSchema.safeParse({
+      ...validPayload,
+      url: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("accepts pathname url (default getPageScope output)", () => {
     const result = feedbackCreateSchema.safeParse({
       ...validPayload,

--- a/packages/adapter-prisma/__tests__/validation.test.ts
+++ b/packages/adapter-prisma/__tests__/validation.test.ts
@@ -54,12 +54,22 @@ describe("feedbackCreateSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid URL", () => {
+  it("rejects empty url", () => {
+    // Hosts override `getPageScope()` to return any string identifier
+    // (pathname, full URL, opaque slug, …); we only require non-empty.
     const result = feedbackCreateSchema.safeParse({
       ...validPayload,
-      url: "not-a-url",
+      url: "",
     });
     expect(result.success).toBe(false);
+  });
+
+  it("accepts pathname url (default getPageScope output)", () => {
+    const result = feedbackCreateSchema.safeParse({
+      ...validPayload,
+      url: "/orders/42",
+    });
+    expect(result.success).toBe(true);
   });
 
   it("rejects negative annotation rect dimensions", () => {

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -75,6 +75,7 @@ export class PrismaStore implements SitepingStore {
         message: data.message,
         status: data.status,
         url: data.url,
+        urlPattern: data.urlPattern ?? null,
         viewport: data.viewport,
         userAgent: data.userAgent,
         authorName: data.authorName,
@@ -91,6 +92,7 @@ export class PrismaStore implements SitepingStore {
             textSuffix: ann.textSuffix,
             fingerprint: ann.fingerprint,
             neighborText: ann.neighborText,
+            anchorKey: ann.anchorKey ?? null,
             xPct: ann.xPct,
             yPct: ann.yPct,
             wPct: ann.wPct,
@@ -115,11 +117,13 @@ export class PrismaStore implements SitepingStore {
   }
 
   async getFeedbacks(query: FeedbackQuery): Promise<{ feedbacks: FeedbackRecord[]; total: number }> {
-    const { projectName, type, status, search, page = 1, limit = 50 } = query;
+    const { projectName, type, status, search, url, urlPattern, page = 1, limit = 50 } = query;
 
     const where: Record<string, unknown> = { projectName };
     if (type) where.type = type;
     if (status) where.status = status;
+    if (url) where.url = url;
+    if (urlPattern) where.urlPattern = urlPattern;
     if (search) where.message = { contains: search, mode: "insensitive" as const };
 
     const [feedbacks, total] = await Promise.all([
@@ -354,6 +358,7 @@ export function createSitepingHandler({
           message: data.message,
           status: "open",
           url: data.url,
+          urlPattern: data.urlPattern ?? null,
           viewport: data.viewport,
           userAgent: data.userAgent,
           authorName: data.authorName,
@@ -383,7 +388,7 @@ export function createSitepingHandler({
 
       const url = new URL(request.url);
       const rawQuery: Record<string, unknown> = {};
-      for (const key of ["projectName", "page", "limit", "type", "status", "search"]) {
+      for (const key of ["projectName", "page", "limit", "type", "status", "search", "url", "urlPattern"]) {
         const val = url.searchParams.get(key);
         if (val !== null) rawQuery[key] = val;
       }

--- a/packages/adapter-prisma/src/validation.ts
+++ b/packages/adapter-prisma/src/validation.ts
@@ -48,10 +48,10 @@ export const feedbackCreateSchema = z.object({
   // Page-scope identifier the widget uses to group feedbacks. Defaults to
   // `window.location.pathname` ("/orders/42"), but hosts can override
   // `getPageScope()` to return a full URL, an opaque slug, anything they
-  // want. We bound length and require non-empty; the value is opaque to
-  // the server and only used as a literal Prisma equality filter, so the
-  // loose shape is safe.
-  url: z.string().min(1).max(2000),
+  // want. We trim + require non-empty so whitespace-only payloads don't
+  // leak into the DB; otherwise the value is opaque to the server and only
+  // used as a literal Prisma equality filter, so the loose shape is safe.
+  url: z.string().trim().min(1).max(2000),
   // Optional parameterized URL template (e.g. "/orders/:orderId") provided
   // by the host via `getPageScope()`. Null when host omits it.
   urlPattern: z.string().max(2000).nullable().optional(),

--- a/packages/adapter-prisma/src/validation.ts
+++ b/packages/adapter-prisma/src/validation.ts
@@ -45,7 +45,13 @@ export const feedbackCreateSchema = z.object({
   projectName: z.string().min(1).max(200),
   type: z.enum(FEEDBACK_TYPES),
   message: z.string().min(1).max(5000),
-  url: z.string().max(2000).url(),
+  // Page-scope identifier the widget uses to group feedbacks. Defaults to
+  // `window.location.pathname` ("/orders/42"), but hosts can override
+  // `getPageScope()` to return a full URL, an opaque slug, anything they
+  // want. We bound length and require non-empty; the value is opaque to
+  // the server and only used as a literal Prisma equality filter, so the
+  // loose shape is safe.
+  url: z.string().min(1).max(2000),
   // Optional parameterized URL template (e.g. "/orders/:orderId") provided
   // by the host via `getPageScope()`. Null when host omits it.
   urlPattern: z.string().max(2000).nullable().optional(),

--- a/packages/adapter-prisma/src/validation.ts
+++ b/packages/adapter-prisma/src/validation.ts
@@ -19,6 +19,9 @@ const anchorSchema = z.object({
   textSuffix: z.string().max(200),
   fingerprint: z.string().max(200),
   neighborText: z.string().max(500),
+  // Optional semantic anchor identifier from `data-feedback-anchor`.
+  // Null when no semantic ancestor exists; widget always sends this field.
+  anchorKey: z.string().max(200).nullable().optional(),
 });
 
 const rectSchema = z.object({
@@ -43,6 +46,9 @@ export const feedbackCreateSchema = z.object({
   type: z.enum(FEEDBACK_TYPES),
   message: z.string().min(1).max(5000),
   url: z.string().max(2000).url(),
+  // Optional parameterized URL template (e.g. "/orders/:orderId") provided
+  // by the host via `getPageScope()`. Null when host omits it.
+  urlPattern: z.string().max(2000).nullable().optional(),
   viewport: z.string().min(1).max(50),
   userAgent: z.string().min(1).max(500),
   authorName: z.string().min(1).max(200),
@@ -69,6 +75,9 @@ export const getQuerySchema = z.object({
   type: z.enum(FEEDBACK_TYPES).optional(),
   status: z.enum(FEEDBACK_STATUSES).optional(),
   search: z.string().max(200).optional(),
+  // Page scope filters — used by the panel's "this page / this type" controls
+  url: z.string().max(2000).optional(),
+  urlPattern: z.string().max(2000).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -85,6 +94,7 @@ export interface AnchorInput {
   textSuffix: string;
   fingerprint: string;
   neighborText: string;
+  anchorKey?: string | null | undefined;
 }
 
 export interface RectInput {
@@ -110,6 +120,7 @@ export interface FeedbackCreateInput {
   type: FeedbackType;
   message: string;
   url: string;
+  urlPattern?: string | null | undefined;
   viewport: string;
   userAgent: string;
   authorName: string;
@@ -145,6 +156,8 @@ export interface GetQueryInput {
   type?: FeedbackType | undefined;
   status?: FeedbackStatus | undefined;
   search?: string | undefined;
+  url?: string | undefined;
+  urlPattern?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -27,6 +27,7 @@ model SitepingFeedback {
   message      String              @db.Text
   status       String              @default("open")
   url          String
+  urlPattern   String?
   viewport     String
   userAgent    String
   authorName   String
@@ -39,6 +40,7 @@ model SitepingFeedback {
 
   @@index([projectName])
   @@index([projectName, status, createdAt])
+  @@index([projectName, url])
 }
 
 model SitepingAnnotation {
@@ -54,6 +56,7 @@ model SitepingAnnotation {
   textSuffix       String           @db.Text
   fingerprint      String
   neighborText     String           @db.Text
+  anchorKey        String?
   xPct             Float
   yPct             Float
   wPct             Float
@@ -174,6 +177,7 @@ model SitepingFeedback {
   message      String              @db.Text
   status       String              @default("open")
   url          String
+  urlPattern   String?
   viewport     String
   userAgent    String
   authorName   String
@@ -197,6 +201,7 @@ model SitepingAnnotation {
   textSuffix       String           @db.Text
   fingerprint      String
   neighborText     String           @db.Text
+  anchorKey        String?
   xPct             Float
   yPct             Float
   wPct             Float

--- a/packages/core/__tests__/store-errors.test.ts
+++ b/packages/core/__tests__/store-errors.test.ts
@@ -214,6 +214,7 @@ describe("flattenAnnotation", () => {
     const result = flattenAnnotation(sampleAnnotation);
     const keys = Object.keys(result).sort();
     expect(keys).toEqual([
+      "anchorKey",
       "cssSelector",
       "devicePixelRatio",
       "elementId",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type {
   FeedbackStatus,
   FeedbackType,
   FeedbackUpdateInput,
+  PageScope,
   RectData,
   SitepingConfig,
   SitepingInstance,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -50,6 +50,7 @@ const _SITEPING_MODELS = {
       message: { type: "String", nativeType: "Text" },
       status: { type: "String", default: '"open"' },
       url: { type: "String" },
+      urlPattern: { type: "String", optional: true },
       viewport: { type: "String" },
       userAgent: { type: "String" },
       authorName: { type: "String" },
@@ -63,7 +64,11 @@ const _SITEPING_MODELS = {
         relation: { kind: "1-to-many", model: "SitepingAnnotation" },
       },
     },
-    indexes: [{ fields: ["projectName"] }, { fields: ["projectName", "status", "createdAt"] }],
+    indexes: [
+      { fields: ["projectName"] },
+      { fields: ["projectName", "status", "createdAt"] },
+      { fields: ["projectName", "url"] },
+    ],
   },
   SitepingAnnotation: {
     fields: {
@@ -88,6 +93,7 @@ const _SITEPING_MODELS = {
       textSuffix: { type: "String", nativeType: "Text" },
       fingerprint: { type: "String" },
       neighborText: { type: "String", nativeType: "Text" },
+      anchorKey: { type: "String", optional: true },
       xPct: { type: "Float" },
       yPct: { type: "Float" },
       wPct: { type: "Float" },

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -141,6 +141,42 @@ export function testSitepingStore(factory: () => SitepingStore): void {
         expect(record.annotations[0]?.elementId).toBeNull();
       });
 
+      it("persists anchorKey when provided", async () => {
+        freshStore();
+        const input = createInput({
+          annotations: [
+            {
+              cssSelector: "section",
+              xpath: "/section",
+              textSnippet: "Services",
+              elementTag: "SECTION",
+              textPrefix: "",
+              textSuffix: "",
+              fingerprint: "1:0:x",
+              neighborText: "",
+              anchorKey: "order-card.services",
+              xPct: 0,
+              yPct: 0,
+              wPct: 1,
+              hPct: 1,
+              scrollX: 0,
+              scrollY: 0,
+              viewportW: 1920,
+              viewportH: 1080,
+              devicePixelRatio: 1,
+            },
+          ],
+        });
+        const record = await store.createFeedback(input);
+        expect(record.annotations[0]?.anchorKey).toBe("order-card.services");
+      });
+
+      it("persists anchorKey as null when omitted", async () => {
+        freshStore();
+        const record = await store.createFeedback(createInput());
+        expect(record.annotations[0]?.anchorKey).toBeNull();
+      });
+
       it("deduplicates by clientId (idempotent)", async () => {
         freshStore();
         const input = createInput({ clientId: "same-id" });
@@ -225,6 +261,32 @@ export function testSitepingStore(factory: () => SitepingStore): void {
         const result = await store.getFeedbacks({ projectName: "test-project", search: "BROKEN" });
         expect(result.feedbacks).toHaveLength(1);
         expect(result.feedbacks[0]?.message).toBe("Button is broken");
+      });
+
+      it("filters by exact url", async () => {
+        freshStore();
+        await store.createFeedback(createInput({ url: "https://app.test/orders/42" }));
+        await store.createFeedback(createInput({ url: "https://app.test/dashboard" }));
+
+        const result = await store.getFeedbacks({ projectName: "test-project", url: "https://app.test/dashboard" });
+        expect(result.feedbacks).toHaveLength(1);
+        expect(result.feedbacks[0]?.url).toBe("https://app.test/dashboard");
+      });
+
+      it("filters by urlPattern", async () => {
+        freshStore();
+        await store.createFeedback(createInput({ url: "https://app.test/orders/42", urlPattern: "/orders/:id" }));
+        await store.createFeedback(createInput({ url: "https://app.test/orders/99", urlPattern: "/orders/:id" }));
+        await store.createFeedback(createInput({ url: "https://app.test/dashboard", urlPattern: "/dashboard" }));
+
+        const result = await store.getFeedbacks({ projectName: "test-project", urlPattern: "/orders/:id" });
+        expect(result.feedbacks).toHaveLength(2);
+      });
+
+      it("persists urlPattern as null when omitted from input", async () => {
+        freshStore();
+        const record = await store.createFeedback(createInput());
+        expect(record.urlPattern).toBeNull();
       });
 
       it("paginates correctly", async () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,6 +22,25 @@ export interface SitepingConfig {
   theme?: "light" | "dark" | "auto";
   /** UI locale — defaults to 'en'. Built-in: en, fr, de, es, it, pt (Brazilian), ru. Any other string falls back to English. */
   locale?: "en" | "fr" | "de" | "es" | "it" | "pt" | "ru" | (string & {}) | undefined;
+  /**
+   * Returns the current page scope for annotations and panel filtering.
+   * Called on initial markers load and on `instance.refresh()`.
+   *
+   * Default: `{ url: window.location.pathname, urlPattern: null }` — annotations
+   * are scoped strictly to the current pathname.
+   *
+   * Apps with parameterized routes (e.g. React Router) should return both the
+   * concrete URL and the route template (e.g. `/orders/:orderId`) so the panel
+   * can offer a "this type of page" filter that groups feedbacks by template.
+   */
+  getPageScope?: (() => PageScope) | undefined;
+  /**
+   * When true (default), the widget filters initial markers and panel results
+   * by `feedback.url === scope.url`, so annotations created on one page never
+   * leak to other pages — even if their CSS selector accidentally matches.
+   * Set to `false` to revert to the legacy project-wide behavior.
+   */
+  scopeAnnotationsByUrl?: boolean | undefined;
   /** Called when the widget is skipped (production mode, mobile viewport) */
   onSkip?: (reason: "production" | "mobile") => void;
 
@@ -77,6 +96,20 @@ export type FeedbackType = (typeof FEEDBACK_TYPES)[number];
 export const FEEDBACK_STATUSES = ["open", "resolved"] as const;
 export type FeedbackStatus = (typeof FEEDBACK_STATUSES)[number];
 
+/**
+ * Page scope returned by `SitepingConfig.getPageScope()`.
+ *
+ * - `url`: concrete page identifier — usually `window.location.pathname`,
+ *   used as the strict scope for marker rendering.
+ * - `urlPattern`: optional parameterized template (e.g. `/orders/:orderId`)
+ *   used by the panel's "this type of page" filter to group feedbacks across
+ *   instances of the same page kind.
+ */
+export interface PageScope {
+  url: string;
+  urlPattern: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Abstract Store — adapter pattern
 // ---------------------------------------------------------------------------
@@ -88,6 +121,13 @@ export interface FeedbackCreateInput {
   message: string;
   status: FeedbackStatus;
   url: string;
+  /**
+   * Optional parameterized URL template (e.g. `/orders/:orderId`) for the page
+   * where the feedback was created. Allows the panel to filter feedbacks by
+   * "this type of page" across different instances. Null when the host did not
+   * provide a `getPageScope` callback or the route has no template.
+   */
+  urlPattern?: string | null | undefined;
   viewport: string;
   userAgent: string;
   authorName: string;
@@ -107,6 +147,13 @@ export interface AnnotationCreateInput {
   textSuffix: string;
   fingerprint: string;
   neighborText: string;
+  /**
+   * Semantic anchor identifier from the closest ancestor's `data-feedback-anchor`
+   * attribute. When set, this is the most stable re-anchoring signal because
+   * hosts deliberately place these on layout/section roots that survive DOM
+   * refactors and viewport changes. Null when no semantic ancestor exists.
+   */
+  anchorKey?: string | null | undefined;
   xPct: number;
   yPct: number;
   wPct: number;
@@ -126,6 +173,17 @@ export interface FeedbackQuery {
   search?: string | undefined;
   page?: number | undefined;
   limit?: number | undefined;
+  /**
+   * Filter to feedbacks created on this exact URL (path). Used by the panel's
+   * "this page" filter and by the markers loader to keep page scopes isolated.
+   */
+  url?: string | undefined;
+  /**
+   * Filter to feedbacks created on this URL pattern (e.g. `/orders/:orderId`).
+   * Used by the panel's "this type of page" filter to group feedbacks across
+   * different concrete instances of the same template.
+   */
+  urlPattern?: string | undefined;
 }
 
 /** Update payload for patching a feedback. */
@@ -142,6 +200,11 @@ export interface FeedbackRecord {
   status: FeedbackStatus;
   projectName: string;
   url: string;
+  /**
+   * Parameterized URL template the feedback was created on.
+   * Null for legacy records or hosts without `getPageScope`.
+   */
+  urlPattern: string | null;
   authorName: string;
   authorEmail: string;
   viewport: string;
@@ -166,6 +229,11 @@ export interface AnnotationRecord {
   textSuffix: string;
   fingerprint: string;
   neighborText: string;
+  /**
+   * Semantic anchor identifier from `data-feedback-anchor`. Null for legacy
+   * annotations or those drawn outside any anchored region.
+   */
+  anchorKey: string | null;
   xPct: number;
   yPct: number;
   wPct: number;
@@ -239,6 +307,7 @@ export function flattenAnnotation(ann: AnnotationPayload): AnnotationCreateInput
     textSuffix: ann.anchor.textSuffix,
     fingerprint: ann.anchor.fingerprint,
     neighborText: ann.anchor.neighborText,
+    anchorKey: ann.anchor.anchorKey ?? null,
     xPct: ann.rect.xPct,
     yPct: ann.rect.yPct,
     wPct: ann.rect.wPct,
@@ -292,6 +361,11 @@ export interface FeedbackPayload {
   type: FeedbackType;
   message: string;
   url: string;
+  /**
+   * Parameterized URL template (e.g. `/orders/:orderId`) supplied by
+   * `SitepingConfig.getPageScope()`. Null when the host did not provide one.
+   */
+  urlPattern?: string | null | undefined;
   viewport: string;
   userAgent: string;
   authorName: string;
@@ -325,6 +399,13 @@ export interface AnchorData {
   fingerprint: string;
   /** Text content of adjacent sibling elements (context) */
   neighborText: string;
+  /**
+   * Semantic anchor identifier from the closest ancestor's `data-feedback-anchor`
+   * attribute. When set, this is the highest-priority re-anchoring signal —
+   * hosts deliberately place these on layout/section roots that survive
+   * viewport changes and DOM refactors.
+   */
+  anchorKey?: string | null | undefined;
 }
 
 /** Drawn rectangle coordinates as percentages relative to the anchor element. */
@@ -362,6 +443,8 @@ export interface FeedbackResponse {
   message: string;
   status: FeedbackStatus;
   url: string;
+  /** Parameterized URL template the feedback was created on, or null. */
+  urlPattern: string | null;
   viewport: string;
   userAgent: string;
   authorName: string;
@@ -385,6 +468,8 @@ export interface AnnotationResponse {
   textSuffix: string;
   fingerprint: string;
   neighborText: string;
+  /** Semantic anchor identifier from `data-feedback-anchor`, or null. */
+  anchorKey: string | null;
   xPct: number;
   yPct: number;
   wPct: number;

--- a/packages/widget/__tests__/dom/anchor-key.test.ts
+++ b/packages/widget/__tests__/dom/anchor-key.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { generateAnchor } from "../../src/dom/anchor.js";
+import { resolveAnchor } from "../../src/dom/resolver.js";
+
+// jsdom lacks CSS.escape in older versions
+if (typeof CSS === "undefined") {
+  (globalThis as Record<string, unknown>).CSS = { escape: (s: string) => s };
+} else if (!CSS.escape) {
+  CSS.escape = (s: string) => s;
+}
+
+function clearBody(): void {
+  while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
+}
+
+// ---------------------------------------------------------------------------
+// generateAnchor — captures data-feedback-anchor from the element or ancestors
+// ---------------------------------------------------------------------------
+
+describe("generateAnchor — data-feedback-anchor", () => {
+  afterEach(() => {
+    clearBody();
+  });
+
+  it("captures anchorKey from the closest ancestor", () => {
+    const section = document.createElement("section");
+    section.setAttribute("data-feedback-anchor", "order-card.services");
+    const inner = document.createElement("button");
+    inner.textContent = "Add service";
+    section.appendChild(inner);
+    document.body.appendChild(section);
+
+    const anchor = generateAnchor(inner);
+
+    expect(anchor.anchorKey).toBe("order-card.services");
+  });
+
+  it("captures anchorKey when the element itself has the attribute", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-feedback-anchor", "layout.sidebar");
+    document.body.appendChild(el);
+
+    const anchor = generateAnchor(el);
+
+    expect(anchor.anchorKey).toBe("layout.sidebar");
+  });
+
+  it("returns null anchorKey when no ancestor has the attribute", () => {
+    const el = document.createElement("p");
+    el.textContent = "Plain";
+    document.body.appendChild(el);
+
+    const anchor = generateAnchor(el);
+
+    expect(anchor.anchorKey).toBeNull();
+  });
+
+  it("uses the nearest ancestor when nested anchors exist", () => {
+    const outer = document.createElement("section");
+    outer.setAttribute("data-feedback-anchor", "page.root");
+    const inner = document.createElement("div");
+    inner.setAttribute("data-feedback-anchor", "page.toolbar");
+    const button = document.createElement("button");
+    button.textContent = "Save";
+    inner.appendChild(button);
+    outer.appendChild(inner);
+    document.body.appendChild(outer);
+
+    const anchor = generateAnchor(button);
+
+    expect(anchor.anchorKey).toBe("page.toolbar");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAnchor — semantic anchor at priority 0
+// ---------------------------------------------------------------------------
+
+describe("resolveAnchor — anchorKey strategy", () => {
+  afterEach(() => {
+    clearBody();
+  });
+
+  it("resolves via anchorKey at confidence 1.0", () => {
+    const section = document.createElement("section");
+    section.setAttribute("data-feedback-anchor", "order-card.services");
+    section.textContent = "Services panel";
+    document.body.appendChild(section);
+
+    const resolution = resolveAnchor({
+      cssSelector: "section",
+      xpath: "/html/body/section",
+      textSnippet: "Services panel",
+      elementTag: "SECTION",
+      textPrefix: "",
+      textSuffix: "",
+      fingerprint: "",
+      neighborText: "",
+      anchorKey: "order-card.services",
+    });
+
+    expect(resolution).not.toBeNull();
+    expect(resolution?.strategy).toBe("anchorKey");
+    expect(resolution?.confidence).toBe(1.0);
+    expect(resolution?.element).toBe(section);
+  });
+
+  it("does not enforce tag-name match — host can refactor section → div", () => {
+    const div = document.createElement("div");
+    div.setAttribute("data-feedback-anchor", "order-card.services");
+    div.textContent = "Services panel";
+    document.body.appendChild(div);
+
+    const resolution = resolveAnchor({
+      cssSelector: "section",
+      xpath: "/html/body/section",
+      textSnippet: "Services panel",
+      elementTag: "SECTION",
+      textPrefix: "",
+      textSuffix: "",
+      fingerprint: "",
+      neighborText: "",
+      anchorKey: "order-card.services",
+    });
+
+    expect(resolution?.strategy).toBe("anchorKey");
+    expect(resolution?.element).toBe(div);
+  });
+
+  it("falls back to the next strategy when anchorKey is not in the DOM", () => {
+    const el = document.createElement("section");
+    el.id = "the-section";
+    el.textContent = "Hello";
+    document.body.appendChild(el);
+
+    const resolution = resolveAnchor({
+      cssSelector: "#the-section",
+      xpath: "/html/body/section",
+      textSnippet: "Hello",
+      elementTag: "SECTION",
+      elementId: "the-section",
+      textPrefix: "",
+      textSuffix: "",
+      fingerprint: "",
+      neighborText: "",
+      anchorKey: "missing.key",
+    });
+
+    expect(resolution?.strategy).toBe("id");
+  });
+
+  it("safely escapes special characters in anchorKey", () => {
+    const el = document.createElement("div");
+    el.setAttribute("data-feedback-anchor", 'tricky"key');
+    el.textContent = "ok";
+    document.body.appendChild(el);
+
+    const resolution = resolveAnchor({
+      cssSelector: "div",
+      xpath: "/html/body/div",
+      textSnippet: "ok",
+      elementTag: "DIV",
+      textPrefix: "",
+      textSuffix: "",
+      fingerprint: "",
+      neighborText: "",
+      anchorKey: 'tricky"key',
+    });
+
+    expect(resolution?.strategy).toBe("anchorKey");
+    expect(resolution?.element).toBe(el);
+  });
+
+  it("text snippet mismatch causes anchorKey to be skipped", () => {
+    const el = document.createElement("section");
+    el.setAttribute("data-feedback-anchor", "key");
+    el.textContent = "completely different content";
+    document.body.appendChild(el);
+
+    const resolution = resolveAnchor({
+      cssSelector: "section",
+      xpath: "/html/body/section",
+      textSnippet: "expected snippet that does not match",
+      elementTag: "SECTION",
+      textPrefix: "",
+      textSuffix: "",
+      fingerprint: "",
+      neighborText: "",
+      anchorKey: "key",
+    });
+
+    // anchorKey skipped, falls through to other strategies (which all fail) → null
+    expect(resolution).toBeNull();
+  });
+});

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -48,12 +48,17 @@ vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
   ),
 }));
 
+// Module-level marker spies so individual tests can assert against the same
+// instance that launch() created. Reset by `vi.clearAllMocks` in afterEach.
+const mockMarkersAddFeedback = vi.fn();
+const mockMarkersRender = vi.fn();
+
 vi.mock(new URL("../../src/markers.js", import.meta.url).pathname, () => ({
   MarkerManager: vi.fn().mockImplementation(() => ({
-    render: vi.fn(),
+    render: mockMarkersRender,
     highlight: vi.fn(),
     pinHighlight: vi.fn(),
-    addFeedback: vi.fn(),
+    addFeedback: mockMarkersAddFeedback,
     destroy: vi.fn(),
     count: 0,
   })),
@@ -803,6 +808,74 @@ describe("launcher — annotation:complete integration", () => {
       const payload = mockSendFeedback.mock.calls[0][0];
       expect(payload.url).toBe("/fallback/path");
       expect(payload.urlPattern).toBeNull();
+
+      instance.destroy();
+    });
+
+    it("does NOT add a marker when the response.url falls outside the current scope", async () => {
+      // The server may persist a feedback the widget submitted, but the
+      // panel.refresh() that follows could resolve to a different page (race
+      // with SPA navigation). The launcher compares response.url to scope.url
+      // and skips out-of-scope feedbacks so the user doesn't see a phantom
+      // marker for content they're no longer on.
+      const response = makeFeedbackResponse({ url: "/some-other-page" });
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch({
+        ...defaultConfig(),
+        getPageScope: () => ({ url: "/current-page", urlPattern: null }),
+      });
+      expect(capturedBus).not.toBeNull();
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      expect(mockMarkersAddFeedback).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("DOES add the marker when response.url matches scope.url", async () => {
+      // Inverse of the previous case — when the feedback's URL matches the
+      // current scope (or when scopeAnnotationsByUrl is off), the marker is
+      // added immediately so the user sees their submission land.
+      const response = makeFeedbackResponse({ url: "/current-page" });
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch({
+        ...defaultConfig(),
+        getPageScope: () => ({ url: "/current-page", urlPattern: null }),
+      });
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockMarkersAddFeedback).toHaveBeenCalledOnce();
+      });
+
+      instance.destroy();
+    });
+
+    it("DOES add the marker regardless of url when scopeAnnotationsByUrl is disabled", async () => {
+      // Legacy project-wide mode: the user opts out of scope filtering, so
+      // every feedback's marker is added on submit even if the URLs differ.
+      const response = makeFeedbackResponse({ url: "/some-other-page" });
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch({
+        ...defaultConfig(),
+        scopeAnnotationsByUrl: false,
+        getPageScope: () => ({ url: "/current-page", urlPattern: null }),
+      });
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockMarkersAddFeedback).toHaveBeenCalledOnce();
+      });
 
       instance.destroy();
     });

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -716,13 +716,16 @@ describe("launcher — annotation:complete integration", () => {
   // URL sanitization
   // -------------------------------------------------------------------------
 
-  describe("URL sanitization", () => {
-    it("annotation:complete strips sensitive query params (token, key, secret, auth) from URL", async () => {
+  describe("URL identifier (scope-driven)", () => {
+    it("annotation:complete uses scope.url (pathname by default — query string never leaks)", async () => {
       const response = makeFeedbackResponse();
       mockSendFeedback.mockResolvedValue(response);
 
-      // Set location with sensitive params
-      const sensitiveUrl = "http://localhost/?token=abc&key=def&secret=ghi&auth=jkl&page=1";
+      // Sensitive params would have leaked under the old "sanitize full URL"
+      // approach. The contract is now "scope identifier, not current URL":
+      // default scope returns `pathname`, so query strings are absent by
+      // construction.
+      const sensitiveUrl = "http://localhost/orders/123?token=abc&key=def&secret=ghi&auth=jkl&page=1";
       Object.defineProperty(window, "location", {
         value: new URL(sensitiveUrl),
         writable: true,
@@ -739,12 +742,67 @@ describe("launcher — annotation:complete integration", () => {
       });
 
       const payload = mockSendFeedback.mock.calls[0][0];
+      // Pathname only — no origin, no query, no fragment.
+      expect(payload.url).toBe("/orders/123");
+      expect(payload.url).not.toContain("?");
       expect(payload.url).not.toContain("token=");
       expect(payload.url).not.toContain("key=");
       expect(payload.url).not.toContain("secret=");
       expect(payload.url).not.toContain("auth=");
-      // Non-sensitive params should remain
-      expect(payload.url).toContain("page=1");
+
+      instance.destroy();
+    });
+
+    it("annotation:complete honours a custom getPageScope().url", async () => {
+      const response = makeFeedbackResponse();
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch({
+        ...defaultConfig(),
+        getPageScope: () => ({ url: "/custom/scope/key", urlPattern: "/custom/:id" }),
+      });
+      expect(capturedBus).not.toBeNull();
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      const payload = mockSendFeedback.mock.calls[0][0];
+      expect(payload.url).toBe("/custom/scope/key");
+      expect(payload.urlPattern).toBe("/custom/:id");
+
+      instance.destroy();
+    });
+
+    it("falls back to pathname when getPageScope() throws", async () => {
+      const response = makeFeedbackResponse();
+      mockSendFeedback.mockResolvedValue(response);
+
+      Object.defineProperty(window, "location", {
+        value: new URL("http://localhost/fallback/path"),
+        writable: true,
+        configurable: true,
+      });
+
+      const instance = launch({
+        ...defaultConfig(),
+        getPageScope: () => {
+          throw new Error("boom");
+        },
+      });
+      expect(capturedBus).not.toBeNull();
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      const payload = mockSendFeedback.mock.calls[0][0];
+      expect(payload.url).toBe("/fallback/path");
+      expect(payload.urlPattern).toBeNull();
 
       instance.destroy();
     });

--- a/packages/widget/__tests__/widget/markers.test.ts
+++ b/packages/widget/__tests__/widget/markers.test.ts
@@ -647,6 +647,36 @@ describe("MarkerManager", () => {
 
       vi.useRealTimers();
     });
+
+    it("re-renders the pinned highlight rectangle so it tracks the layout on resize", () => {
+      vi.useFakeTimers();
+
+      const fb = makeFeedback({ id: "fb-pin" });
+      markers.render([fb]);
+      markers.pinHighlight(fb);
+
+      // The highlight is a div with no [data-feedback-id] inside
+      // #siteping-markers — distinct from marker dots which carry the id.
+      const container = document.getElementById("siteping-markers")!;
+      const findHighlights = () => Array.from(container.children).filter((c) => !(c as HTMLElement).dataset.feedbackId);
+
+      const before = findHighlights();
+      expect(before.length).toBeGreaterThan(0);
+
+      // Simulate viewport resize — the layout has shifted, the percentage-
+      // based rect resolves to a new pixel position. repositionAll should
+      // re-render the highlight so it tracks the new layout.
+      window.dispatchEvent(new Event("resize"));
+      vi.advanceTimersByTime(400);
+
+      const after = findHighlights();
+      expect(after.length).toBeGreaterThan(0);
+      // showHighlight calls removeHighlightElements first then appends fresh
+      // elements — so the post-resize element is a different instance.
+      expect(after[0]).not.toBe(before[0]);
+
+      vi.useRealTimers();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/widget/__tests__/widget/panel.test.ts
+++ b/packages/widget/__tests__/widget/panel.test.ts
@@ -195,7 +195,8 @@ describe("Panel", () => {
     it("calls getFeedbacks on open", async () => {
       await panel.open();
 
-      expect(apiClient.getFeedbacks).toHaveBeenCalledWith("test-project", { page: 1, limit: 20 });
+      // Default scope filter is "this", so url=/ (jsdom pathname) is passed.
+      expect(apiClient.getFeedbacks).toHaveBeenCalledWith("test-project", { page: 1, limit: 20, url: "/" });
     });
 
     it("sets aria-hidden=true when closed", async () => {
@@ -3265,6 +3266,105 @@ describe("Panel", () => {
   // -------------------------------------------------------------------------
   // showError on subsequent loads — covers line 490 idx 1 (hasContent true, no error UI)
   // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // Page scope segmented control
+  // -------------------------------------------------------------------------
+
+  describe("scope segmented control", () => {
+    it("renders three scope buttons with 'this page' selected by default", () => {
+      const scopeSegmented = shadow.querySelector<HTMLElement>(".sp-segmented--scope")!;
+      expect(scopeSegmented).not.toBeNull();
+      expect(scopeSegmented.getAttribute("role")).toBe("radiogroup");
+      expect(scopeSegmented.getAttribute("aria-label")).toBe(t("scope.label"));
+
+      const buttons = scopeSegmented.querySelectorAll<HTMLButtonElement>(".sp-segmented__btn");
+      expect(buttons.length).toBe(3);
+      const thisBtn = scopeSegmented.querySelector<HTMLButtonElement>('[data-scope-filter="this"]')!;
+      expect(thisBtn.getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("hides 'this type' button when scope has no urlPattern", () => {
+      const scopeSegmented = shadow.querySelector<HTMLElement>(".sp-segmented--scope")!;
+      const templateBtn = scopeSegmented.querySelector<HTMLButtonElement>('[data-scope-filter="template"]')!;
+      // jsdom has no urlPattern by default — button is display:none
+      expect(templateBtn.style.display).toBe("none");
+    });
+
+    it("passes url filter to getFeedbacks when default scope active", async () => {
+      apiClient.getFeedbacks.mockClear();
+      await panel.open();
+      expect(apiClient.getFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/" }));
+    });
+
+    it("clicking 'all pages' clears the scope filter from queries", async () => {
+      await panel.open();
+      apiClient.getFeedbacks.mockClear();
+
+      const allBtn = shadow.querySelector<HTMLButtonElement>('[data-scope-filter="all"]')!;
+      allBtn.click();
+
+      await vi.waitFor(() => {
+        expect(apiClient.getFeedbacks).toHaveBeenCalled();
+      });
+      const lastCall = apiClient.getFeedbacks.mock.calls[apiClient.getFeedbacks.mock.calls.length - 1];
+      expect(lastCall?.[1]).not.toHaveProperty("url");
+      expect(lastCall?.[1]).not.toHaveProperty("urlPattern");
+    });
+
+    it("respects custom getScope option for url and urlPattern", async () => {
+      panel.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      bus = new EventBus<WidgetEvents>();
+      apiClient = createMockApiClient();
+      markers = createMockMarkers();
+      panel = new Panel(shadow, colors, bus, apiClient as never, "test-project", markers as never, t, "fr", {
+        getScope: () => ({ url: "/orders/42", urlPattern: "/orders/:id" }),
+        scopeAnnotationsByUrl: true,
+      });
+
+      // The "this type" button should now be visible
+      const scopeSegmented = shadow.querySelector<HTMLElement>(".sp-segmented--scope")!;
+      const templateBtn = scopeSegmented.querySelector<HTMLButtonElement>('[data-scope-filter="template"]')!;
+
+      apiClient.getFeedbacks.mockClear();
+      await panel.open();
+      // syncScopeAvailability runs on loadFeedbacks; templateBtn is now visible
+      expect(templateBtn.style.display).not.toBe("none");
+
+      // Default scope is "this" → url filter is /orders/42
+      expect(apiClient.getFeedbacks).toHaveBeenCalledWith(
+        "test-project",
+        expect.objectContaining({ url: "/orders/42" }),
+      );
+
+      // Switch to "this type" → urlPattern filter
+      apiClient.getFeedbacks.mockClear();
+      templateBtn.click();
+      await vi.waitFor(() => {
+        expect(apiClient.getFeedbacks).toHaveBeenCalled();
+      });
+      const lastCall = apiClient.getFeedbacks.mock.calls[apiClient.getFeedbacks.mock.calls.length - 1];
+      expect(lastCall?.[1]).toMatchObject({ urlPattern: "/orders/:id" });
+    });
+
+    it("filters markers to current url even when panel shows wider scope", async () => {
+      const here = makeFeedback({ id: "here", url: "/" });
+      const elsewhere = makeFeedback({ id: "elsewhere", url: "/other" });
+      apiClient.getFeedbacks.mockResolvedValue({ feedbacks: [here, elsewhere], total: 2 });
+
+      await panel.open();
+      const allBtn = shadow.querySelector<HTMLButtonElement>('[data-scope-filter="all"]')!;
+      allBtn.click();
+
+      await vi.waitFor(() => {
+        // Markers should always render only the local subset
+        const lastCall = markers.render.mock.calls[markers.render.mock.calls.length - 1];
+        expect(lastCall?.[0]).toEqual([here]);
+      });
+    });
+  });
 
   describe("loadFeedbacks error handling with prior content", () => {
     it("error after prior content keeps content visible and emits feedback:error", async () => {

--- a/packages/widget/src/api-client.ts
+++ b/packages/widget/src/api-client.ts
@@ -10,11 +10,24 @@ export interface WidgetClient {
   sendFeedback(payload: FeedbackPayload): Promise<FeedbackResponse>;
   getFeedbacks(
     projectName: string,
-    options?: { page?: number; limit?: number; type?: FeedbackType; status?: FeedbackStatus; search?: string },
+    options?: GetFeedbacksOptions,
   ): Promise<{ feedbacks: FeedbackResponse[]; total: number }>;
   resolveFeedback(id: string, resolved: boolean): Promise<FeedbackResponse>;
   deleteFeedback(id: string): Promise<void>;
   deleteAllFeedbacks(projectName: string): Promise<void>;
+}
+
+/** Options accepted by `WidgetClient.getFeedbacks`. */
+export interface GetFeedbacksOptions {
+  page?: number;
+  limit?: number;
+  type?: FeedbackType;
+  status?: FeedbackStatus;
+  search?: string;
+  /** Restrict to feedbacks created on this exact URL (path). */
+  url?: string;
+  /** Restrict to feedbacks created on this URL pattern (e.g. `/orders/:orderId`). */
+  urlPattern?: string;
 }
 
 const MAX_RETRIES = 3;
@@ -172,13 +185,7 @@ export class ApiClient {
 
   async getFeedbacks(
     projectName: string,
-    options?: {
-      page?: number;
-      limit?: number;
-      type?: FeedbackType;
-      status?: FeedbackStatus;
-      search?: string;
-    },
+    options?: GetFeedbacksOptions,
   ): Promise<{ feedbacks: FeedbackResponse[]; total: number }> {
     const params = new URLSearchParams({ projectName });
     if (options?.page) params.set("page", String(options.page));
@@ -186,6 +193,8 @@ export class ApiClient {
     if (options?.type) params.set("type", options.type);
     if (options?.status) params.set("status", options.status);
     if (options?.search) params.set("search", options.search);
+    if (options?.url) params.set("url", options.url);
+    if (options?.urlPattern) params.set("urlPattern", options.urlPattern);
 
     const response = await resilientFetch(`${this.endpoint}?${params.toString()}`, {
       method: "GET",

--- a/packages/widget/src/dom/anchor.ts
+++ b/packages/widget/src/dom/anchor.ts
@@ -4,13 +4,19 @@ import { generateFingerprint } from "./fingerprint.js";
 import { adjacentText, neighborText } from "./text-context.js";
 import { generateXPath } from "./xpath.js";
 
+/** HTML attribute hosts use to mark stable semantic anchors. */
+export const ANCHOR_KEY_ATTR = "data-feedback-anchor";
+
 /**
  * Generate a multi-selector anchor for a DOM element.
  *
- * Uses three complementary strategies (Hypothesis-inspired):
- * 1. CSS selector via @medv/finder (primary — fast, compact)
- * 2. XPath (fallback — survives class changes)
- * 3. Text snippet (fallback — survives structural changes)
+ * Resolution priority (used by `resolveAnchor`):
+ * 1. Semantic anchor (`data-feedback-anchor` on closest ancestor) — hosts opt
+ *    into stable, narrow anchors that survive viewport changes and refactors
+ * 2. Element id
+ * 3. CSS selector via @medv/finder
+ * 4. XPath
+ * 5. Smart scan (fingerprint + text + prefix/suffix + neighbor)
  */
 export function generateAnchor(element: Element): AnchorData {
   const cssSelector = finder(element, {
@@ -34,6 +40,9 @@ export function generateAnchor(element: Element): AnchorData {
   const fingerprint = generateFingerprint(element);
   const neighbor = neighborText(element);
 
+  const semanticAncestor = element.closest(`[${ANCHOR_KEY_ATTR}]`);
+  const anchorKey = semanticAncestor?.getAttribute(ANCHOR_KEY_ATTR) ?? null;
+
   return {
     cssSelector,
     xpath,
@@ -44,16 +53,26 @@ export function generateAnchor(element: Element): AnchorData {
     neighborText: neighbor,
     elementTag: element.tagName,
     elementId: element.id || undefined,
+    anchorKey,
   };
 }
 
+/** Whether `el`'s bounding box fully contains `rect`. */
+function containsRect(el: Element, rect: DOMRect): boolean {
+  const b = el.getBoundingClientRect();
+  return b.left <= rect.x && b.top <= rect.y && b.right >= rect.x + rect.width && b.bottom >= rect.y + rect.height;
+}
+
 /**
- * Find the smallest DOM element whose bounding box fully contains the drawn rectangle.
+ * Find the best DOM element to use as the rect's anchor.
  *
- * Walks up from the element at the rect's center until an ancestor contains the
- * full rectangle. Falls back to `document.body` when no ancestor matches — without
- * this fallback, callers compute percentages against a too-small anchor and produce
- * out-of-range values (negative / > 1).
+ * Priority:
+ * 1. Closest ancestor with `data-feedback-anchor` whose bounds contain the rect —
+ *    semantic anchors are typically narrow section roots, so anchoring against
+ *    them keeps the percentage-based rect stable across viewport changes
+ *    instead of stretching to the width of `<main>` or `<body>`.
+ * 2. Smallest ancestor that contains the rect (legacy behavior).
+ * 3. `document.body` fallback — keeps percentages in [0, 1].
  */
 export function findAnchorElement(rect: DOMRect, root: Element = document.documentElement): Element {
   const centerX = rect.x + rect.width / 2;
@@ -62,17 +81,19 @@ export function findAnchorElement(rect: DOMRect, root: Element = document.docume
   const elementAtCenter = document.elementFromPoint(centerX, centerY);
   if (!elementAtCenter || elementAtCenter === root) return document.body;
 
+  // Pass 1 — semantic anchor (host-controlled, most stable)
   let current: Element | null = elementAtCenter;
   while (current && current !== document.body) {
-    const bounds = current.getBoundingClientRect();
-    if (
-      bounds.left <= rect.x &&
-      bounds.top <= rect.y &&
-      bounds.right >= rect.x + rect.width &&
-      bounds.bottom >= rect.y + rect.height
-    ) {
+    if (current.hasAttribute(ANCHOR_KEY_ATTR) && containsRect(current, rect)) {
       return current;
     }
+    current = current.parentElement;
+  }
+
+  // Pass 2 — original behavior: smallest ancestor that contains the rect
+  current = elementAtCenter;
+  while (current && current !== document.body) {
+    if (containsRect(current, rect)) return current;
     current = current.parentElement;
   }
 

--- a/packages/widget/src/dom/resolver.ts
+++ b/packages/widget/src/dom/resolver.ts
@@ -1,9 +1,10 @@
 import type { AnchorData, RectData } from "@siteping/core";
+import { ANCHOR_KEY_ATTR } from "./anchor.js";
 import { scoreFingerprint } from "./fingerprint.js";
 import { fuzzyIncludes, similarity } from "./fuzzy.js";
 import { adjacentText, neighborText } from "./text-context.js";
 
-export type ResolutionStrategy = "id" | "css" | "xpath" | "scan";
+export type ResolutionStrategy = "anchorKey" | "id" | "css" | "xpath" | "scan";
 
 export interface AnchorResolution {
   element: Element;
@@ -40,6 +41,10 @@ function textMatches(el: Element, anchor: AnchorData): boolean {
  * with text verification and confidence scoring.
  *
  * Resolution order:
+ * 0. Semantic anchor key (`[data-feedback-anchor="X"]`) — confidence 1.0
+ *    when host explicitly tagged the section. Tag name is NOT enforced —
+ *    hosts may legitimately refactor the wrapper element while keeping the
+ *    semantic key stable.
  * 1. getElementById + text verification — confidence 1.0
  * 2. CSS selector + text verification — confidence 0.95
  * 3. XPath + text verification — confidence 0.9
@@ -49,6 +54,21 @@ function textMatches(el: Element, anchor: AnchorData): boolean {
  * Returns null if all strategies fail (annotation is orphaned).
  */
 export function resolveAnchor(anchor: AnchorData): AnchorResolution | null {
+  // Level 0: Semantic anchor key (host-controlled, most stable)
+  if (anchor.anchorKey) {
+    // Escape backslash and double-quote so an arbitrary key never breaks the selector
+    const escaped = anchor.anchorKey.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    try {
+      const el = document.querySelector(`[${ANCHOR_KEY_ATTR}="${escaped}"]`);
+      // Skip tagName check — semantic anchor identifies a section, not a tag
+      if (el && textMatches(el, anchor)) {
+        return { element: el, confidence: 1.0, strategy: "anchorKey" };
+      }
+    } catch {
+      // Invalid attribute value — fall through to next strategy
+    }
+  }
+
   // Level 1: Element ID (most stable, still verify text)
   if (anchor.elementId) {
     const el = document.getElementById(anchor.elementId);

--- a/packages/widget/src/i18n/de.ts
+++ b/packages/widget/src/i18n/de.ts
@@ -41,6 +41,12 @@ export const de: Translations = {
   // Status segmented control label
   "status.label": "Status",
 
+  // Page scope segmented control
+  "scope.label": "Bereich",
+  "scope.thisPage": "Diese Seite",
+  "scope.thisType": "Dieser Typ",
+  "scope.all": "Alle Seiten",
+
   // FAB menu
   "fab.aria": "Siteping — Feedback-Menü",
   "fab.messages": "Nachrichten",

--- a/packages/widget/src/i18n/en.ts
+++ b/packages/widget/src/i18n/en.ts
@@ -40,6 +40,12 @@ export const en: Translations = {
   // Status segmented control label
   "status.label": "Status",
 
+  // Page scope segmented control
+  "scope.label": "Scope",
+  "scope.thisPage": "This page",
+  "scope.thisType": "This type",
+  "scope.all": "All pages",
+
   // FAB menu
   "fab.aria": "Siteping \u2014 Feedback menu",
   "fab.messages": "Messages",

--- a/packages/widget/src/i18n/es.ts
+++ b/packages/widget/src/i18n/es.ts
@@ -41,6 +41,12 @@ export const es: Translations = {
   // Status segmented control label
   "status.label": "Estado",
 
+  // Page scope segmented control
+  "scope.label": "Ámbito",
+  "scope.thisPage": "Esta página",
+  "scope.thisType": "Este tipo",
+  "scope.all": "Todas las páginas",
+
   // FAB menu
   "fab.aria": "Siteping — Menú de comentarios",
   "fab.messages": "Mensajes",

--- a/packages/widget/src/i18n/fr.ts
+++ b/packages/widget/src/i18n/fr.ts
@@ -40,6 +40,12 @@ export const fr: Translations = {
   // Status segmented control label
   "status.label": "Statut",
 
+  // Page scope segmented control
+  "scope.label": "Portée",
+  "scope.thisPage": "Cette page",
+  "scope.thisType": "Ce type",
+  "scope.all": "Toutes les pages",
+
   // FAB menu
   "fab.aria": "Siteping \u2014 Menu feedback",
   "fab.messages": "Messages",

--- a/packages/widget/src/i18n/it.ts
+++ b/packages/widget/src/i18n/it.ts
@@ -42,6 +42,12 @@ export const it: Translations = {
   // Status segmented control label
   "status.label": "Stato",
 
+  // Page scope segmented control
+  "scope.label": "Ambito",
+  "scope.thisPage": "Questa pagina",
+  "scope.thisType": "Questo tipo",
+  "scope.all": "Tutte le pagine",
+
   // FAB menu
   "fab.aria": "Siteping — Menu feedback",
   "fab.messages": "Messaggi",

--- a/packages/widget/src/i18n/pt.ts
+++ b/packages/widget/src/i18n/pt.ts
@@ -41,6 +41,12 @@ export const pt: Translations = {
   // Status segmented control label
   "status.label": "Status",
 
+  // Page scope segmented control
+  "scope.label": "Escopo",
+  "scope.thisPage": "Esta página",
+  "scope.thisType": "Este tipo",
+  "scope.all": "Todas as páginas",
+
   // FAB menu
   "fab.aria": "Siteping — Menu de feedback",
   "fab.messages": "Mensagens",

--- a/packages/widget/src/i18n/ru.ts
+++ b/packages/widget/src/i18n/ru.ts
@@ -40,6 +40,12 @@ export const ru: Translations = {
   // Status segmented control label
   "status.label": "Статус",
 
+  // Page scope segmented control
+  "scope.label": "Область",
+  "scope.thisPage": "Эта страница",
+  "scope.thisType": "Этот тип",
+  "scope.all": "Все страницы",
+
   // FAB menu
   "fab.aria": "Siteping — Меню обратной связи",
   "fab.messages": "Сообщения",

--- a/packages/widget/src/i18n/types.ts
+++ b/packages/widget/src/i18n/types.ts
@@ -39,6 +39,13 @@ export interface Translations {
   // Status segmented control label
   "status.label": string;
 
+  // Page scope segmented control — keep panel results focused on the current
+  // page or expand to the same template / all pages
+  "scope.label": string;
+  "scope.thisPage": string;
+  "scope.thisType": string;
+  "scope.all": string;
+
   // FAB menu
   "fab.aria": string;
   "fab.messages": string;

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -221,15 +221,6 @@ export function launch(config: SitepingConfig): SitepingInstance {
         saveIdentity(identity);
       }
 
-      // Sanitize URL — strip sensitive query params before sending
-      const rawUrl = new URL(window.location.href);
-      for (const key of [...rawUrl.searchParams.keys()]) {
-        if (/token|key|secret|auth|session|password|code/i.test(key)) {
-          rawUrl.searchParams.delete(key);
-        }
-      }
-      const sanitizedUrl = rawUrl.toString();
-
       // crypto.randomUUID() throws in non-secure contexts (plain HTTP)
       const clientId = (() => {
         try {
@@ -239,12 +230,19 @@ export function launch(config: SitepingConfig): SitepingInstance {
         }
       })();
 
+      // Use scope.url as the single source of truth — same identifier the
+      // panel filter and marker filter use. If we stored full URLs here while
+      // filtering by pathname, freshly-created feedbacks would never match
+      // their own scope filter and would vanish from the UI immediately.
+      // Default scope.url is `window.location.pathname` (no query string,
+      // so token/key/secret query params can't leak by construction). Hosts
+      // that need origin or query in the identifier override `getPageScope`.
       const scope = getScope();
       const payload: FeedbackPayload = {
         projectName: config.projectName,
         type,
         message,
-        url: sanitizedUrl,
+        url: scope.url,
         urlPattern: scope.urlPattern,
         viewport: `${window.innerWidth}x${window.innerHeight}`,
         userAgent: navigator.userAgent,
@@ -257,9 +255,10 @@ export function launch(config: SitepingConfig): SitepingInstance {
       try {
         const response = await client.sendFeedback(payload);
         bus.emit("feedback:sent", response);
-        // Only show the marker for the current scope; out-of-scope feedbacks
-        // are still saved but don't render a marker on this page.
-        if (!scopeAnnotationsByUrl || response.url === sanitizedUrl) {
+        // Compare against the scope captured before submit (route may have
+        // changed during the network round-trip — re-reading scope here
+        // would race with SPA navigation).
+        if (!scopeAnnotationsByUrl || response.url === scope.url) {
           markers.addFeedback(response, markers.count + 1);
         }
         liveRegion.textContent = t("feedback.sent.confirmation");
@@ -319,8 +318,17 @@ export function launch(config: SitepingConfig): SitepingInstance {
       panel.close();
     },
     refresh: () => {
-      // Also reload markers — important for SPA hosts that call refresh() on
-      // route change so annotations re-scope to the new pathname.
+      // When the panel is open, its `refresh()` already runs `loadFeedbacks()`
+      // which renders markers. Doing a second fetch here would race with that
+      // one — the loser overwrites the winner's markers, off by a generation.
+      // So: when the panel is open, delegate. When it's closed, fetch markers
+      // ourselves (the panel won't, but SPA hosts still need the new page's
+      // markers after a route change).
+      if (panel.isCurrentlyOpen) {
+        panel.refresh();
+        return;
+      }
+
       const scope = getScope();
       const opts = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: scope.url } : { limit: PAGE_SIZE };
       client
@@ -330,7 +338,6 @@ export function launch(config: SitepingConfig): SitepingInstance {
           markers.render(visible);
         })
         .catch(() => {});
-      panel.refresh();
     },
     on: <K extends keyof SitepingPublicEvents>(event: K, listener: (...args: SitepingPublicEvents[K]) => void) => {
       // Safe cast: SitepingPublicEvents and PublicWidgetEvents have identical keys and value types

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -1,4 +1,11 @@
-import type { FeedbackPayload, SitepingConfig, SitepingInstance, SitepingPublicEvents } from "@siteping/core";
+import type {
+  FeedbackPayload,
+  FeedbackResponse,
+  PageScope,
+  SitepingConfig,
+  SitepingInstance,
+  SitepingPublicEvents,
+} from "@siteping/core";
 import { Annotator } from "./annotator.js";
 import { ApiClient, flushRetryQueue, type WidgetClient } from "./api-client.js";
 import { MOBILE_BREAKPOINT, PAGE_SIZE, Z_INDEX_MAX } from "./constants.js";
@@ -89,7 +96,27 @@ export function launch(config: SitepingConfig): SitepingInstance {
   const locale = config.locale ?? "en";
   const t = createT(locale);
 
-  log("Initializing widget", { projectName: config.projectName, theme: config.theme ?? "light", locale });
+  // Page scope — concrete URL + optional template, used to keep annotations
+  // and panel results scoped to the current page. The widget calls this on
+  // every initial markers load and on `instance.refresh()`, so SPA hosts can
+  // re-fetch when the route changes.
+  const scopeAnnotationsByUrl = config.scopeAnnotationsByUrl ?? true;
+  const getScope = (): PageScope => {
+    try {
+      const result = config.getPageScope?.();
+      if (result) return result;
+    } catch (e) {
+      log("getPageScope() threw, falling back to pathname:", e);
+    }
+    return { url: window.location.pathname, urlPattern: null };
+  };
+
+  log("Initializing widget", {
+    projectName: config.projectName,
+    theme: config.theme ?? "light",
+    locale,
+    scopeAnnotationsByUrl,
+  });
 
   const colors = buildThemeColors(config.accentColor, config.theme);
   const bus = new EventBus<WidgetEvents>();
@@ -171,7 +198,10 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   // Components inside Shadow DOM
   const fab = new Fab(shadow, config, bus, t);
-  const panel = new Panel(shadow, colors, bus, client, config.projectName, markers, t, locale);
+  const panel = new Panel(shadow, colors, bus, client, config.projectName, markers, t, locale, {
+    getScope,
+    scopeAnnotationsByUrl,
+  });
   const annotator = new Annotator(colors, bus, t);
 
   // Handle annotation completion via event bus (not DOM events)
@@ -209,11 +239,13 @@ export function launch(config: SitepingConfig): SitepingInstance {
         }
       })();
 
+      const scope = getScope();
       const payload: FeedbackPayload = {
         projectName: config.projectName,
         type,
         message,
         url: sanitizedUrl,
+        urlPattern: scope.urlPattern,
         viewport: `${window.innerWidth}x${window.innerHeight}`,
         userAgent: navigator.userAgent,
         authorName: identity.name,
@@ -225,7 +257,11 @@ export function launch(config: SitepingConfig): SitepingInstance {
       try {
         const response = await client.sendFeedback(payload);
         bus.emit("feedback:sent", response);
-        markers.addFeedback(response, markers.count + 1);
+        // Only show the marker for the current scope; out-of-scope feedbacks
+        // are still saved but don't render a marker on this page.
+        if (!scopeAnnotationsByUrl || response.url === sanitizedUrl) {
+          markers.addFeedback(response, markers.count + 1);
+        }
         liveRegion.textContent = t("feedback.sent.confirmation");
         await panel.refresh();
       } catch (error) {
@@ -237,11 +273,18 @@ export function launch(config: SitepingConfig): SitepingInstance {
     }
   });
 
-  // Load markers immediately on page load
+  // Load markers immediately on page load. We always pass the current page URL
+  // when scopeAnnotationsByUrl is enabled so the server narrows results to the
+  // current page — preventing annotations from one page accidentally rendering
+  // on another (when CSS selectors happen to match unrelated elements).
+  const initialScope = getScope();
+  const initialOptions = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: initialScope.url } : { limit: PAGE_SIZE };
   client
-    .getFeedbacks(config.projectName, { limit: PAGE_SIZE })
-    .then(({ feedbacks }) => {
-      markers.render(feedbacks);
+    .getFeedbacks(config.projectName, initialOptions)
+    .then(({ feedbacks }: { feedbacks: FeedbackResponse[] }) => {
+      // Defensive client-side filter — backend may not yet support the `url` query.
+      const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === initialScope.url) : feedbacks;
+      markers.render(visible);
     })
     .catch((err) => {
       log("Failed to load initial markers:", err);
@@ -276,6 +319,17 @@ export function launch(config: SitepingConfig): SitepingInstance {
       panel.close();
     },
     refresh: () => {
+      // Also reload markers — important for SPA hosts that call refresh() on
+      // route change so annotations re-scope to the new pathname.
+      const scope = getScope();
+      const opts = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: scope.url } : { limit: PAGE_SIZE };
+      client
+        .getFeedbacks(config.projectName, opts)
+        .then(({ feedbacks }: { feedbacks: FeedbackResponse[] }) => {
+          const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === scope.url) : feedbacks;
+          markers.render(visible);
+        })
+        .catch(() => {});
       panel.refresh();
     },
     on: <K extends keyof SitepingPublicEvents>(event: K, listener: (...args: SitepingPublicEvents[K]) => void) => {

--- a/packages/widget/src/markers.ts
+++ b/packages/widget/src/markers.ts
@@ -113,13 +113,16 @@ export class MarkerManager {
     window.addEventListener("scroll", this.scrollHandler, { passive: true, capture: true });
 
     // Re-resolve after DOM changes (SPA, lazy-load).
-    // Filter out widget-owned mutations and skip batches with only irrelevant changes.
-    // Fast-path: large batches (>20 mutations) skip per-record filtering.
+    // Filter out widget-owned mutations and skip batches with only irrelevant
+    // changes. Filtering short-circuits at the first non-widget mutation, so
+    // even large batches stop after one DOM walk.
+    //
+    // The filter is applied unconditionally — earlier versions had a >20-batch
+    // fast-path that skipped filtering, but that lets reposition self-trigger
+    // when `repositionAll` re-renders the pinned highlight (showHighlight
+    // appends N elements to `this.container`); a host page churning lots of
+    // DOM (infinite scroll) would then loop at the 200ms debounce interval.
     this.mutationObserver = new MutationObserver((mutations) => {
-      if (mutations.length > 20) {
-        this.scheduleReposition();
-        return;
-      }
       let hasRelevantMutation = false;
       for (const m of mutations) {
         if (this.container.contains(m.target) || this.tooltip.contains(m.target)) continue;

--- a/packages/widget/src/markers.ts
+++ b/packages/widget/src/markers.ts
@@ -20,6 +20,7 @@ function toAnchorData(a: Annotation): AnchorData {
     textSuffix: a.textSuffix,
     fingerprint: a.fingerprint,
     neighborText: a.neighborText,
+    anchorKey: a.anchorKey ?? null,
   };
 }
 

--- a/packages/widget/src/markers.ts
+++ b/packages/widget/src/markers.ts
@@ -219,6 +219,14 @@ export class MarkerManager {
     }
 
     this.applyClusterPositions();
+
+    // Re-render the pinned highlight rectangle so it tracks the layout after
+    // resize / SPA mutation. Marker dots reposition above; without this,
+    // the highlight rect keeps its old pixel position and visibly drifts
+    // away from the underlying content.
+    if (this.pinnedFeedback) {
+      this.showHighlight(this.pinnedFeedback);
+    }
   }
 
   private applyClusterPositions(): void {

--- a/packages/widget/src/panel.ts
+++ b/packages/widget/src/panel.ts
@@ -1315,6 +1315,11 @@ export class Panel {
     }
   }
 
+  /** Whether the panel is currently open — used by the launcher to coordinate marker refreshes. */
+  get isCurrentlyOpen(): boolean {
+    return this.isOpen;
+  }
+
   destroy(): void {
     this.loadController?.abort();
     if (this.searchTimeout) clearTimeout(this.searchTimeout);

--- a/packages/widget/src/panel.ts
+++ b/packages/widget/src/panel.ts
@@ -1,5 +1,5 @@
-import type { FeedbackResponse, FeedbackStatus, FeedbackType } from "@siteping/core";
-import type { WidgetClient } from "./api-client.js";
+import type { FeedbackResponse, FeedbackStatus, FeedbackType, PageScope } from "@siteping/core";
+import type { GetFeedbacksOptions, WidgetClient } from "./api-client.js";
 import { PAGE_SIZE } from "./constants.js";
 import { el, formatRelativeDate, parseSvg, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
@@ -84,6 +84,15 @@ export class Panel {
   // i18n helpers
   private readonly bulkI18n: typeof BULK_I18N_EN;
 
+  // Page scope — supplied by launcher so the panel can scope its results to
+  // the current page (or template) and filter markers accordingly.
+  private readonly getScope: () => PageScope;
+  private readonly scopeAnnotationsByUrl: boolean;
+  /** "this" = current url, "template" = url pattern, "all" = no scope filter */
+  private activeScopeFilter: "this" | "template" | "all" = "this";
+  private scopeSegmented!: HTMLElement;
+  private scopeOptions!: ReadonlyArray<{ value: "this" | "template" | "all"; label: string }>;
+
   constructor(
     shadowRoot: ShadowRoot,
     private readonly colors: ThemeColors,
@@ -93,9 +102,12 @@ export class Panel {
     private readonly markers: MarkerManager,
     private readonly t: TFunction,
     private readonly locale: string,
+    pageScopeOptions?: { getScope: () => PageScope; scopeAnnotationsByUrl: boolean },
   ) {
     this.shadowRoot = shadowRoot;
     this.bulkI18n = locale === "fr" ? BULK_I18N_FR : BULK_I18N_EN;
+    this.getScope = pageScopeOptions?.getScope ?? (() => ({ url: window.location.pathname, urlPattern: null }));
+    this.scopeAnnotationsByUrl = pageScopeOptions?.scopeAnnotationsByUrl ?? true;
 
     this.root = el("div", { class: "sp-panel" });
     this.root.setAttribute("role", "complementary");
@@ -156,10 +168,13 @@ export class Panel {
     searchWrap.appendChild(searchIcon);
     searchWrap.appendChild(this.searchInput);
 
-    // Filter bar (type dropdown + status segmented control)
+    // Filter bar (type dropdown + status segmented + scope segmented).
+    // The scope control gives users a fast way to widen results to "this type
+    // of page" or "all pages" when the host provides a route template.
     const filterBar = el("div", { class: "sp-filter-bar" });
     filterBar.appendChild(this.buildTypeDropdown());
     filterBar.appendChild(this.buildStatusSegmented());
+    filterBar.appendChild(this.buildScopeSegmented());
 
     // Sort controls
     this.sortControls = new PanelSortControls(colors, () => this.renderList(), locale);
@@ -464,13 +479,21 @@ export class Panel {
     const typeFilter = this.activeFilters.has("all") ? undefined : (Array.from(this.activeFilters)[0] as FeedbackType);
     const statusFilter = this.activeStatusFilter === "all" ? undefined : this.activeStatusFilter;
 
-    const options: { page: number; limit: number; type?: FeedbackType; status?: FeedbackStatus; search?: string } = {
+    const scope = this.getScope();
+    // Refresh scope-filter button visibility based on current scope (SPA nav).
+    this.syncScopeAvailability();
+    const options: GetFeedbacksOptions & { page: number; limit: number } = {
       page: 1,
       limit: PAGE_SIZE,
     };
     if (typeFilter) options.type = typeFilter;
     if (statusFilter) options.status = statusFilter;
     if (search) options.search = search;
+    if (this.activeScopeFilter === "this") {
+      options.url = scope.url;
+    } else if (this.activeScopeFilter === "template" && scope.urlPattern) {
+      options.urlPattern = scope.urlPattern;
+    }
 
     // Only show spinner on first load (empty list) — otherwise keep current content visible
     const hasContent = this.feedbacks.length > 0;
@@ -484,7 +507,11 @@ export class Panel {
       this.stats.update(feedbacks, total);
       this.bulk.reset();
       this.renderList();
-      this.markers.render(feedbacks);
+      // Markers always render only the current-URL slice — even when the panel
+      // shows a wider scope ("template" or "all"), markers stay strictly local
+      // so the user never sees out-of-context dots on the page.
+      const markerFeedbacks = this.scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === scope.url) : feedbacks;
+      this.markers.render(markerFeedbacks);
     } catch (error) {
       if (signal.aborted) return; // Expected abort, not a real error
       if (!hasContent) this.showError();
@@ -505,13 +532,19 @@ export class Panel {
     const typeFilter = this.activeFilters.has("all") ? undefined : (Array.from(this.activeFilters)[0] as FeedbackType);
     const statusFilter = this.activeStatusFilter === "all" ? undefined : this.activeStatusFilter;
 
-    const options: { page: number; limit: number; type?: FeedbackType; status?: FeedbackStatus; search?: string } = {
+    const scope = this.getScope();
+    const options: GetFeedbacksOptions & { page: number; limit: number } = {
       page: nextPage,
       limit: PAGE_SIZE,
     };
     if (typeFilter) options.type = typeFilter;
     if (statusFilter) options.status = statusFilter;
     if (search) options.search = search;
+    if (this.activeScopeFilter === "this") {
+      options.url = scope.url;
+    } else if (this.activeScopeFilter === "template" && scope.urlPattern) {
+      options.urlPattern = scope.urlPattern;
+    }
 
     // Show spinner on the "Load more" button
     const loadMoreBtn = this.listContainer.querySelector<HTMLButtonElement>(".sp-btn-load-more");
@@ -526,7 +559,10 @@ export class Panel {
       this.feedbacks = [...this.feedbacks, ...feedbacks];
       this.stats.update(this.feedbacks, total);
       this.renderList();
-      this.markers.render(this.feedbacks);
+      const markerFeedbacks = this.scopeAnnotationsByUrl
+        ? this.feedbacks.filter((f) => f.url === scope.url)
+        : this.feedbacks;
+      this.markers.render(markerFeedbacks);
     } catch (error) {
       if (restoreBtn) restoreBtn();
       this.bus.emit("feedback:error", error instanceof Error ? error : new Error(String(error)));
@@ -1139,6 +1175,112 @@ export class Panel {
       btn.tabIndex = isActive ? 0 : -1;
     }
     this.loadFeedbacks().catch(() => {});
+  }
+
+  /**
+   * Build the page-scope segmented control: "this page / this type / all".
+   * The "this type" button is hidden when the current scope has no urlPattern
+   * (host did not provide one for this route). Visibility is refreshed on
+   * every `loadFeedbacks` so SPA navigation stays consistent.
+   */
+  private buildScopeSegmented(): HTMLElement {
+    this.scopeOptions = [
+      { value: "this", label: this.t("scope.thisPage") },
+      { value: "template", label: this.t("scope.thisType") },
+      { value: "all", label: this.t("scope.all") },
+    ];
+
+    this.scopeSegmented = el("div", { class: "sp-segmented sp-segmented--scope", role: "radiogroup" });
+    this.scopeSegmented.setAttribute("aria-label", this.t("scope.label"));
+
+    for (const option of this.scopeOptions) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = `sp-segmented__btn sp-segmented__btn--scope-${option.value}`;
+      btn.dataset.scopeFilter = option.value;
+      btn.setAttribute("role", "radio");
+      const isActive = this.activeScopeFilter === option.value;
+      btn.setAttribute("aria-checked", String(isActive));
+      btn.tabIndex = isActive ? 0 : -1;
+      if (isActive) btn.classList.add("sp-segmented__btn--active");
+
+      const labelEl = el("span", { class: "sp-segmented__label" });
+      setText(labelEl, option.label);
+      btn.appendChild(labelEl);
+
+      btn.addEventListener("click", () => this.selectScopeFilter(option.value));
+      btn.addEventListener("keydown", (e) => this.handleScopeKey(e, option.value));
+
+      this.scopeSegmented.appendChild(btn);
+    }
+
+    // Initial visibility — "this type" only meaningful when scope has urlPattern
+    this.syncScopeAvailability();
+    return this.scopeSegmented;
+  }
+
+  private handleScopeKey(e: KeyboardEvent, current: "this" | "template" | "all"): void {
+    const visibleValues = this.scopeOptions
+      .map((o) => o.value)
+      .filter((v) => {
+        const btn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="${v}"]`);
+        return btn && btn.style.display !== "none";
+      });
+    const idx = visibleValues.indexOf(current);
+    if (idx < 0) return;
+    let nextIdx: number;
+    switch (e.key) {
+      case "ArrowLeft":
+        nextIdx = (idx - 1 + visibleValues.length) % visibleValues.length;
+        break;
+      case "ArrowRight":
+        nextIdx = (idx + 1) % visibleValues.length;
+        break;
+      case "Home":
+        nextIdx = 0;
+        break;
+      case "End":
+        nextIdx = visibleValues.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const next = visibleValues[nextIdx];
+    if (!next) return;
+    this.selectScopeFilter(next);
+    const btn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="${next}"]`);
+    btn?.focus();
+  }
+
+  private selectScopeFilter(value: "this" | "template" | "all"): void {
+    this.activeScopeFilter = value;
+    const buttons = this.scopeSegmented.querySelectorAll<HTMLButtonElement>(".sp-segmented__btn");
+    for (const btn of buttons) {
+      const isActive = btn.dataset.scopeFilter === value;
+      btn.classList.toggle("sp-segmented__btn--active", isActive);
+      btn.setAttribute("aria-checked", String(isActive));
+      btn.tabIndex = isActive ? 0 : -1;
+    }
+    this.loadFeedbacks().catch(() => {});
+  }
+
+  /**
+   * Hide the "this type" button when the current scope has no urlPattern, and
+   * fall back to "this page" if it was the active selection. Called on every
+   * `loadFeedbacks` so SPA navigation stays consistent.
+   */
+  private syncScopeAvailability(): void {
+    if (!this.scopeSegmented) return;
+    const scope = this.getScope();
+    const templateBtn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="template"]`);
+    if (!templateBtn) return;
+    const showTemplate = !!scope.urlPattern;
+    templateBtn.style.display = showTemplate ? "" : "none";
+    if (!showTemplate && this.activeScopeFilter === "template") {
+      this.activeScopeFilter = "this";
+      this.selectScopeFilter("this");
+    }
   }
 
   /** Get the focused feedback (for keyboard shortcuts) */

--- a/packages/widget/src/store-client.ts
+++ b/packages/widget/src/store-client.ts
@@ -4,12 +4,10 @@ import {
   type FeedbackPayload,
   type FeedbackRecord,
   type FeedbackResponse,
-  type FeedbackStatus,
-  type FeedbackType,
   flattenAnnotation,
   type SitepingStore,
 } from "@siteping/core";
-import type { WidgetClient } from "./api-client.js";
+import type { GetFeedbacksOptions, WidgetClient } from "./api-client.js";
 
 /**
  * `WidgetClient` implementation that delegates directly to a `SitepingStore`.
@@ -31,6 +29,7 @@ export class StoreClient implements WidgetClient {
       message: payload.message,
       status: "open",
       url: payload.url,
+      urlPattern: payload.urlPattern ?? null,
       viewport: payload.viewport,
       userAgent: payload.userAgent,
       authorName: payload.authorName,
@@ -44,7 +43,7 @@ export class StoreClient implements WidgetClient {
 
   async getFeedbacks(
     projectName: string,
-    options?: { page?: number; limit?: number; type?: FeedbackType; status?: FeedbackStatus; search?: string },
+    options?: GetFeedbacksOptions,
   ): Promise<{ feedbacks: FeedbackResponse[]; total: number }> {
     const { feedbacks, total } = await this.store.getFeedbacks({
       projectName,
@@ -53,6 +52,8 @@ export class StoreClient implements WidgetClient {
       type: options?.type,
       status: options?.status,
       search: options?.search,
+      url: options?.url,
+      urlPattern: options?.urlPattern,
     });
 
     return { feedbacks: feedbacks.map(toResponse), total };
@@ -87,6 +88,7 @@ function toResponse(record: FeedbackRecord): FeedbackResponse {
     message: record.message,
     status: record.status,
     url: record.url,
+    urlPattern: record.urlPattern ?? null,
     viewport: record.viewport,
     userAgent: record.userAgent,
     authorName: record.authorName,
@@ -111,6 +113,7 @@ function toAnnotationResponse(ann: AnnotationRecord): AnnotationResponse {
     textSuffix: ann.textSuffix,
     fingerprint: ann.fingerprint,
     neighborText: ann.neighborText,
+    anchorKey: ann.anchorKey ?? null,
     xPct: ann.xPct,
     yPct: ann.yPct,
     wPct: ann.wPct,


### PR DESCRIPTION
## Summary

Solves the cross-page annotation leak: when `scopeAnnotationsByUrl` is on (default), markers and panel results are scoped to the current page so annotations created on one page never render on another — even if their CSS selector accidentally matches.

Improves anchor stability across viewport changes and DOM refactors via a host-controlled semantic anchor protocol: ancestors marked with \`data-feedback-anchor="X"\` become the highest-priority re-anchoring target.

## API additions (all backwards-compatible)

- \`SitepingConfig.getPageScope?: () => { url: string; urlPattern: string | null }\`
- \`SitepingConfig.scopeAnnotationsByUrl?: boolean\` (default \`true\`)
- \`FeedbackQuery.url\` / \`FeedbackQuery.urlPattern\` — exact-URL / template filters
- \`FeedbackRecord.urlPattern\`, \`FeedbackPayload.urlPattern\`, \`FeedbackResponse.urlPattern\`
- \`AnchorData.anchorKey\`, \`AnnotationRecord.anchorKey\`, \`AnnotationResponse.anchorKey\`
- \`SitepingInstance.refresh()\` now also reloads markers (was: panel only)

## Resolver priority

0. \`anchorKey\` (host-controlled) — confidence 1.0
1. \`elementId\` — 1.0
2. CSS selector — 0.95
3. XPath — 0.9
4. Smart scan — up to 0.85

## Schema migration

Adds to \`packages/core/src/schema.ts\` (CLI \`siteping sync\` propagates):
- \`SitepingFeedback.urlPattern: String?\`
- \`SitepingFeedback\` index on \`(projectName, url)\` for fast scope queries
- \`SitepingAnnotation.anchorKey: String?\`

⚠️ For large prod tables, run \`CREATE INDEX CONCURRENTLY\` manually before \`prisma db push\` — see the new "Upgrading on a large existing table" section in the adapter-prisma README.

## Panel UI

New scope segmented control: "This page / This type / All". "This type" hides automatically when the current scope has no \`urlPattern\`. Markers stay filtered to the current URL even when the panel shows a wider scope, so users never see out-of-context dots.

## Fixes added during review

This PR includes 4 follow-up fix commits found via deep review:

- **fix(widget): align feedback.url with scope.url** — the launcher previously stored the full sanitized \`window.location.href\` as \`feedback.url\` while filters compared against \`scope.url\` (pathname). The two never matched, so freshly-submitted feedbacks vanished from the UI immediately. Independently caught by us, also fixed in [Trade-su@c613156](https://github.com/Trade-su/SitePing/commit/c613156).
- **fix(widget): de-race instance.refresh()** — when the panel was open, \`refresh()\` ran two concurrent fetches (launcher's + panel's). Now delegates to \`panel.refresh()\` when open. Single fetch.
- **fix(adapter-prisma): accept any non-empty string as feedback.url** — Zod \`.url()\` rejected the new pathname-based URLs. Loosened to \`z.string().trim().min(1).max(2000)\`.
- **fix(widget): re-render pinned highlight on resize / DOM mutation** — the pinned highlight rect drifted after layout reflow because \`repositionAll\` only repositioned marker dots. Now also re-renders highlight elements.
- **fix: tighten review edge cases (MO fast-path, url whitespace)** — drops the \`>20\` mutation fast-path that bypassed widget-owned filtering (would self-trigger reposition pulses on heavy host DOM churn); rejects whitespace-only urls.

## Adapters

- \`adapter-memory\` and \`adapter-localstorage\` filter by \`url\` / \`urlPattern\` and persist \`urlPattern\` / \`anchorKey\`.
- \`adapter-prisma\` extends Zod schemas, wires the new fields to Prisma, README updated.

## i18n

New keys \`scope.label / scope.thisPage / scope.thisType / scope.all\` added to all 7 built-in locales (en, fr, de, es, it, pt, ru).

## Inspired by

[Trade-su/SitePing@60e615f](https://github.com/Trade-su/SitePing/commit/60e615f) — adapted with proper Prisma schema migration via \`siteping sync\` instead of the \`as FeedbackRecord\` cast.

Co-Authored-By: Valerii (@Trade-su)

## Test plan

- [x] \`bun run test:run\` — 1274/1274 passing (+29 new tests)
- [x] \`bun run check\` — type-check OK
- [x] \`bun run lint\` — biome clean
- [x] Tested locally on a Next.js host: \`/\` and \`/about\` markers stay scoped, segmented control works, semantic anchors re-anchor across layout changes
- [ ] Verify your existing data: feedbacks created with previous widget versions store full URLs, but the new scope filter compares pathnames. Either (a) backfill your DB, or (b) set \`scopeAnnotationsByUrl: false\` on the config to keep legacy behavior