### PR TITLE
fix(adapter-prisma): require apiKey for DELETE/PATCH in production

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,3 +48,10 @@ This policy applies to all packages in the `@siteping/*` scope:
 - `@siteping/adapter-memory`
 - `@siteping/adapter-localstorage`
 - `@siteping/cli`
+
+## Hardening checklist for self-hosters
+
+- **`apiKey` is required in production.** Starting `createSitepingHandler({ prisma })` with `NODE_ENV=production` and no `apiKey` throws at startup. Destructive endpoints (DELETE, PATCH) refuse to operate without authentication unless you explicitly opt out via `requireAuthForDestructive: false` (only safe behind your own auth middleware).
+- **Set `allowedOrigins`.** Without it, no CORS headers are emitted and cross-origin browser requests are blocked. With `allowedOrigins: ["https://your-site.com"]`, only listed origins can call the API.
+- **Rate-limit POST.** The widget submits from unauthenticated browser contexts. Apply rate limiting at the reverse proxy or middleware layer (Next.js middleware, Nginx, Cloudflare).
+- **Run the CLI doctor.** `npx @siteping/cli doctor` flags missing `apiKey`, missing `allowedOrigins`, and other production red flags.

--- a/apps/demo/src/app/api/siteping/route.ts
+++ b/apps/demo/src/app/api/siteping/route.ts
@@ -3,4 +3,7 @@ import { memoryStore } from "@/lib/memory-store";
 
 export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
   store: memoryStore,
+  // Demo only: everyone can wipe the in-memory store. Never do this on a
+  // real deployment — set `apiKey` instead.
+  requireAuthForDestructive: false,
 });

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -177,7 +177,11 @@ When the upload fails (transient S3 outage etc.), the adapter persists `screensh
 
 ## Authentication
 
-By default, all endpoints are publicly accessible. To protect read/update/delete operations, pass an `apiKey`:
+GET and POST are publicly accessible by default (read + widget-side submit). DELETE and PATCH are gated:
+
+- **No `apiKey` in production (`NODE_ENV === "production"`)** — `createSitepingHandler` throws at startup. This is intentional: without it, anyone could `DELETE { deleteAll: true }` against your endpoint.
+- **No `apiKey` in dev** — DELETE and PATCH return `401 { error: "apiKey required for destructive operations" }`. GET/POST stay open so the widget keeps working locally.
+- **`apiKey` set** — DELETE/PATCH require `Authorization: Bearer <apiKey>`; GET/POST stay public unless you override `publicEndpoints`.
 
 ```ts
 export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
@@ -191,6 +195,15 @@ When `apiKey` is set:
 
 - **POST** and **OPTIONS** remain public (the browser widget needs to submit feedback and perform CORS preflight without authentication).
 - **GET**, **PATCH**, and **DELETE** require a `Bearer <apiKey>` token in the `Authorization` header.
+
+### Escape hatch: `requireAuthForDestructive: false`
+
+If SitePing sits behind your own session-based / OAuth middleware and you want destructive ops to inherit that auth, pass `requireAuthForDestructive: false`. This disables the startup guard and the dev-mode 401s:
+
+```ts
+// Only safe when an upstream middleware authenticates DELETE/PATCH.
+createSitepingHandler({ prisma, requireAuthForDestructive: false })
+```
 
 ## Framework Compatibility
 

--- a/packages/adapter-prisma/__tests__/auth-cors.test.ts
+++ b/packages/adapter-prisma/__tests__/auth-cors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSitepingHandler } from "../src/index.js";
 import { validPayloadNoAnnotations } from "./fixtures.js";
 
@@ -186,29 +186,74 @@ describe("Authentication", () => {
     });
   });
 
