### PR TITLE
docs(readme): add Acknowledgements section crediting Trade-su fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,20 @@ bun run test:e2e   # E2E tests
 
 ---
 
+## Acknowledgements
+
+A big thank you to the [Trade-su/SitePing](https://github.com/Trade-su/SitePing) fork — Valerii ([@Trade-su](https://github.com/Trade-su)) and grizodubov ([@grizodubov](https://github.com/grizodubov)) — for the work that inspired several upstream features. Forks that ship real ideas back are the best kind.
+
+Specifically:
+
+- **Page-scoped annotations + semantic anchors** (`data-feedback-anchor`) — solves the cross-page leak when CSS selectors accidentally match unrelated elements.
+- **Screenshot capture** via `html2canvas` — adapted upstream with a pluggable `ScreenshotStorage` so production users can offload to S3/R2 instead of bloating Postgres.
+- **Popup positioning fix** — clamps inside the viewport when the drawn rect leaves no room above or below.
+
+If you maintain a fork that adds features, opening an upstream PR or even just an issue describing what you've built is incredibly valuable — it lets the community benefit beyond your fork's user base.
+
+---
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=NeosiaNexus/SitePing&type=Date)](https://star-history.com/#NeosiaNexus/SitePing&Date)


### PR DESCRIPTION
## Summary

Recognises Valerii ([@Trade-su](https://github.com/Trade-su)) and grizodubov ([@grizodubov](https://github.com/grizodubov)) as the original authors of the page-scoped annotations, screenshot capture, and popup positioning fix that landed (or are landing) upstream via #54, #55, #56.

Adds a short note inviting other forks to contribute upstream rather than working in isolation — visibility for fork-driven features benefits everyone, not just the fork's own users.

## Test plan

- [x] No code changes, just README
- [x] \`bun run lint\` — biome clean