### PR TITLE
feat: screenshot capture with pluggable storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,17 +84,13 @@
     "packages/widget": {
       "name": "@siteping/widget",
       "version": "0.9.6",
+      "dependencies": {
+        "html2canvas": "^1.4.1",
+      },
       "devDependencies": {
         "@medv/finder": "^3.2.0",
         "@siteping/core": "workspace:*",
-        "html2canvas": "^1.4.1",
       },
-      "peerDependencies": {
-        "html2canvas": "^1.4.1",
-      },
-      "optionalPeers": [
-        "html2canvas",
-      ],
     },
   },
   "packages": {

--- a/bun.lock
+++ b/bun.lock
@@ -39,21 +39,21 @@
     },
     "packages/adapter-localstorage": {
       "name": "@siteping/adapter-localstorage",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "devDependencies": {
         "@siteping/core": "workspace:*",
       },
     },
     "packages/adapter-memory": {
       "name": "@siteping/adapter-memory",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "devDependencies": {
         "@siteping/core": "workspace:*",
       },
     },
     "packages/adapter-prisma": {
       "name": "@siteping/adapter-prisma",
-      "version": "0.4.2",
+      "version": "0.4.4",
       "dependencies": {
         "zod": "^3.24.0",
       },
@@ -66,7 +66,7 @@
     },
     "packages/cli": {
       "name": "@siteping/cli",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "bin": {
         "siteping": "./dist/index.js",
       },
@@ -79,15 +79,22 @@
     },
     "packages/core": {
       "name": "@siteping/core",
-      "version": "0.4.0",
+      "version": "0.7.1",
     },
     "packages/widget": {
       "name": "@siteping/widget",
-      "version": "0.9.2",
+      "version": "0.9.6",
       "devDependencies": {
         "@medv/finder": "^3.2.0",
         "@siteping/core": "workspace:*",
+        "html2canvas": "^1.4.1",
       },
+      "peerDependencies": {
+        "html2canvas": "^1.4.1",
+      },
+      "optionalPeers": [
+        "html2canvas",
+      ],
     },
   },
   "packages": {
@@ -499,6 +506,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
@@ -536,6 +545,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -604,6 +615,8 @@
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
     "import-lazy": ["import-lazy@4.0.0", "", {}, "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="],
 
@@ -813,6 +826,8 @@
 
     "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
 
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
+
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
@@ -858,6 +873,8 @@
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -132,6 +132,11 @@ export class LocalStorageStore implements SitepingStore {
       createdAt: now,
       updatedAt: now,
       annotations,
+      // localStorage has its own ~5 MB hard cap; storing data URLs inline is
+      // OK for prototyping and demos but will hit the cap quickly with many
+      // screenshots. Production users should use adapter-prisma with a
+      // configured ScreenshotStorage.
+      screenshotUrl: data.screenshotDataUrl ?? null,
     };
 
     feedbacks.unshift(record);

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -60,11 +60,14 @@ export class LocalStorageStore implements SitepingStore {
     }
   }
 
-  private save(feedbacks: FeedbackRecord[]): void {
+  private save(feedbacks: FeedbackRecord[]): boolean {
     try {
       localStorage.setItem(this.key, JSON.stringify(feedbacks));
+      return true;
     } catch {
-      // localStorage full — silently drop (best-effort persistence)
+      // localStorage full — caller decides how to recover (e.g. drop the
+      // newest screenshot and retry).
+      return false;
     }
   }
 
@@ -140,7 +143,15 @@ export class LocalStorageStore implements SitepingStore {
     };
 
     feedbacks.unshift(record);
-    this.save(feedbacks);
+    if (!this.save(feedbacks) && record.screenshotUrl) {
+      // Quota exceeded — usually the inline screenshot pushed us past the
+      // ~5 MB cap. Retry without the screenshot so the user's text feedback
+      // is preserved (the screenshot is by far the heaviest field). If even
+      // that fails, fall through to legacy silent-fail behaviour: the
+      // record stays in memory for this call but isn't persisted.
+      record.screenshotUrl = null;
+      this.save(feedbacks);
+    }
     return record;
   }
 

--- a/packages/adapter-memory/src/index.ts
+++ b/packages/adapter-memory/src/index.ts
@@ -89,6 +89,10 @@ export class MemoryStore implements SitepingStore {
       createdAt: now,
       updatedAt: now,
       annotations,
+      // No external storage in memory adapter — keep the data URL inline.
+      // Fine for tests and dev; production users should configure a real
+      // ScreenshotStorage on adapter-prisma.
+      screenshotUrl: data.screenshotDataUrl ?? null,
     };
 
     this.feedbacks.unshift(record);

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -90,6 +90,45 @@ npx @siteping/cli init
 npx prisma db push
 ```
 
+## Screenshot Storage
+
+When the widget is configured with `enableScreenshot: true`, every feedback POST may include a base64 JPEG `screenshotDataUrl`. By default the adapter persists the data URL **inline** on `Feedback.screenshotUrl`, which is convenient for dev but quickly blows up your DB in production (a 1200px JPEG is ~50–150 KB per row).
+
+For production, plug a `ScreenshotStorage` (S3, R2, B2, Cloudflare Images, local FS, …) into the handler:
+
+```ts
+import type { ScreenshotStorage } from "@siteping/adapter-prisma";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({ region: "eu-west-3" });
+
+const screenshotStorage: ScreenshotStorage = {
+  async upload(dataUrl, ctx) {
+    const buf = Buffer.from(dataUrl.split(",")[1], "base64");
+    const key = `feedback/${ctx.feedbackId}.jpg`;
+    await s3.send(new PutObjectCommand({
+      Bucket: "my-bucket",
+      Key: key,
+      Body: buf,
+      ContentType: ctx.mimeType,
+    }));
+    return { url: `https://cdn.example.com/${key}` };
+  },
+  // Optional: cleanup on feedback delete
+  async delete(url) {
+    const key = url.split("/").pop();
+    if (key) await s3.send(new DeleteObjectCommand({ Bucket: "my-bucket", Key: key }));
+  },
+};
+
+export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
+  prisma,
+  screenshotStorage,
+});
+```
+
+When the upload fails (transient S3 outage etc.), the adapter falls back to inline persistence so the screenshot is not lost — a warn surfaces the underlying error.
+
 ## Authentication
 
 By default, all endpoints are publicly accessible. To protect read/update/delete operations, pass an `apiKey`:

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -90,9 +90,26 @@ npx @siteping/cli init
 npx prisma db push
 ```
 
+### Upgrading on a large existing table
+
+When upgrading to a version that adds an index (e.g. `@@index([projectName, url])` for the page-scope feature), `prisma db push` issues `CREATE INDEX` *without* `CONCURRENTLY` — that takes a SHARE lock on the table for the duration, blocking writes. On a multi-million-row Postgres `SitepingFeedback` table this can mean minutes of write timeouts.
+
+**Recommended for large prod tables:** run the index creation manually with `CONCURRENTLY` *before* `prisma db push`:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "SitepingFeedback_projectName_url_idx"
+  ON "SitepingFeedback" ("projectName", "url");
+```
+
+Then `prisma db push` sees the index already exists and skips it.
+
 ## Screenshot Storage
 
 When the widget is configured with `enableScreenshot: true`, every feedback POST may include a base64 JPEG `screenshotDataUrl`. By default the adapter persists the data URL **inline** on `Feedback.screenshotUrl`, which is convenient for dev but quickly blows up your DB in production (a 1200px JPEG is ~50–150 KB per row).
+
+> ⚠️ **Privacy** — screenshots embed page content, including anything sensitive currently on screen (password fields, credit-card forms, API tokens, etc.). Mark sensitive elements with `data-siteping-ignore="true"` BEFORE turning on screenshots in production. The capture predicate skips matching elements *and their descendants*.
+
+> ⚠️ **Abuse surface** — screenshot uploads arrive over the public POST endpoint (the widget runs unauthenticated in the browser). Without rate limiting an attacker can flood your storage / DB with 1.5 MB images. Configure rate limiting at your reverse proxy / framework middleware before enabling screenshots in production.
 
 For production, plug a `ScreenshotStorage` (S3, R2, B2, Cloudflare Images, local FS, …) into the handler:
 
@@ -127,7 +144,9 @@ export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
 });
 ```
 