-  describe("without apiKey configured", () => {
-    it("POST succeeds without any Authorization header", async () => {
+  describe("without apiKey configured (dev mode)", () => {
+    it("POST succeeds without any Authorization header (public by default)", async () => {
       const handler = createSitepingHandler({ prisma });
       const res = await handler.POST(postRequest(validPayloadNoAnnotations));
       expect(res.status).toBe(201);
     });
 
-    it("GET succeeds without any Authorization header", async () => {
+    it("GET succeeds without any Authorization header (public by default)", async () => {
       const handler = createSitepingHandler({ prisma });
       const res = await handler.GET(getRequest("projectName=test"));
       expect(res.status).toBe(200);
     });
 
-    it("PATCH succeeds without any Authorization header", async () => {
+    it("PATCH without apiKey returns 401 (destructive ops require auth by default)", async () => {
       const handler = createSitepingHandler({ prisma });
+      const res = await handler.PATCH(patchRequest({ id: "fb-1", projectName: "test", status: "resolved" }));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toContain("apiKey required");
+    });
+
+    it("DELETE without apiKey returns 401 (destructive ops require auth by default)", async () => {
+      const handler = createSitepingHandler({ prisma });
+      const res = await handler.DELETE(deleteRequest({ id: "fb-1", projectName: "test" }));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toContain("apiKey required");
+    });
+
+    it("DELETE { deleteAll: true } without apiKey returns 401 (closes the wipe-everything hole)", async () => {
+      const handler = createSitepingHandler({ prisma });
+      const res = await handler.DELETE(deleteRequest({ projectName: "test", deleteAll: true }));
+      expect(res.status).toBe(401);
+    });
+
+    it("PATCH succeeds when requireAuthForDestructive=false (explicit escape hatch)", async () => {
+      const handler = createSitepingHandler({ prisma, requireAuthForDestructive: false });
       const res = await handler.PATCH(patchRequest({ id: "fb-1", projectName: "test", status: "resolved" }));
       expect(res.status).toBe(200);
     });
 
-    it("DELETE succeeds without any Authorization header", async () => {
-      const handler = createSitepingHandler({ prisma });
+    it("DELETE succeeds when requireAuthForDestructive=false (explicit escape hatch)", async () => {
+      const handler = createSitepingHandler({ prisma, requireAuthForDestructive: false });
       const res = await handler.DELETE(deleteRequest({ id: "fb-1", projectName: "test" }));
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("startup guard in production", () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it("throws when NODE_ENV=production and apiKey is missing", () => {
+      process.env.NODE_ENV = "production";
+      expect(() => createSitepingHandler({ prisma })).toThrow(/apiKey is required in production/);
+    });
+
+    it("does not throw when apiKey is provided in production", () => {
+      process.env.NODE_ENV = "production";
+      expect(() => createSitepingHandler({ prisma, apiKey: API_KEY })).not.toThrow();
+    });
+
+    it("does not throw in production when requireAuthForDestructive=false (delegated auth)", () => {
+      process.env.NODE_ENV = "production";
+      expect(() => createSitepingHandler({ prisma, requireAuthForDestructive: false })).not.toThrow();
     });
   });
 });
@@ -324,6 +369,7 @@ describe("CORS", () => {
       const handler = createSitepingHandler({
         prisma,
         allowedOrigins: [ALLOWED_ORIGIN],
+        requireAuthForDestructive: false,
       });
       const res = await handler.PATCH(
         patchRequest({ id: "fb-1", projectName: "test", status: "resolved" }, { Origin: ALLOWED_ORIGIN }),
@@ -337,6 +383,7 @@ describe("CORS", () => {
       const handler = createSitepingHandler({
         prisma,
         allowedOrigins: [ALLOWED_ORIGIN],
+        requireAuthForDestructive: false,
       });
       const res = await handler.DELETE(deleteRequest({ id: "fb-1", projectName: "test" }, { Origin: ALLOWED_ORIGIN }));
 

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -31,7 +31,9 @@ describe("createSitepingHandler", () => {
 
   beforeEach(() => {
     prisma = mockPrisma();
-    handler = createSitepingHandler({ prisma });
+    // These tests focus on validation/persistence/error paths; the destructive-op
+    // auth gate is exercised in auth-cors.test.ts.
+    handler = createSitepingHandler({ prisma, requireAuthForDestructive: false });
   });
 
   describe("POST", () => {

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -364,6 +364,20 @@ export interface HandlerOptions {
    * auto-detection and per-provider semantics.
    */
   caseInsensitiveSearch?: boolean;
+  /**
+   * Whether destructive endpoints (DELETE, PATCH) require `apiKey`.
+   *
+   * Defaults to `true` and intentionally cannot be disabled in production:
+   * - `NODE_ENV === "production"` without `apiKey` throws at startup. The
+   *   factory refuses to return an unauthenticated destructive surface.
+   * - `NODE_ENV !== "production"` without `apiKey` keeps the handler running
+   *   for local dev/tests, but DELETE/PATCH return 401 until you set
+   *   `apiKey` or explicitly opt out with `requireAuthForDestructive: false`.
+   *
+   * Set to `false` only when you wrap `createSitepingHandler` in your own
+   * auth middleware (session, OAuth, etc.) and want SitePing to stay open.
+   */
+  requireAuthForDestructive?: boolean;
 }
 
 /**
@@ -464,9 +478,20 @@ export function createSitepingHandler({
   publicEndpoints = apiKey ? ["POST", "OPTIONS"] : undefined,
   allowedOrigins,
   caseInsensitiveSearch,
+  requireAuthForDestructive = true,
 }: HandlerOptions): SitepingHandler {
   if (!providedStore && !prisma) {
     throw new Error("[siteping] createSitepingHandler requires either `store` or `prisma`.");
+  }
+
+  // Refuse to expose destructive endpoints publicly in production. Without
+  // this guard, anyone could `DELETE { deleteAll: true }` against the API.
+  if (!apiKey && requireAuthForDestructive && process.env.NODE_ENV === "production") {
+    throw new Error(
+      "[siteping] adapter-prisma: apiKey is required in production. " +
+        "Set `apiKey` to enable destructive endpoints, or pass " +
+        "`requireAuthForDestructive: false` if SitePing sits behind your own auth middleware.",
+    );
   }
 
   // Safe: the throw above guarantees at least one is defined
@@ -481,7 +506,14 @@ export function createSitepingHandler({
 
   /** Verify Bearer token when apiKey is configured. Skips methods listed in `publicEndpoints`. */
   function authenticate(request: Request, method: string): Response | null {
-    if (!apiKey) return null;
+    if (!apiKey) {
+      // No apiKey + destructive method + guard enabled → reject. GET/POST/OPTIONS
+      // stay open by default so the widget keeps working in dev without config.
+      if (requireAuthForDestructive && (method === "DELETE" || method === "PATCH")) {
+        return Response.json({ error: "apiKey required for destructive operations" }, { status: 401 });
+      }
+      return null;
+    }
     if (publicMethods?.has(method as "GET" | "POST" | "PATCH" | "DELETE" | "OPTIONS")) return null;
     const header = request.headers.get("Authorization");
     if (!header || !safeCompare(header, `Bearer ${apiKey}`)) {


### PR DESCRIPTION
## Why
Without an `apiKey`, anyone could `DELETE { deleteAll: true }` anonymously and wipe a project's feedbacks. The factory was happily handing out an unauthenticated destructive surface.

## What
- `requireAuthForDestructive: true` is the new default.
- `NODE_ENV === "production"` **throws at startup** if `apiKey` is missing — the factory refuses to return an unauthenticated handler.
- Dev mode (`NODE_ENV !== "production"`) keeps the handler running but DELETE/PATCH return 401 until `apiKey` is set.
- Opt-out via `requireAuthForDestructive: false` for setups that wrap the handler in their own auth middleware (session, OAuth, etc.).

## Tests
- 8 new tests in `auth-cors.test.ts` cover the throw / 401 / opt-out paths.
- All existing 1306 tests still green.

## Notes
- Severity: CVE-grade hardening. Existing self-hosted users without `apiKey` will need to set one (or opt out explicitly).
- `SECURITY.md` updated.
- See companion fix `fix/security-clientid-path-traversal` (separate PR).