### PR TITLE
chore(release): mark @siteping/core as internal

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
-  "packages/core": "0.7.2",
   "packages/widget": "0.9.7",
   "packages/adapter-prisma": "0.4.5",
   "packages/adapter-memory": "0.4.4",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ## Architecture
 - **Monorepo** with bun workspaces — 6 packages in `packages/`:
-  - `@siteping/core` — shared types, schema, store errors + helpers (internal, not published)
+  - `@siteping/core` — shared types, schema, store errors + helpers (internal, not published, no release-please entry, no npm publish job)
   - `@siteping/widget` — browser feedback widget (Shadow DOM, closed mode). Accepts `store` option for client-side mode (no server needed)
   - `@siteping/adapter-prisma` — server-side Prisma request handlers
   - `@siteping/adapter-memory` — in-memory adapter (testing, demos, serverless)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,11 +12,6 @@
     { "type": "chore", "section": "Miscellaneous" }
   ],
   "packages": {
-    "packages/core": {
-      "release-type": "node",
-      "component": "core",
-      "bump-minor-pre-major": true
-    },
     "packages/widget": {
       "release-type": "node",
       "component": "widget",


### PR DESCRIPTION
## Why
\`release-please-config.json\` declared \`packages/core\` but \`.github/workflows/release.yml\` had no \`publish-core\` job and the build artifact didn't include \`packages/core/dist/\`. Release-please would have opened core PRs that could never publish.

## What
- Remove \`packages/core\` from \`release-please-config.json\` and \`.release-please-manifest.json\`.
- Clarify in \`CLAUDE.md\` that core is internal (\`private: true\`, bundled via \`noExternal\` into every consumer).