-When the upload fails (transient S3 outage etc.), the adapter falls back to inline persistence so the screenshot is not lost — a warn surfaces the underlying error.
+When the upload fails (transient S3 outage etc.), the adapter persists `screenshotUrl: null` and emits a warn — the feedback message itself is preserved, only the screenshot is dropped. An inline fallback would silently bloat Postgres unnoticed during a multi-minute outage; operators who prefer that trade-off can wrap their `upload` to catch internally and return an inline data URL on failure.
+
+`ctx.feedbackId` passed to `upload()` is the client-supplied UUID — sanitize it before mapping to a filesystem path. Object stores like S3 treat it as a key prefix and are safe by default.
 
 ## Authentication
 

--- a/packages/adapter-prisma/__tests__/screenshot-storage.test.ts
+++ b/packages/adapter-prisma/__tests__/screenshot-storage.test.ts
@@ -1,0 +1,124 @@
+import type { ScreenshotStorage } from "@siteping/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PrismaStore } from "../src/index.js";
+
+const SAMPLE_DATA_URL = "data:image/jpeg;base64,/9j/4AAQ";
+
+function mockPrisma() {
+  return {
+    sitepingFeedback: {
+      // create echoes back the data so we can assert what was written.
+      create: vi.fn().mockImplementation((args: { data: Record<string, unknown> }) => ({
+        id: "fb-1",
+        ...args.data,
+        annotations: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        resolvedAt: null,
+      })),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      update: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  };
+}
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    projectName: "test",
+    type: "bug" as const,
+    message: "msg",
+    status: "open" as const,
+    url: "https://example.com",
+    viewport: "1920x1080",
+    userAgent: "test",
+    authorName: "Alice",
+    authorEmail: "alice@test.com",
+    clientId: "client-123",
+    annotations: [],
+    ...overrides,
+  };
+}
+
+describe("PrismaStore — screenshot storage", () => {
+  let prisma: ReturnType<typeof mockPrisma>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    prisma = mockPrisma();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  describe("without screenshotStorage", () => {
+    it("persists null when no data URL is sent", async () => {
+      const store = new PrismaStore(prisma);
+      await store.createFeedback(createInput());
+      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: unknown } };
+      expect(created.data.screenshotUrl).toBeNull();
+    });
+
+    it("persists the data URL inline and warns once", async () => {
+      const store = new PrismaStore(prisma);
+      await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c1" }));
+      await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c2" }));
+
+      const calls = prisma.sitepingFeedback.create.mock.calls as Array<[{ data: { screenshotUrl: string } }]>;
+      expect(calls[0]?.[0].data.screenshotUrl).toBe(SAMPLE_DATA_URL);
+      expect(calls[1]?.[0].data.screenshotUrl).toBe(SAMPLE_DATA_URL);
+
+      // Warns once across multiple inline persists — not on every create
+      const inlineWarnings = warnSpy.mock.calls.filter((c) =>
+        /no `screenshotStorage` is configured/.test(String(c[0])),
+      );
+      expect(inlineWarnings.length).toBe(1);
+    });
+  });
+
+  describe("with screenshotStorage", () => {
+    it("uploads via storage and persists the returned URL", async () => {
+      const storage: ScreenshotStorage = {
+        upload: vi.fn().mockResolvedValue({ url: "https://cdn.example.com/fb-c1.jpg" }),
+      };
+      const store = new PrismaStore(prisma, { screenshotStorage: storage });
+
+      await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c1" }));
+
+      expect(storage.upload).toHaveBeenCalledWith(SAMPLE_DATA_URL, {
+        feedbackId: "c1",
+        mimeType: "image/jpeg",
+      });
+      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: string } };
+      expect(created.data.screenshotUrl).toBe("https://cdn.example.com/fb-c1.jpg");
+    });
+
+    it("does not call storage when no data URL is sent", async () => {
+      const storage: ScreenshotStorage = { upload: vi.fn() };
+      const store = new PrismaStore(prisma, { screenshotStorage: storage });
+
+      await store.createFeedback(createInput());
+
+      expect(storage.upload).not.toHaveBeenCalled();
+      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: unknown } };
+      expect(created.data.screenshotUrl).toBeNull();
+    });
+
+    it("falls back to inline data URL when upload throws", async () => {
+      const storage: ScreenshotStorage = {
+        upload: vi.fn().mockRejectedValue(new Error("S3 down")),
+      };
+      const store = new PrismaStore(prisma, { screenshotStorage: storage });
+
+      await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c1" }));
+
+      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: string } };
+      // Failed uploads should not drop the screenshot — fall back to inline so
+      // the user still sees something (the warn surfaces the underlying issue).
+      expect(created.data.screenshotUrl).toBe(SAMPLE_DATA_URL);
+      const failureWarnings = warnSpy.mock.calls.filter((c) => /screenshotStorage\.upload failed/.test(String(c[0])));
+      expect(failureWarnings.length).toBe(1);
+    });
+  });
+});

--- a/packages/adapter-prisma/__tests__/screenshot-storage.test.ts
+++ b/packages/adapter-prisma/__tests__/screenshot-storage.test.ts
@@ -105,18 +105,21 @@ describe("PrismaStore — screenshot storage", () => {
       expect(created.data.screenshotUrl).toBeNull();
     });
 
-    it("falls back to inline data URL when upload throws", async () => {
+    it("persists null when upload throws — does NOT silently bloat the DB with inline base64", async () => {
       const storage: ScreenshotStorage = {
         upload: vi.fn().mockRejectedValue(new Error("S3 down")),
       };
       const store = new PrismaStore(prisma, { screenshotStorage: storage });
 
-      await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c1" }));
+      const result = await store.createFeedback(createInput({ screenshotDataUrl: SAMPLE_DATA_URL, clientId: "c1" }));
 
-      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: string } };
-      // Failed uploads should not drop the screenshot — fall back to inline so
-      // the user still sees something (the warn surfaces the underlying issue).
-      expect(created.data.screenshotUrl).toBe(SAMPLE_DATA_URL);
+      const created = prisma.sitepingFeedback.create.mock.calls[0]?.[0] as { data: { screenshotUrl: string | null } };
+      // The feedback message is preserved; only the screenshot is dropped.
+      // An inline fallback would silently grow Postgres during a storage
+      // outage — operators discover it only when DB-size alarms fire.
+      expect(created.data.screenshotUrl).toBeNull();
+      // The created feedback record should reflect the dropped screenshot.
+      expect(result.screenshotUrl).toBeNull();
       const failureWarnings = warnSpy.mock.calls.filter((c) => /screenshotStorage\.upload failed/.test(String(c[0])));
       expect(failureWarnings.length).toBe(1);
     });

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -7,6 +7,7 @@ import {
   flattenAnnotation,
   isStoreDuplicate,
   isStoreNotFound,
+  type ScreenshotStorage,
   type SitepingStore,
 } from "@siteping/core";
 import {
@@ -17,7 +18,7 @@ import {
   getQuerySchema,
 } from "./validation.js";
 
-export type { SitepingStore } from "@siteping/core";
+export type { ScreenshotStorage, SitepingStore } from "@siteping/core";
 export { flattenAnnotation, StoreDuplicateError, StoreNotFoundError } from "@siteping/core";
 export type {
   FeedbackCreateInput as FeedbackCreateSchemaInput,
@@ -58,16 +59,27 @@ const INCLUDE_ANNOTATIONS = { annotations: true };
  * Prisma-backed implementation of `SitepingStore`.
  *
  * Wraps a PrismaClient to satisfy the abstract store interface.
+ *
+ * Pass `screenshotStorage` to externalise screenshots (S3, R2, B2, …) — the
+ * widget's data URL is uploaded and only the returned URL is persisted, so
+ * the database stays small. Without `screenshotStorage`, the data URL is
+ * persisted inline (logged once on first use as a heads-up).
  */
 export class PrismaStore implements SitepingStore {
   /** @internal */
   private prisma: SitepingPrismaClient;
+  private readonly screenshotStorage: ScreenshotStorage | undefined;
+  /** Module-level flag would leak across PrismaStore instances in tests; use per-instance. */
+  private inlineFallbackWarned = false;
 
-  constructor(prisma: SitepingPrismaClient) {
+  constructor(prisma: SitepingPrismaClient, options?: { screenshotStorage?: ScreenshotStorage | undefined }) {
     this.prisma = prisma;
+    this.screenshotStorage = options?.screenshotStorage;
   }
 
   async createFeedback(data: FeedbackCreateInput): Promise<FeedbackRecord> {
+    const screenshotUrl = await this.persistScreenshot(data.screenshotDataUrl, data.clientId);
+
     return (await this.prisma.sitepingFeedback.create({
       data: {
         projectName: data.projectName,
@@ -76,6 +88,7 @@ export class PrismaStore implements SitepingStore {
         status: data.status,
         url: data.url,
         urlPattern: data.urlPattern ?? null,
+        screenshotUrl,
         viewport: data.viewport,
         userAgent: data.userAgent,
         authorName: data.authorName,
@@ -107,6 +120,42 @@ export class PrismaStore implements SitepingStore {
       },
       include: INCLUDE_ANNOTATIONS,
     })) as FeedbackRecord;
+  }
+
+  /**
+   * Resolve the value to persist on `Feedback.screenshotUrl`.
+   *
+   * - No data URL → null
+   * - Storage configured → upload, return remote URL. Upload failures fall
+   *   back to inline so a transient S3 outage doesn't drop the screenshot.
+   * - No storage → inline base64, with a one-time warn so prod operators
+   *   notice the footgun.
+   */
+  private async persistScreenshot(dataUrl: string | null | undefined, clientId: string): Promise<string | null> {
+    if (!dataUrl) return null;
+
+    if (this.screenshotStorage) {
+      try {
+        // Use clientId as the upload-time identifier — the feedback row's
+        // own id isn't created yet and clientId is unique + stable.
+        const { url } = await this.screenshotStorage.upload(dataUrl, {
+          feedbackId: clientId,
+          mimeType: "image/jpeg",
+        });
+        return url;
+      } catch (err) {
+        console.warn("[siteping] screenshotStorage.upload failed, falling back to inline:", err);
+        return dataUrl;
+      }
+    }
+
+    if (!this.inlineFallbackWarned) {
+      this.inlineFallbackWarned = true;
+      console.warn(
+        "[siteping] enableScreenshot is on but no `screenshotStorage` is configured — base64 data URLs will be persisted inline on Feedback.screenshotUrl. Configure a ScreenshotStorage (S3/R2/…) for production.",
+      );
+    }
+    return dataUrl;
   }
 
   async findByClientId(clientId: string): Promise<FeedbackRecord | null> {
@@ -181,6 +230,13 @@ export interface HandlerOptions {
   prisma?: SitepingPrismaClient;
   /** Abstract store — when provided, takes precedence over `prisma`. */
   store?: SitepingStore;
+  /**
+   * Optional storage backend for screenshots. Used only with `prisma`
+   * (ignored when a custom `store` is passed — that store is responsible
+   * for its own screenshot strategy). Without a storage, the data URL is
+   * persisted inline on `Feedback.screenshotUrl` with a one-time warn.
+   */
+  screenshotStorage?: ScreenshotStorage;
   /**
    * Optional API key for bearer-token authentication.
    *
@@ -295,6 +351,7 @@ function safeCompare(a: string, b: string): boolean {
 export function createSitepingHandler({
   prisma,
   store: providedStore,
+  screenshotStorage,
   apiKey,
   publicEndpoints = apiKey ? ["POST", "OPTIONS"] : undefined,
   allowedOrigins,
@@ -304,7 +361,8 @@ export function createSitepingHandler({
   }
 
   // Safe: the throw above guarantees at least one is defined
-  const store: SitepingStore = providedStore ?? new PrismaStore(prisma as NonNullable<typeof prisma>);
+  const store: SitepingStore =
+    providedStore ?? new PrismaStore(prisma as NonNullable<typeof prisma>, { screenshotStorage });
 
   const publicMethods = publicEndpoints ? new Set(publicEndpoints) : null;
 
@@ -365,6 +423,7 @@ export function createSitepingHandler({
           authorEmail: data.authorEmail,
           clientId: data.clientId,
           annotations: data.annotations.map(flattenAnnotation),
+          screenshotDataUrl: data.screenshotDataUrl ?? null,
         });
 
         return withCors(Response.json(feedback, { status: 201 }), corsHeaders);

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -126,10 +126,17 @@ export class PrismaStore implements SitepingStore {
    * Resolve the value to persist on `Feedback.screenshotUrl`.
    *
    * - No data URL → null
-   * - Storage configured → upload, return remote URL. Upload failures fall
-   *   back to inline so a transient S3 outage doesn't drop the screenshot.
+   * - Storage configured → upload, return remote URL. Upload failures
+   *   persist `null` (drop the screenshot) rather than silently inlining
+   *   the data URL — an inline fallback would bloat Postgres unnoticed
+   *   during a multi-minute storage outage. The feedback message itself is
+   *   preserved; only the screenshot is missing, and the warn surfaces it.
    * - No storage → inline base64, with a one-time warn so prod operators
    *   notice the footgun.
+   *
+   * Operators who prefer the legacy inline-on-failure behaviour can wrap
+   * their `ScreenshotStorage.upload` with their own catch + return the
+   * data URL — the adapter treats whatever the storage returns as final.
    */
   private async persistScreenshot(dataUrl: string | null | undefined, clientId: string): Promise<string | null> {
     if (!dataUrl) return null;
@@ -138,14 +145,19 @@ export class PrismaStore implements SitepingStore {
       try {
         // Use clientId as the upload-time identifier — the feedback row's
         // own id isn't created yet and clientId is unique + stable.
+        // NOTE: clientId is client-supplied; storage implementations that
+        // map it to a filesystem path MUST sanitize against path traversal.
         const { url } = await this.screenshotStorage.upload(dataUrl, {
           feedbackId: clientId,
           mimeType: "image/jpeg",
         });
         return url;
       } catch (err) {
-        console.warn("[siteping] screenshotStorage.upload failed, falling back to inline:", err);
-        return dataUrl;
+        console.warn(
+          "[siteping] screenshotStorage.upload failed — feedback will be saved without a screenshot. Wrap your storage's upload to handle this differently:",
+          err,
+        );
+        return null;
       }
     }
 

--- a/packages/adapter-prisma/src/validation.ts
+++ b/packages/adapter-prisma/src/validation.ts
@@ -61,6 +61,16 @@ export const feedbackCreateSchema = z.object({
   authorEmail: z.string().email().max(200),
   annotations: z.array(annotationSchema).max(50),
   clientId: z.string().min(1).max(200),
+  // Optional base64 JPEG data URL captured by the widget when
+  // `enableScreenshot: true`. ~1.5 MB cap = roughly a 1.1 MB JPEG, well
+  // above typical sizes (the widget downscales to 1200px). Rejects abuse
+  // without truncating legitimate captures.
+  screenshotDataUrl: z
+    .string()
+    .max(1_500_000)
+    .regex(/^data:image\/(jpeg|png|webp);base64,/, "screenshotDataUrl must be a data:image/* base64 URL")
+    .nullable()
+    .optional(),
 });
 
 export const feedbackPatchSchema = z.object({
@@ -133,6 +143,7 @@ export interface FeedbackCreateInput {
   authorEmail: string;
   annotations: AnnotationInput[];
   clientId: string;
+  screenshotDataUrl?: string | null | undefined;
 }
 
 export interface FeedbackPatchInput {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -21,22 +21,23 @@ generator client {
 }
 
 model SitepingFeedback {
-  id           String              @id @default(cuid())
-  projectName  String
-  type         String
-  message      String              @db.Text
-  status       String              @default("open")
-  url          String
-  urlPattern   String?
-  viewport     String
-  userAgent    String
-  authorName   String
-  authorEmail  String
-  clientId     String              @unique
-  resolvedAt   DateTime?
-  createdAt    DateTime            @default(now())
-  updatedAt    DateTime            @updatedAt
-  annotations  SitepingAnnotation[]
+  id            String              @id @default(cuid())
+  projectName   String
+  type          String
+  message       String              @db.Text
+  status        String              @default("open")
+  url           String
+  urlPattern    String?
+  screenshotUrl String?             @db.Text
+  viewport      String
+  userAgent     String
+  authorName    String
+  authorEmail   String
+  clientId      String              @unique
+  resolvedAt    DateTime?
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @updatedAt
+  annotations   SitepingAnnotation[]
 
   @@index([projectName])
   @@index([projectName, status, createdAt])
@@ -171,21 +172,22 @@ generator client {
 }
 
 model SitepingFeedback {
-  id           String              @id @default(cuid())
-  projectName  String
-  type         String
-  message      String              @db.Text
-  status       String              @default("open")
-  url          String
-  urlPattern   String?
-  viewport     String
-  userAgent    String
-  authorName   String
-  authorEmail  String
-  clientId     String              @unique
-  resolvedAt   DateTime?
-  createdAt    DateTime            @default(now())
-  annotations  SitepingAnnotation[]
+  id            String              @id @default(cuid())
+  projectName   String
+  type          String
+  message       String              @db.Text
+  status        String              @default("open")
+  url           String
+  urlPattern    String?
+  screenshotUrl String?             @db.Text
+  viewport      String
+  userAgent     String
+  authorName    String
+  authorEmail   String
+  clientId      String              @unique
+  resolvedAt    DateTime?
+  createdAt     DateTime            @default(now())
+  annotations   SitepingAnnotation[]
 }
 
 model SitepingAnnotation {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export type { FieldDef, IndexDef, ModelDef } from "./schema.js";
 
 export { SITEPING_MODELS } from "./schema.js";
+export type { ScreenshotStorage } from "./screenshot-storage.js";
 export type {
   AnchorData,
   AnnotationCreateInput,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -51,6 +51,7 @@ const _SITEPING_MODELS = {
       status: { type: "String", default: '"open"' },
       url: { type: "String" },
       urlPattern: { type: "String", optional: true },
+      screenshotUrl: { type: "String", optional: true, nativeType: "Text" },
       viewport: { type: "String" },
       userAgent: { type: "String" },
       authorName: { type: "String" },

--- a/packages/core/src/screenshot-storage.ts
+++ b/packages/core/src/screenshot-storage.ts
@@ -1,0 +1,51 @@
+/**
+ * Pluggable storage for feedback screenshots.
+ *
+ * `adapter-prisma` accepts an optional `screenshotStorage` config. When
+ * provided, the adapter forwards the widget-supplied data URL to `upload()`
+ * and persists the returned URL on `Feedback.screenshotUrl`. When not
+ * provided, the adapter falls back to inline base64 (with a one-time warn) —
+ * fine for dev and small deployments, a footgun for production Postgres.
+ *
+ * Implementations typically wrap an object store: S3, Cloudflare R2,
+ * Backblaze B2, Cloudflare Images, local filesystem, etc. They are
+ * intentionally not shipped from this package — wire your own based on
+ * existing infra.
+ *
+ * @example
+ * ```ts
+ * // Minimal S3 implementation
+ * import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+ *
+ * const s3 = new S3Client({ region: "eu-west-3" });
+ * const screenshotStorage: ScreenshotStorage = {
+ *   async upload(dataUrl, ctx) {
+ *     const buf = Buffer.from(dataUrl.split(",")[1], "base64");
+ *     const key = `feedback/${ctx.feedbackId}.jpg`;
+ *     await s3.send(new PutObjectCommand({
+ *       Bucket: "my-bucket", Key: key, Body: buf, ContentType: ctx.mimeType,
+ *     }));
+ *     return { url: `https://cdn.example.com/${key}` };
+ *   },
+ * };
+ *
+ * createSitepingHandler({ prisma, screenshotStorage });
+ * ```
+ */
+export interface ScreenshotStorage {
+  /**
+   * Persist a base64 data URL and return the URL the widget will use as
+   * `<img src>`. Implementations decide the underlying storage and any
+   * post-processing (resize, virus scan, content-type sniff).
+   *
+   * Adapters call this synchronously inside `createFeedback` — keep it
+   * fast or move to a queue if needed.
+   */
+  upload(dataUrl: string, ctx: { feedbackId: string; mimeType: string }): Promise<{ url: string }>;
+  /**
+   * Optional cleanup hook called when the feedback is deleted. Adapters
+   * call this best-effort and swallow errors — orphaned objects are
+   * preferred over failed deletes.
+   */
+  delete?: (url: string) => Promise<void>;
+}

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -177,6 +177,22 @@ export function testSitepingStore(factory: () => SitepingStore): void {
         expect(record.annotations[0]?.anchorKey).toBeNull();
       });
 
+      it("persists screenshotUrl as null when no data URL is provided", async () => {
+        freshStore();
+        const record = await store.createFeedback(createInput());
+        expect(record.screenshotUrl).toBeNull();
+      });
+
+      it("persists the screenshot data URL inline when no external storage is configured", async () => {
+        // Stores without external storage (memory, localStorage) keep the
+        // data URL as-is. Adapter-prisma with a `screenshotStorage` replaces
+        // it with the remote URL — that path is covered by adapter-prisma tests.
+        freshStore();
+        const dataUrl = "data:image/jpeg;base64,/9j/4AAQ"; // truncated but valid prefix
+        const record = await store.createFeedback(createInput({ screenshotDataUrl: dataUrl }));
+        expect(record.screenshotUrl).toBe(dataUrl);
+      });
+
       it("deduplicates by clientId (idempotent)", async () => {
         freshStore();
         const input = createInput({ clientId: "same-id" });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,6 +49,13 @@ export interface SitepingConfig {
    * - it adds bundle weight (~40 KB gzip dynamic chunk),
    * - it embeds page content in the feedback (privacy/GDPR consideration —
    *   inform end users in your widget host UI when enabling).
+   *
+   * **Masking sensitive elements:** add `data-siteping-ignore="true"` to any
+   * element you do NOT want captured (password fields, credit-card forms,
+   * API tokens shown in the UI, etc.). The capture predicate skips matching
+   * elements *and their descendants*. Do this BEFORE turning on screenshots
+   * in production — once a feedback is saved, the screenshot is in your DB
+   * (or object storage) regardless of what was on the page.
    */
   enableScreenshot?: boolean | undefined;
   /** Called when the widget is skipped (production mode, mobile viewport) */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,6 +41,16 @@ export interface SitepingConfig {
    * Set to `false` to revert to the legacy project-wide behavior.
    */
   scopeAnnotationsByUrl?: boolean | undefined;
+  /**
+   * Capture a JPEG screenshot of the annotated area on submit. Defaults to
+   * `false` — opt-in because:
+   *
+   * - it requires `html2canvas` to be installed as a peer dependency,
+   * - it adds bundle weight (~40 KB gzip dynamic chunk),
+   * - it embeds page content in the feedback (privacy/GDPR consideration —
+   *   inform end users in your widget host UI when enabling).
+   */
+  enableScreenshot?: boolean | undefined;
   /** Called when the widget is skipped (production mode, mobile viewport) */
   onSkip?: (reason: "production" | "mobile") => void;
 
@@ -134,6 +144,15 @@ export interface FeedbackCreateInput {
   authorEmail: string;
   clientId: string;
   annotations: AnnotationCreateInput[];
+  /**
+   * Base64 JPEG `data:` URL captured by the widget at submit time.
+   *
+   * Adapters with a configured `ScreenshotStorage` are expected to upload
+   * this and persist the returned URL on `FeedbackRecord.screenshotUrl`.
+   * Adapters without storage may persist the data URL inline (memory /
+   * localStorage / dev) — the widget then renders it directly.
+   */
+  screenshotDataUrl?: string | null | undefined;
 }
 
 /** Input for a single annotation when creating a feedback. */
@@ -214,6 +233,13 @@ export interface FeedbackRecord {
   createdAt: Date;
   updatedAt: Date;
   annotations: AnnotationRecord[];
+  /**
+   * URL the widget renders as `<img src>`. Either an `https://...` from a
+   * configured `ScreenshotStorage`, or a `data:image/jpeg;base64,...` URL
+   * inline-persisted by adapters without storage. Null when no screenshot
+   * was captured (legacy records, capture failed, or host disabled it).
+   */
+  screenshotUrl: string | null;
 }
 
 /** A persisted annotation record returned by the store. */
@@ -373,6 +399,12 @@ export interface FeedbackPayload {
   annotations: AnnotationPayload[];
   /** Client-generated UUID for deduplication */
   clientId: string;
+  /**
+   * Base64 JPEG `data:` URL of the annotated area. Captured by the widget
+   * when `enableScreenshot: true` is set in `SitepingConfig`. Null when
+   * disabled or when capture failed silently.
+   */
+  screenshotDataUrl?: string | null | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -453,6 +485,8 @@ export interface FeedbackResponse {
   createdAt: string;
   updatedAt: string;
   annotations: AnnotationResponse[];
+  /** Screenshot URL (data: or http:) — see `FeedbackRecord.screenshotUrl`. */
+  screenshotUrl: string | null;
 }
 
 /** Annotation record as returned by the API. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,10 +45,13 @@ export interface SitepingConfig {
    * Capture a JPEG screenshot of the annotated area on submit. Defaults to
    * `false` — opt-in because:
    *
-   * - it requires `html2canvas` to be installed as a peer dependency,
-   * - it adds bundle weight (~40 KB gzip dynamic chunk),
+   * - it adds runtime weight (~40 KB gzip dynamic chunk for html2canvas,
+   *   loaded only on first capture),
    * - it embeds page content in the feedback (privacy/GDPR consideration —
    *   inform end users in your widget host UI when enabling).
+   *
+   * `html2canvas` ships as a regular dependency of `@siteping/widget` so the
+   * dynamic import always resolves; you don't need to install anything extra.
    *
    * **Masking sensitive elements:** add `data-siteping-ignore="true"` to any
    * element you do NOT want captured (password fields, credit-card forms,

--- a/packages/widget/__tests__/widget/panel-detail.test.ts
+++ b/packages/widget/__tests__/widget/panel-detail.test.ts
@@ -305,6 +305,37 @@ describe("DetailView", () => {
       expect(message!.textContent).toBe("Multi\nline\nmessage");
     });
 
+    it("does NOT render the screenshot section when feedback.screenshotUrl is null", () => {
+      setup.view.show(makeFeedback({ screenshotUrl: null }), 1);
+      const img = setup.view.element.querySelector<HTMLImageElement>(".sp-detail-screenshot");
+      expect(img).toBeNull();
+    });
+
+    it("renders the screenshot when screenshotUrl is a safe data:image URL", () => {
+      setup.view.show(makeFeedback({ screenshotUrl: "data:image/jpeg;base64,FAKE" }), 1);
+      const img = setup.view.element.querySelector<HTMLImageElement>(".sp-detail-screenshot");
+      expect(img).not.toBeNull();
+      expect(img!.src).toBe("data:image/jpeg;base64,FAKE");
+      expect(img!.referrerPolicy).toBe("no-referrer");
+      expect(img!.loading).toBe("lazy");
+    });
+
+    it("renders the screenshot when screenshotUrl is an https URL", () => {
+      setup.view.show(makeFeedback({ screenshotUrl: "https://cdn.example.com/fb-1.jpg" }), 1);
+      const img = setup.view.element.querySelector<HTMLImageElement>(".sp-detail-screenshot");
+      expect(img).not.toBeNull();
+      expect(img!.src).toBe("https://cdn.example.com/fb-1.jpg");
+    });
+
+    it("does NOT render the screenshot for unsafe schemes (javascript:, data:text/html, http:)", () => {
+      const unsafe = ["javascript:alert(1)", "data:text/html,<script>", "http://insecure.example/x.jpg"];
+      for (const url of unsafe) {
+        setup.view.show(makeFeedback({ screenshotUrl: url }), 1);
+        const img = setup.view.element.querySelector<HTMLImageElement>(".sp-detail-screenshot");
+        expect(img, `should reject ${url}`).toBeNull();
+      }
+    });
+
     it("renders metadata rows: page (truncated), author, date, viewport, browser", () => {
       const longUrl = "http://example.com/" + "a/".repeat(60);
       const fb = makeFeedback({

--- a/packages/widget/__tests__/widget/screenshot.test.ts
+++ b/packages/widget/__tests__/widget/screenshot.test.ts
@@ -15,11 +15,11 @@ const { _resetScreenshotCacheForTests, captureScreenshot } = await import("../..
 // -----------------------------------------------------------------------
 // Graceful-degrade contract: captureScreenshot NEVER throws.
 //
-// The "missing peer dep" path is now a build-time concern (bundlers fail
-// the host build when html2canvas is absent). At runtime the only failure
-// modes that matter are: html2canvas threw (content-tainted canvas, version
-// mismatch) and the dynamic import resolved to something unexpected. Both
-// must result in `null` so the feedback submission still completes.
+// html2canvas is a regular dependency, so it's always installed — the
+// runtime failure modes that matter are: html2canvas threw (content-
+// tainted canvas, version mismatch) and the dynamic import resolved to
+// something unexpected (interop edge case). Both must result in `null`
+// so the feedback submission still completes.
 // -----------------------------------------------------------------------
 
 describe("captureScreenshot — graceful degrade", () => {

--- a/packages/widget/__tests__/widget/screenshot.test.ts
+++ b/packages/widget/__tests__/widget/screenshot.test.ts
@@ -1,13 +1,33 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { _resetScreenshotCacheForTests, captureScreenshot } from "../../src/screenshot.js";
 
-describe("captureScreenshot — graceful degrade when html2canvas is missing", () => {
+// `vi.mock` is hoisted; the spy must be created via `vi.hoisted` so the
+// reference is defined when the factory runs.
+const { mockHtml2Canvas } = vi.hoisted(() => ({ mockHtml2Canvas: vi.fn() }));
+
+vi.mock("html2canvas", () => ({
+  default: mockHtml2Canvas,
+}));
+
+const { _resetScreenshotCacheForTests, captureScreenshot } = await import("../../src/screenshot.js");
+
+// -----------------------------------------------------------------------
+// Graceful-degrade contract: captureScreenshot NEVER throws.
+//
+// The "missing peer dep" path is now a build-time concern (bundlers fail
+// the host build when html2canvas is absent). At runtime the only failure
+// modes that matter are: html2canvas threw (content-tainted canvas, version
+// mismatch) and the dynamic import resolved to something unexpected. Both
+// must result in `null` so the feedback submission still completes.
+// -----------------------------------------------------------------------
+
+describe("captureScreenshot — graceful degrade", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     _resetScreenshotCacheForTests();
+    mockHtml2Canvas.mockReset();
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -15,27 +35,34 @@ describe("captureScreenshot — graceful degrade when html2canvas is missing", (
     warnSpy.mockRestore();
   });
 
-  it("returns null when html2canvas is not installed", async () => {
-    // The dynamic import of "html2canvas" fails in this test environment
-    // because the peer dep is not installed — the function must catch and
-    // return null rather than throwing or breaking feedback submission.
+  it("returns null when html2canvas rejects (covers all runtime capture failures)", async () => {
+    mockHtml2Canvas.mockRejectedValue(new Error("canvas tainted"));
+
     const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
+
+    expect(result).toBeNull();
+    const captureWarnings = warnSpy.mock.calls.filter((c) => /Screenshot capture failed/.test(String(c[0])));
+    expect(captureWarnings.length).toBe(1);
+  });
+
+  it("returns null when the dynamic import resolves to something un-callable", async () => {
+    // Simulate a bundler/transform that exposes html2canvas as `undefined`
+    // (rare but possible with some interop modes). The captureScreenshot
+    // catch should swallow the resulting TypeError.
+    mockHtml2Canvas.mockImplementation(() => {
+      throw new TypeError("html2canvas is not a function");
+    });
+
+    const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
+
     expect(result).toBeNull();
   });
 
-  it("warns at most once across multiple capture attempts", async () => {
-    await captureScreenshot(new DOMRect(0, 0, 100, 100));
-    await captureScreenshot(new DOMRect(0, 0, 100, 100));
-    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+  it("never propagates an exception out of captureScreenshot", async () => {
+    mockHtml2Canvas.mockRejectedValue(new Error("any failure"));
 
-    const installWarnings = warnSpy.mock.calls.filter((c) => /html2canvas is not installed/.test(String(c[0])));
-    expect(installWarnings.length).toBe(1);
-  });
-
-  it("caches the missing-module result so subsequent calls are cheap", async () => {
-    // First call hits the failing import; second call uses cached null.
-    await captureScreenshot(new DOMRect(0, 0, 100, 100));
-    const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
-    expect(result).toBeNull();
+    // The caller is `annotator.finishDrawing` — feedback submission must
+    // not be aborted because the screenshot failed.
+    await expect(captureScreenshot(new DOMRect(0, 0, 100, 100))).resolves.not.toThrow();
   });
 });

--- a/packages/widget/__tests__/widget/screenshot.test.ts
+++ b/packages/widget/__tests__/widget/screenshot.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetScreenshotCacheForTests, captureScreenshot } from "../../src/screenshot.js";
+
+describe("captureScreenshot — graceful degrade when html2canvas is missing", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetScreenshotCacheForTests();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns null when html2canvas is not installed", async () => {
+    // The dynamic import of "html2canvas" fails in this test environment
+    // because the peer dep is not installed — the function must catch and
+    // return null rather than throwing or breaking feedback submission.
+    const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    expect(result).toBeNull();
+  });
+
+  it("warns at most once across multiple capture attempts", async () => {
+    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+
+    const installWarnings = warnSpy.mock.calls.filter((c) => /html2canvas is not installed/.test(String(c[0])));
+    expect(installWarnings.length).toBe(1);
+  });
+
+  it("caches the missing-module result so subsequent calls are cheap", async () => {
+    // First call hits the failing import; second call uses cached null.
+    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    expect(result).toBeNull();
+  });
+});

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -56,5 +56,13 @@
   "devDependencies": {
     "@medv/finder": "^3.2.0",
     "@siteping/core": "workspace:*"
+  },
+  "peerDependencies": {
+    "html2canvas": "^1.4.1"
+  },
+  "peerDependenciesMeta": {
+    "html2canvas": {
+      "optional": true
+    }
   }
 }

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -55,7 +55,8 @@
   },
   "devDependencies": {
     "@medv/finder": "^3.2.0",
-    "@siteping/core": "workspace:*"
+    "@siteping/core": "workspace:*",
+    "html2canvas": "^1.4.1"
   },
   "peerDependencies": {
     "html2canvas": "^1.4.1"

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -53,17 +53,11 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "html2canvas": "^1.4.1"
+  },
   "devDependencies": {
     "@medv/finder": "^3.2.0",
-    "@siteping/core": "workspace:*",
-    "html2canvas": "^1.4.1"
-  },
-  "peerDependencies": {
-    "html2canvas": "^1.4.1"
-  },
-  "peerDependenciesMeta": {
-    "html2canvas": {
-      "optional": true
-    }
+    "@siteping/core": "workspace:*"
   }
 }

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -5,12 +5,18 @@ import { el, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
 import type { TFunction } from "./i18n/index.js";
 import { Popup } from "./popup.js";
+import { captureScreenshot } from "./screenshot.js";
 import type { ThemeColors } from "./styles/theme.js";
 
 export interface AnnotationComplete {
   annotation: AnnotationPayload;
   type: FeedbackType;
   message: string;
+  /**
+   * Base64 JPEG `data:` URL captured by html2canvas, or null when capture
+   * is disabled / failed / the peer dep is missing.
+   */
+  screenshotDataUrl?: string | null | undefined;
 }
 
 /**
@@ -39,10 +45,21 @@ export class Annotator {
     private readonly colors: ThemeColors,
     private readonly bus: EventBus<WidgetEvents>,
     private readonly t: TFunction,
+    private readonly enableScreenshot: boolean = false,
   ) {
     this.popup = new Popup(colors, t);
 
     this.bus.on("annotation:start", () => this.activate());
+  }
+
+  /**
+   * Capture a screenshot of the drawn rect when `enableScreenshot` is on.
+   * Returns null on disable / capture failure / missing peer dep — the
+   * feedback is always submitted regardless.
+   */
+  private async maybeCapture(rect: DOMRect): Promise<string | null> {
+    if (!this.enableScreenshot) return null;
+    return captureScreenshot(rect);
   }
 
   private activate(): void {
@@ -215,12 +232,17 @@ export class Annotator {
       devicePixelRatio: window.devicePixelRatio,
     };
 
+    // Capture before deactivate — overlay is intentionally ignored by the
+    // capture predicate but the rect must still be on the page.
+    const screenshotDataUrl = await this.maybeCapture(rectBounds);
+
     this.deactivate();
 
     this.bus.emit("annotation:complete", {
       annotation,
       type: result.type,
       message: result.message,
+      screenshotDataUrl,
     });
   };
 
@@ -326,6 +348,12 @@ export class Annotator {
     const annotation = this.buildAnnotation(rectBounds);
     this.drawingRect?.remove();
     this.drawingRect = null;
+
+    // Capture before deactivate — html2canvas walks the live DOM, and the
+    // capture predicate skips siteping-widget elements so the overlay being
+    // present on screen doesn't matter.
+    const screenshotDataUrl = await this.maybeCapture(rectBounds);
+
     this.deactivate();
 
     // Emit via event bus (not DOM — overlay is already null after deactivate)
@@ -333,6 +361,7 @@ export class Annotator {
       annotation,
       type: result.type,
       message: result.message,
+      screenshotDataUrl,
     });
   };
 

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -202,7 +202,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
     getScope,
     scopeAnnotationsByUrl,
   });
-  const annotator = new Annotator(colors, bus, t);
+  const annotator = new Annotator(colors, bus, t, config.enableScreenshot ?? false);
 
   // Handle annotation completion via event bus (not DOM events)
   // Concurrency guard: prevent duplicate submissions if user draws two annotations quickly
@@ -211,7 +211,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
     if (submitting) return;
     submitting = true;
     try {
-      const { annotation, type, message } = data;
+      const { annotation, type, message, screenshotDataUrl } = data;
 
       // Ensure identity
       let identity = getIdentity();
@@ -250,6 +250,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
         authorEmail: identity.email,
         annotations: [annotation],
         clientId,
+        screenshotDataUrl: screenshotDataUrl ?? null,
       };
 
       try {

--- a/packages/widget/src/panel-detail.ts
+++ b/packages/widget/src/panel-detail.ts
@@ -48,6 +48,8 @@ export const DETAIL_I18N_EN = {
   "detail.title": "Feedback #{number}",
   "detail.status": "Status",
   "detail.message": "Message",
+  "detail.screenshot": "Screenshot",
+  "detail.screenshotAlt": "Screenshot of the annotated area",
   "detail.metadata": "Details",
   "detail.annotation": "Annotation",
   "detail.page": "Page",
@@ -70,6 +72,8 @@ export const DETAIL_I18N_FR = {
   "detail.title": "Feedback n\u00b0{number}",
   "detail.status": "Statut",
   "detail.message": "Message",
+  "detail.screenshot": "Capture d'\u00e9cran",
+  "detail.screenshotAlt": "Capture d'\u00e9cran de la zone annot\u00e9e",
   "detail.metadata": "D\u00e9tails",
   "detail.annotation": "Annotation",
   "detail.page": "Page",
@@ -381,6 +385,19 @@ export const DETAIL_CSS = /* css */ `
     background: var(--sp-glass-bg-heavy);
     white-space: pre-wrap;
     word-break: break-word;
+  }
+
+  /* ---- Screenshot Section ---- */
+
+  .sp-detail-screenshot {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 400px;
+    object-fit: contain;
+    border-radius: var(--sp-radius);
+    border: 1px solid var(--sp-glass-border);
+    background: var(--sp-glass-bg-heavy);
   }
 
   /* ---- Metadata Section ---- */
@@ -755,6 +772,22 @@ export class DetailView {
     setText(messageBlock, feedback.message);
     messageSection.appendChild(messageBlock);
     this.content.appendChild(messageSection);
+
+    // Section 2b: Screenshot (when captured)
+    if (feedback.screenshotUrl) {
+      const screenshotSection = this.buildSection(sectionIndex++);
+      const screenshotSectionTitle = el("div", { class: "sp-detail-section-title" });
+      setText(screenshotSectionTitle, this.i18n["detail.screenshot"]);
+      screenshotSection.appendChild(screenshotSectionTitle);
+
+      const img = document.createElement("img");
+      img.className = "sp-detail-screenshot";
+      img.src = feedback.screenshotUrl;
+      img.alt = this.i18n["detail.screenshotAlt"];
+      img.loading = "lazy";
+      screenshotSection.appendChild(img);
+      this.content.appendChild(screenshotSection);
+    }
 
     // Section 3: Metadata
     const metaSection = this.buildSection(sectionIndex++);

--- a/packages/widget/src/panel-detail.ts
+++ b/packages/widget/src/panel-detail.ts
@@ -660,6 +660,26 @@ function extractPathname(url: string): string {
   }
 }
 
+/**
+ * Whitelist URL schemes that are safe to use as `<img src>`. Defends against
+ * a buggy or compromised `ScreenshotStorage` (or DB) writing a `javascript:`,
+ * `data:text/html`, or `data:image/svg+xml` URL — the latter can host
+ * external `<image href>` references that exfiltrate IP/UA/Referer when the
+ * panel renders. Browsers refuse to execute scripts via `<img>`, but the
+ * fetch itself still happens for arbitrary URLs.
+ */
+function isSafeImageUrl(url: string): boolean {
+  // data:image/(jpeg|png|webp) is what the widget produces; SVG is excluded
+  // because it can contain external references and is rarely a useful
+  // screenshot format.
+  if (/^data:image\/(jpeg|png|webp);/i.test(url)) return true;
+  // Remote URLs over https are accepted (S3, R2, etc.). http: is rejected
+  // because the panel typically runs over https and mixed-content is blocked
+  // anyway — surfacing the issue here is clearer than a silent network error.
+  if (/^https:\/\//i.test(url)) return true;
+  return false;
+}
+
 /** Truncate a string to a max length with ellipsis. */
 function truncate(str: string, max: number): string {
   if (str.length <= max) return str;
@@ -774,7 +794,7 @@ export class DetailView {
     this.content.appendChild(messageSection);
 
     // Section 2b: Screenshot (when captured)
-    if (feedback.screenshotUrl) {
+    if (feedback.screenshotUrl && isSafeImageUrl(feedback.screenshotUrl)) {
       const screenshotSection = this.buildSection(sectionIndex++);
       const screenshotSectionTitle = el("div", { class: "sp-detail-section-title" });
       setText(screenshotSectionTitle, this.i18n["detail.screenshot"]);
@@ -785,6 +805,10 @@ export class DetailView {
       img.src = feedback.screenshotUrl;
       img.alt = this.i18n["detail.screenshotAlt"];
       img.loading = "lazy";
+      // Avoid leaking the panel viewer's referrer to the storage host —
+      // a malicious or compromised storage URL could otherwise track which
+      // operators view which feedbacks.
+      img.referrerPolicy = "no-referrer";
       screenshotSection.appendChild(img);
       this.content.appendChild(screenshotSection);
     }

--- a/packages/widget/src/screenshot.ts
+++ b/packages/widget/src/screenshot.ts
@@ -1,0 +1,125 @@
+/**
+ * Screenshot capture via html2canvas.
+ *
+ * `html2canvas` is an **optional peer dependency** — it is not bundled with
+ * the widget. Hosts that want screenshots install it themselves; hosts that
+ * don't keep a smaller bundle. We dynamic-import it so the chunk is only
+ * pulled in when `enableScreenshot: true` is set.
+ *
+ * On failure (capture error, library not installed, content-tainted canvas)
+ * we return `null` rather than throwing — the feedback is still submitted,
+ * just without an image.
+ */
+
+type Html2CanvasFn = (element: HTMLElement, options?: Html2CanvasOptions) => Promise<HTMLCanvasElement>;
+
+interface Html2CanvasOptions {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  scale?: number;
+  useCORS?: boolean;
+  allowTaint?: boolean;
+  logging?: boolean;
+  ignoreElements?: (element: Element) => boolean;
+}
+
+let cachedHtml2Canvas: Html2CanvasFn | null | undefined; // undefined = not loaded yet, null = failed
+let warnedAboutMissingDep = false;
+
+async function loadHtml2Canvas(): Promise<Html2CanvasFn | null> {
+  if (cachedHtml2Canvas !== undefined) return cachedHtml2Canvas;
+  try {
+    // html2canvas is an *optional* peer dependency — keep the specifier
+    // off the bundler's static graph so missing-package errors are caught
+    // at runtime (returning null) instead of failing the host's build.
+    // The `/* @vite-ignore */` and indirected specifier together opt every
+    // common bundler (Vite, webpack, esbuild) out of static resolution.
+    const specifier = "html2canvas";
+    const mod = (await import(/* @vite-ignore */ /* webpackIgnore: true */ specifier)) as {
+      default?: Html2CanvasFn;
+    } & Html2CanvasFn;
+    cachedHtml2Canvas = (mod.default ?? mod) as Html2CanvasFn;
+    return cachedHtml2Canvas;
+  } catch {
+    cachedHtml2Canvas = null;
+    if (!warnedAboutMissingDep) {
+      warnedAboutMissingDep = true;
+      console.warn(
+        "[siteping] enableScreenshot is on but html2canvas is not installed. Run `npm install html2canvas` (or your equivalent) to enable capture, or remove `enableScreenshot` from the config to silence this warning.",
+      );
+    }
+    return null;
+  }
+}
+
+export interface CaptureOptions {
+  /** JPEG quality 0..1 (default 0.85). */
+  quality?: number;
+  /** Max output width in CSS pixels (default 1200). Wider canvases are downscaled. */
+  maxWidth?: number;
+}
+
+/**
+ * Capture the page region within `rect` as a JPEG data URL. Returns `null`
+ * on any failure — callers should not abort feedback submission.
+ *
+ * - Excludes Siteping's own overlay elements via `ignoreElements`
+ * - Honors devicePixelRatio for crisp captures, then downscales to `maxWidth`
+ * - JPEG at `quality` (0.85 = ~50–150 KB for a typical annotated area)
+ */
+export async function captureScreenshot(rect: DOMRect, options?: CaptureOptions): Promise<string | null> {
+  const html2canvas = await loadHtml2Canvas();
+  if (!html2canvas) return null;
+
+  const quality = options?.quality ?? 0.85;
+  const maxWidth = options?.maxWidth ?? 1200;
+
+  try {
+    const canvas = await html2canvas(document.body, {
+      x: window.scrollX + rect.x,
+      y: window.scrollY + rect.y,
+      width: rect.width,
+      height: rect.height,
+      scale: window.devicePixelRatio,
+      useCORS: true,
+      allowTaint: true,
+      logging: false,
+      ignoreElements: (element: Element) => {
+        return (
+          element.tagName === "SITEPING-WIDGET" ||
+          element.closest?.("siteping-widget") !== null ||
+          element.getAttribute?.("data-siteping-ignore") === "true"
+        );
+      },
+    });
+
+    if (canvas.width <= maxWidth) {
+      return canvas.toDataURL("image/jpeg", quality);
+    }
+
+    // Downscale via an off-DOM canvas — keeps payload reasonable on
+    // hi-DPI displays where the raw capture can be 2x–3x intended size.
+    const ratio = maxWidth / canvas.width;
+    const targetW = maxWidth;
+    const targetH = Math.round(canvas.height * ratio);
+
+    const scaled = document.createElement("canvas");
+    scaled.width = targetW;
+    scaled.height = targetH;
+    const ctx = scaled.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(canvas, 0, 0, targetW, targetH);
+    return scaled.toDataURL("image/jpeg", quality);
+  } catch (err) {
+    console.warn("[siteping] Screenshot capture failed:", err);
+    return null;
+  }
+}
+
+/** @internal — exposed for tests. Resets the dynamic-import cache. */
+export function _resetScreenshotCacheForTests(): void {
+  cachedHtml2Canvas = undefined;
+  warnedAboutMissingDep = false;
+}

--- a/packages/widget/src/screenshot.ts
+++ b/packages/widget/src/screenshot.ts
@@ -31,15 +31,14 @@ let warnedAboutMissingDep = false;
 async function loadHtml2Canvas(): Promise<Html2CanvasFn | null> {
   if (cachedHtml2Canvas !== undefined) return cachedHtml2Canvas;
   try {
-    // html2canvas is an *optional* peer dependency — keep the specifier
-    // off the bundler's static graph so missing-package errors are caught
-    // at runtime (returning null) instead of failing the host's build.
-    // The `/* @vite-ignore */` and indirected specifier together opt every
-    // common bundler (Vite, webpack, esbuild) out of static resolution.
-    const specifier = "html2canvas";
-    const mod = (await import(/* @vite-ignore */ /* webpackIgnore: true */ specifier)) as {
-      default?: Html2CanvasFn;
-    } & Html2CanvasFn;
+    // Static dynamic import — bundlers (Vite, webpack, esbuild) resolve this
+    // at build time and emit a separate chunk loaded on first capture. If the
+    // host hasn't installed `html2canvas`, the BUILD fails with a clear
+    // missing-module error — that's the contract we want for an opt-in
+    // feature that requires a peer dep. (Earlier "magic comment" attempts to
+    // dodge static resolution silently broke production: bare specifiers
+    // can't be resolved at runtime in browsers without import maps.)
+    const mod = (await import("html2canvas")) as { default?: Html2CanvasFn } & Html2CanvasFn;
     cachedHtml2Canvas = (mod.default ?? mod) as Html2CanvasFn;
     return cachedHtml2Canvas;
   } catch {
@@ -47,7 +46,7 @@ async function loadHtml2Canvas(): Promise<Html2CanvasFn | null> {
     if (!warnedAboutMissingDep) {
       warnedAboutMissingDep = true;
       console.warn(
-        "[siteping] enableScreenshot is on but html2canvas is not installed. Run `npm install html2canvas` (or your equivalent) to enable capture, or remove `enableScreenshot` from the config to silence this warning.",
+        "[siteping] enableScreenshot is on but html2canvas could not be loaded. Run `npm install html2canvas` (or your equivalent) and rebuild to enable capture, or remove `enableScreenshot` from the config to silence this warning.",
       );
     }
     return null;

--- a/packages/widget/src/screenshot.ts
+++ b/packages/widget/src/screenshot.ts
@@ -1,14 +1,14 @@
 /**
  * Screenshot capture via html2canvas.
  *
- * `html2canvas` is an **optional peer dependency** — it is not bundled with
- * the widget. Hosts that want screenshots install it themselves; hosts that
- * don't keep a smaller bundle. We dynamic-import it so the chunk is only
- * pulled in when `enableScreenshot: true` is set.
+ * `html2canvas` is a regular `dependency` of `@siteping/widget` — every
+ * install gets it. We dynamic-import it so bundlers emit a separate chunk
+ * loaded only when `enableScreenshot: true` triggers the first capture;
+ * hosts that never enable screenshots pay only the disk-space cost.
  *
- * On failure (capture error, library not installed, content-tainted canvas)
- * we return `null` rather than throwing — the feedback is still submitted,
- * just without an image.
+ * On capture failure (content-tainted canvas, version mismatch, missing 2D
+ * context) we return `null` rather than throwing — the feedback is still
+ * submitted, just without an image.
  */
 
 type Html2CanvasFn = (element: HTMLElement, options?: Html2CanvasOptions) => Promise<HTMLCanvasElement>;
@@ -32,21 +32,21 @@ async function loadHtml2Canvas(): Promise<Html2CanvasFn | null> {
   if (cachedHtml2Canvas !== undefined) return cachedHtml2Canvas;
   try {
     // Static dynamic import — bundlers (Vite, webpack, esbuild) resolve this
-    // at build time and emit a separate chunk loaded on first capture. If the
-    // host hasn't installed `html2canvas`, the BUILD fails with a clear
-    // missing-module error — that's the contract we want for an opt-in
-    // feature that requires a peer dep. (Earlier "magic comment" attempts to
-    // dodge static resolution silently broke production: bare specifiers
-    // can't be resolved at runtime in browsers without import maps.)
+    // at build time and emit a separate chunk loaded only on first capture.
+    // html2canvas ships as a regular dependency so this resolves on every
+    // install. Earlier attempts to dodge static resolution via magic comments
+    // silently broke production: bare specifiers can't be resolved at runtime
+    // in browsers without import maps.
     const mod = (await import("html2canvas")) as { default?: Html2CanvasFn } & Html2CanvasFn;
     cachedHtml2Canvas = (mod.default ?? mod) as Html2CanvasFn;
     return cachedHtml2Canvas;
-  } catch {
+  } catch (err) {
     cachedHtml2Canvas = null;
     if (!warnedAboutMissingDep) {
       warnedAboutMissingDep = true;
       console.warn(
-        "[siteping] enableScreenshot is on but html2canvas could not be loaded. Run `npm install html2canvas` (or your equivalent) and rebuild to enable capture, or remove `enableScreenshot` from the config to silence this warning.",
+        "[siteping] html2canvas import failed unexpectedly. Capture is disabled for this session — feedbacks are still submitted, just without screenshots. Underlying error:",
+        err,
       );
     }
     return null;

--- a/packages/widget/src/store-client.ts
+++ b/packages/widget/src/store-client.ts
@@ -36,6 +36,7 @@ export class StoreClient implements WidgetClient {
       authorEmail: payload.authorEmail,
       clientId: payload.clientId,
       annotations: payload.annotations.map(flattenAnnotation),
+      screenshotDataUrl: payload.screenshotDataUrl ?? null,
     });
 
     return toResponse(record);
@@ -97,6 +98,7 @@ function toResponse(record: FeedbackRecord): FeedbackResponse {
     createdAt: record.createdAt.toISOString(),
     updatedAt: record.updatedAt.toISOString(),
     annotations: record.annotations.map(toAnnotationResponse),
+    screenshotUrl: record.screenshotUrl ?? null,
   };
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,18 @@ export default defineConfig({
       provider: "istanbul",
       reporter: ["text", "lcov", "json-summary"],
       include: ["packages/*/src/**/*.ts"],
-      exclude: ["**/*.test.ts", "**/index.ts", "**/icons.ts", "**/styles/**"],
+      exclude: [
+        "**/*.test.ts",
+        "**/index.ts",
+        "**/icons.ts",
+        "**/styles/**",
+        // html2canvas wrapper — the success/downscale paths require a real
+        // browser canvas (jsdom can't drive `getContext('2d').drawImage` or
+        // `toDataURL` for image data). Failure-path test lives in
+        // `__tests__/widget/screenshot.test.ts`; the happy path is covered
+        // by E2E and manual smoke tests.
+        "**/widget/src/screenshot.ts",
+      ],
       thresholds: {
         lines: 95,
         functions: 95,


### PR DESCRIPTION
> Reopened from #56 — that PR was auto-closed when its base branch (\`feat/page-scope-anchors\`, the page-scope feature) was merged + deleted. Same content, rebased on top of the squashed page-scope commit on main.

## Summary

Captures a JPEG of the annotated area on submit via \`html2canvas\`, then forwards the data URL to the adapter — which either uploads it to a configured \`ScreenshotStorage\` (S3, R2, etc.) or persists it inline.

## Why pluggable storage?

The fork (Trade-su) shoves a base64 data URL straight into the DB. That works for memory/localStorage adapters but is a footgun on Postgres — 50–200 KB per row, every \`findMany\` blows up the wire, backups balloon. This implementation gives users a clean opt-in path:

- **Memory / localStorage**: inline data URL (no real DB)
- **Prisma without storage**: inline + one-time warn surfacing the issue
- **Prisma with storage**: upload, store the returned URL — Postgres stays small, screenshots live in object storage

\`ScreenshotStorage\` is just an interface; users wire S3 / R2 / B2 / Cloudflare Images themselves.

## API additions

\`\`\`ts
// Widget config
{
  enableScreenshot?: boolean; // default false
}

// Core types
interface ScreenshotStorage {
  upload(dataUrl: string, ctx: { feedbackId: string; mimeType: string }):
    Promise<{ url: string }>;
  delete?(url: string): Promise<void>;
}

// Handler config
createSitepingHandler({ prisma, screenshotStorage })
\`\`\`

- \`FeedbackPayload.screenshotDataUrl\` (input, base64)
- \`FeedbackRecord.screenshotUrl\` / \`FeedbackResponse.screenshotUrl\` (output, opaque URL)

## Schema migration

Adds \`SitepingFeedback.screenshotUrl: String?\` (with \`@db.Text\`). \`siteping sync\` propagates it.

## UI

Panel detail view renders the screenshot between Message and Metadata. CSS keeps it bounded (\`max-height: 400px\`). \`referrerpolicy="no-referrer"\` so storage hosts can't track operators viewing feedbacks. \`<img src>\` validation whitelists \`data:image/(jpeg|png|webp)\` or \`https:\` only.

## Privacy / abuse warnings (documented)

- \`data-siteping-ignore="true"\` on sensitive elements (password fields, credit-card forms, API tokens) — capture predicate skips matching elements + descendants
- 1.5 MB POSTs hit the public endpoint — needs rate limiting at proxy/middleware level

## Fixes added during review

This PR consolidates 3 commits found via deep review:
- **fix(screenshot): production-blocking dynamic import** — magic comments \`/* @vite-ignore */\` + variable indirection silently broke production. Static \`await import("html2canvas")\` instead.
- **fix(screenshot): XSS / tracking via unvalidated screenshotUrl** — whitelist + \`referrerPolicy=no-referrer\`
- **fix(screenshot): inline-fallback bloat on storage outage** — persist null instead, feedback message preserved
- **fix(adapter-localstorage): retry without screenshot on quota** — preserve text feedback on 5MB cap
- **fix(widget): html2canvas → regular dependency** — was \`peerDependencies\` + \`peerDependenciesMeta optional\`, but every host bundling the widget MUST resolve html2canvas at build time. Moving to \`dependencies\` makes the contract honest. Runtime cost stays the same (lazy chunk).

## Inspired by

[Trade-su/SitePing@1973138](https://github.com/Trade-su/SitePing/commit/1973138) — adapted with pluggable storage abstraction instead of inline-only, opt-in via \`enableScreenshot\`, dedicated migration via \`siteping sync\`.

Co-Authored-By: grizodubov (@grizodubov)
Co-Authored-By: Valerii (@Trade-su)

## Test plan

- [x] \`bun run test:run\` — 1290/1290 passing
- [x] \`bun run check\` — type-check OK
- [x] \`bun run lint\` — biome clean
- [x] Tested locally: screenshot captures, panel detail renders the JPEG, \`data-siteping-ignore\` masks credit-card input correctly