### PR TITLE
feat(adapter-prisma): webhooks for Slack, Discord, and generic endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,59 @@ widget.off('feedback:sent', handler)
 
 ---
 
+## Notifications
+
+Fire a Slack, Discord, or generic HTTP webhook every time a feedback is created — useful for surfacing client feedback in the team channel without leaving the chat.
+
+```ts
+// app/api/siteping/route.ts
+import { createSitepingHandler } from '@siteping/adapter-prisma'
+import { prisma } from '@/lib/prisma'
+
+export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
+  prisma,
+  webhooks: [
+    {
+      url: process.env.SLACK_WEBHOOK_URL!,
+      type: 'slack',
+    },
+    {
+      url: process.env.DISCORD_WEBHOOK_URL!,
+      type: 'discord',
+    },
+  ],
+})
+```
+
+You can pass a single config or an array. Each entry accepts:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `url` | `string` | **Required.** Endpoint to POST to (Slack/Discord incoming webhook, or your own). |
+| `type` | `'slack' \| 'discord' \| 'generic'` | Payload format. Defaults to `'generic'` (raw `FeedbackRecord` JSON). |
+| `headers` | `Record<string, string>` | Extra headers merged on top of `Content-Type: application/json` (sign payloads, add bearer tokens, …). |
+| `timeoutMs` | `number` | Abort after this many ms. Defaults to `5000`. |
+| `onError` | `(err, feedbackId) => void` | Observe delivery failures (network error, non-2xx, timeout). Without it, errors land in `console.warn`. |
+
+**Behaviour**
+
+- **Fire-and-forget.** The widget gets its `201` response before any webhook is awaited — a slow Slack response never blocks the user.
+- **Per-webhook isolation.** One failing receiver does not stop the others.
+- **Generic payload.** When `type` is omitted, the body is the full feedback record — wire your own formatter (Microsoft Teams, Mattermost, custom dashboard, …).
+
+```ts
+// Generic receiver — verify signatures, persist to your own queue, etc.
+webhooks: [
+  {
+    url: 'https://my-server.example.com/notify',
+    headers: { 'X-Signature': process.env.WEBHOOK_SECRET! },
+    onError: (err, id) => logger.warn({ err, feedbackId: id }, 'webhook failed'),
+  },
+]
+```
+
+---
+
 ## API Reference
 
 ### Server adapter
@@ -441,13 +494,13 @@ This migration is safe for all supported databases (PostgreSQL, MySQL, SQLite): 
 - ✅ Client-side store mode (no server needed)
 - ✅ In-memory + localStorage adapters
 - ✅ Adapter conformance test suite (22 tests, shared across adapters)
+- ✅ Webhook notifications (Slack, Discord, generic HTTP) — see [Notifications](#notifications)
 
 **Up next**
 
 - 🚧 Drizzle adapter — [help wanted](https://github.com/NeosiaNexus/SitePing/labels/help%20wanted)
 - 🚧 Framework example apps (Astro, SvelteKit, Nuxt) — [good first issues](https://github.com/NeosiaNexus/SitePing/labels/good%20first%20issue)
 - 🚧 MutationObserver for SPA re-anchoring
-- 🚧 Webhook notifications (Discord, Slack)
 
 **Planned**
 

--- a/apps/demo/src/app/api/siteping/route.ts
+++ b/apps/demo/src/app/api/siteping/route.ts
@@ -1,6 +1,16 @@
 import { createSitepingHandler } from "@siteping/adapter-prisma";
 import { memoryStore } from "@/lib/memory-store";
 
+// Webhook notifications — uncomment to ping Slack/Discord on each new feedback.
+// (Self-hosted demos: drop your incoming webhook URL into the env and you're done.)
+//
+// const SLACK_WEBHOOK = process.env.SITEPING_SLACK_WEBHOOK;
+// const DISCORD_WEBHOOK = process.env.SITEPING_DISCORD_WEBHOOK;
+
 export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
   store: memoryStore,
+  // webhooks: [
+  //   ...(SLACK_WEBHOOK ? [{ url: SLACK_WEBHOOK, type: "slack" as const }] : []),
+  //   ...(DISCORD_WEBHOOK ? [{ url: DISCORD_WEBHOOK, type: "discord" as const }] : []),
+  // ],
 });

--- a/packages/adapter-prisma/__tests__/webhooks.test.ts
+++ b/packages/adapter-prisma/__tests__/webhooks.test.ts
@@ -143,9 +143,7 @@ describe("dispatchWebhook", () => {
   it("invokes onError on a 500 response and does not throw", async () => {
     fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 500 }));
     const onError = vi.fn();
-    await expect(
-      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
-    ).resolves.toBeUndefined();
+    await expect(dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK)).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledOnce();
     const [err, id] = onError.mock.calls[0] as [Error, string];
     expect(err).toBeInstanceOf(Error);
@@ -156,9 +154,7 @@ describe("dispatchWebhook", () => {
   it("invokes onError on a network failure and does not throw", async () => {
     fetchSpy.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     const onError = vi.fn();
-    await expect(
-      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
-    ).resolves.toBeUndefined();
+    await expect(dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK)).resolves.toBeUndefined();
     expect(onError).toHaveBeenCalledOnce();
     expect((onError.mock.calls[0] as [Error, string])[0].message).toBe("Failed to fetch");
   });
@@ -188,10 +184,7 @@ describe("dispatchWebhook", () => {
 
     vi.useFakeTimers();
     const onError = vi.fn();
-    const promise = dispatchWebhook(
-      { url: "https://hooks.example.com", timeoutMs: 50, onError },
-      FEEDBACK,
-    );
+    const promise = dispatchWebhook({ url: "https://hooks.example.com", timeoutMs: 50, onError }, FEEDBACK);
     await vi.advanceTimersByTimeAsync(60);
     await promise;
     vi.useRealTimers();
@@ -205,9 +198,7 @@ describe("dispatchWebhook", () => {
     const onError = vi.fn(() => {
       throw new Error("user bug");
     });
-    await expect(
-      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
-    ).resolves.toBeUndefined();
+    await expect(dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK)).resolves.toBeUndefined();
     // The thrown user error is reported via console.warn so it isn't swallowed.
     expect(warnSpy).toHaveBeenCalledOnce();
     expect(String(warnSpy.mock.calls[0]?.[0])).toContain("user bug");

--- a/packages/adapter-prisma/__tests__/webhooks.test.ts
+++ b/packages/adapter-prisma/__tests__/webhooks.test.ts
@@ -1,0 +1,335 @@
+import type { FeedbackRecord } from "@siteping/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSitepingHandler } from "../src/index.js";
+import { buildWebhookPayload, dispatchWebhook, dispatchWebhooks, type WebhookConfig } from "../src/webhooks.js";
+import { validPayloadNoAnnotations } from "./fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const FEEDBACK: FeedbackRecord = {
+  id: "fb-test-1",
+  projectName: "test-project",
+  type: "bug",
+  message: "The button overlaps the modal close icon",
+  status: "open",
+  url: "https://example.com/orders/42",
+  urlPattern: "/orders/:orderId",
+  viewport: "1920x1080",
+  userAgent: "Mozilla/5.0",
+  authorName: "Alice",
+  authorEmail: "alice@example.com",
+  clientId: "client-uuid-1",
+  resolvedAt: null,
+  createdAt: new Date("2026-05-14T10:00:00Z"),
+  updatedAt: new Date("2026-05-14T10:00:00Z"),
+  annotations: [],
+  screenshotUrl: null,
+};
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(new Response("", { status: 200 }));
+  globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Payload formatting
+// ---------------------------------------------------------------------------
+
+describe("buildWebhookPayload", () => {
+  it("formats Slack payload with blocks + text fallback", () => {
+    const payload = buildWebhookPayload("slack", FEEDBACK) as {
+      text: string;
+      blocks: Array<{ type: string }>;
+    };
+    expect(payload.text).toContain("Alice");
+    expect(payload.text).toContain("bug");
+    expect(payload.text).toContain("The button overlaps");
+    expect(Array.isArray(payload.blocks)).toBe(true);
+    expect(payload.blocks.length).toBeGreaterThan(0);
+    expect(payload.blocks[0]).toEqual(expect.objectContaining({ type: "header" }));
+  });
+
+  it("formats Discord payload with content + embed", () => {
+    const payload = buildWebhookPayload("discord", FEEDBACK) as {
+      content: string;
+      embeds: Array<{ title: string; description: string; color: number }>;
+    };
+    expect(payload.content).toContain("Alice");
+    expect(payload.content).toContain("bug");
+    expect(payload.embeds[0]?.title).toContain("test-project");
+    expect(payload.embeds[0]?.description).toContain("button overlaps");
+    // Bug type maps to the red palette colour.
+    expect(payload.embeds[0]?.color).toBe(0xef4444);
+  });
+
+  it("returns raw feedback as generic payload", () => {
+    const payload = buildWebhookPayload("generic", FEEDBACK);
+    expect(payload).toBe(FEEDBACK);
+  });
+
+  it("truncates excessively long messages for chat platforms", () => {
+    const long = { ...FEEDBACK, message: "x".repeat(2000) };
+    const slack = buildWebhookPayload("slack", long) as { text: string };
+    const discord = buildWebhookPayload("discord", long) as { embeds: Array<{ description: string }> };
+    // Headline + ': ' prefix + 300 char preview (with ellipsis) — stays
+    // well below Slack's 3000-char block limit.
+    expect(slack.text.length).toBeLessThan(500);
+    expect(discord.embeds[0]?.description.length).toBeLessThan(500);
+    expect(discord.embeds[0]?.description.endsWith("…")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchWebhook — golden + edge cases
+// ---------------------------------------------------------------------------
+
+describe("dispatchWebhook", () => {
+  it("POSTs Slack payload to the configured URL", async () => {
+    await dispatchWebhook({ url: "https://hooks.slack.com/T/B/X", type: "slack" }, FEEDBACK);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe("https://hooks.slack.com/T/B/X");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    const sent = JSON.parse(init.body as string) as { text: string };
+    expect(sent.text).toContain("Alice");
+  });
+
+  it("POSTs Discord payload to the configured URL", async () => {
+    await dispatchWebhook({ url: "https://discord.com/api/webhooks/x", type: "discord" }, FEEDBACK);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const sent = JSON.parse(init.body as string) as { content: string; embeds: unknown[] };
+    expect(sent.content).toContain("bug");
+    expect(sent.embeds).toHaveLength(1);
+  });
+
+  it("POSTs raw feedback as generic JSON by default", async () => {
+    await dispatchWebhook({ url: "https://hooks.example.com" }, FEEDBACK);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    const sent = JSON.parse(init.body as string) as { id: string; type: string };
+    expect(sent.id).toBe(FEEDBACK.id);
+    expect(sent.type).toBe("bug");
+  });
+
+  it("merges custom headers on top of Content-Type default", async () => {
+    await dispatchWebhook(
+      {
+        url: "https://hooks.example.com",
+        headers: { "X-Signature": "abc", Authorization: "Bearer xyz" },
+      },
+      FEEDBACK,
+    );
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      "X-Signature": "abc",
+      Authorization: "Bearer xyz",
+    });
+  });
+
+  it("invokes onError on a 500 response and does not throw", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+    const onError = vi.fn();
+    await expect(
+      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
+    ).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledOnce();
+    const [err, id] = onError.mock.calls[0] as [Error, string];
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/500/);
+    expect(id).toBe(FEEDBACK.id);
+  });
+
+  it("invokes onError on a network failure and does not throw", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const onError = vi.fn();
+    await expect(
+      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
+    ).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledOnce();
+    expect((onError.mock.calls[0] as [Error, string])[0].message).toBe("Failed to fetch");
+  });
+
+  it("falls back to console.warn when no onError is provided", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 502 }));
+    await dispatchWebhook({ url: "https://hooks.example.com" }, FEEDBACK);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("502");
+  });
+
+  it("aborts the fetch when the per-webhook timeout elapses", async () => {
+    // Spy on fetch so we observe the signal and never resolve.
+    let abortReason: unknown;
+    fetchSpy.mockImplementationOnce(
+      (_url: RequestInfo, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init.signal as AbortSignal;
+          signal.addEventListener("abort", () => {
+            abortReason = signal.reason;
+            // Match real fetch behaviour: rejects with a DOMException-like
+            // AbortError when aborted.
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        }),
+    );
+
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const promise = dispatchWebhook(
+      { url: "https://hooks.example.com", timeoutMs: 50, onError },
+      FEEDBACK,
+    );
+    await vi.advanceTimersByTimeAsync(60);
+    await promise;
+    vi.useRealTimers();
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(abortReason).toBeDefined();
+  });
+
+  it("does not throw when the user-supplied onError itself throws", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("boom"));
+    const onError = vi.fn(() => {
+      throw new Error("user bug");
+    });
+    await expect(
+      dispatchWebhook({ url: "https://hooks.example.com", onError }, FEEDBACK),
+    ).resolves.toBeUndefined();
+    // The thrown user error is reported via console.warn so it isn't swallowed.
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("user bug");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchWebhooks — parallelism
+// ---------------------------------------------------------------------------
+
+describe("dispatchWebhooks", () => {
+  it("dispatches every configured webhook in parallel", async () => {
+    let resolveCount = 0;
+    fetchSpy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          // Tiny stagger to make sure they're actually concurrent — if these
+          // ran sequentially, the sum of delays would exceed any single one.
+          setTimeout(() => {
+            resolveCount++;
+            resolve(new Response("", { status: 200 }));
+          }, 20);
+        }),
+    );
+
+    const start = Date.now();
+    await dispatchWebhooks(
+      [
+        { url: "https://slack.example.com", type: "slack" },
+        { url: "https://discord.example.com", type: "discord" },
+        { url: "https://generic.example.com" },
+      ],
+      FEEDBACK,
+    );
+    const elapsed = Date.now() - start;
+
+    expect(resolveCount).toBe(3);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    // 3 × 20ms sequentially would be >= 60ms; in parallel it should land
+    // well below 60ms. Generous bound to avoid flakes on CI.
+    expect(elapsed).toBeLessThan(120);
+  });
+
+  it("returns immediately when no webhooks are configured", async () => {
+    await dispatchWebhooks([], FEEDBACK);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler integration — webhook fires after successful POST
+// ---------------------------------------------------------------------------
+
+function mockPrisma() {
+  const fbRecord = { ...FEEDBACK, createdAt: new Date(), updatedAt: new Date() };
+  return {
+    sitepingFeedback: {
+      create: vi.fn().mockResolvedValue(fbRecord),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue(fbRecord),
+      delete: vi.fn().mockResolvedValue({ id: fbRecord.id }),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  };
+}
+
+describe("createSitepingHandler — webhooks option", () => {
+  it("dispatches a single webhook after a successful POST", async () => {
+    const prisma = mockPrisma();
+    const webhook: WebhookConfig = { url: "https://hooks.example.com" };
+    const handler = createSitepingHandler({ prisma, webhooks: webhook });
+
+    const req = new Request("http://localhost/api/siteping", {
+      method: "POST",
+      body: JSON.stringify(validPayloadNoAnnotations),
+    });
+    const res = await handler.POST(req);
+    expect(res.status).toBe(201);
+
+    // Wait one microtask tick for the fire-and-forget dispatch to fire.
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce());
+  });
+
+  it("dispatches every webhook in an array config", async () => {
+    const prisma = mockPrisma();
+    const handler = createSitepingHandler({
+      prisma,
+      webhooks: [
+        { url: "https://slack.example.com", type: "slack" },
+        { url: "https://discord.example.com", type: "discord" },
+      ],
+    });
+
+    const req = new Request("http://localhost/api/siteping", {
+      method: "POST",
+      body: JSON.stringify(validPayloadNoAnnotations),
+    });
+    await handler.POST(req);
+
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    const urls = fetchSpy.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("https://slack.example.com");
+    expect(urls).toContain("https://discord.example.com");
+  });
+
+  it("does not fire webhooks when POST fails validation", async () => {
+    const prisma = mockPrisma();
+    const handler = createSitepingHandler({
+      prisma,
+      webhooks: { url: "https://hooks.example.com" },
+    });
+
+    const req = new Request("http://localhost/api/siteping", {
+      method: "POST",
+      body: JSON.stringify({ type: "bug" }), // missing required fields
+    });
+    const res = await handler.POST(req);
+    expect(res.status).toBe(400);
+    // Give any erroneous fire-and-forget a chance to run before asserting.
+    await Promise.resolve();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -17,6 +17,7 @@ import {
   formatValidationErrors,
   getQuerySchema,
 } from "./validation.js";
+import { dispatchWebhooks, type WebhookConfig } from "./webhooks.js";
 
 export type { ScreenshotStorage, SitepingStore } from "@siteping/core";
 export { flattenAnnotation, StoreDuplicateError, StoreNotFoundError } from "@siteping/core";
@@ -26,6 +27,8 @@ export type {
   FeedbackPatchInput,
   GetQueryInput,
 } from "./validation.js";
+export type { WebhookConfig } from "./webhooks.js";
+export { dispatchWebhook, dispatchWebhooks } from "./webhooks.js";
 
 // ---------------------------------------------------------------------------
 // Minimal PrismaClient shape expected by this adapter
@@ -364,6 +367,16 @@ export interface HandlerOptions {
    * auto-detection and per-provider semantics.
    */
   caseInsensitiveSearch?: boolean;
+  /**
+   * Outgoing webhooks fired after a feedback is successfully persisted.
+   *
+   * Pass a single config or an array — every entry receives a POST with a
+   * type-specific payload (Slack, Discord, or generic JSON). Dispatch is
+   * fire-and-forget: the HTTP response is returned to the widget before
+   * webhook delivery completes, so a slow receiver never blocks the client.
+   * Provide `onError` on each config to observe failures.
+   */
+  webhooks?: WebhookConfig | WebhookConfig[];
 }
 
 /**
@@ -464,6 +477,7 @@ export function createSitepingHandler({
   publicEndpoints = apiKey ? ["POST", "OPTIONS"] : undefined,
   allowedOrigins,
   caseInsensitiveSearch,
+  webhooks,
 }: HandlerOptions): SitepingHandler {
   if (!providedStore && !prisma) {
     throw new Error("[siteping] createSitepingHandler requires either `store` or `prisma`.");
@@ -478,6 +492,10 @@ export function createSitepingHandler({
     });
 
   const publicMethods = publicEndpoints ? new Set(publicEndpoints) : null;
+
+  // Normalise the webhook config to an array once so every POST avoids the
+  // allocation. Empty array short-circuits `dispatchWebhooks` cheaply.
+  const webhookList: WebhookConfig[] = webhooks ? (Array.isArray(webhooks) ? webhooks : [webhooks]) : [];
 
   /** Verify Bearer token when apiKey is configured. Skips methods listed in `publicEndpoints`. */
   function authenticate(request: Request, method: string): Response | null {
@@ -538,6 +556,13 @@ export function createSitepingHandler({
           annotations: data.annotations.map(flattenAnnotation),
           screenshotDataUrl: data.screenshotDataUrl ?? null,
         });
+
+        // Fire-and-forget: drop the promise so the widget isn't held back
+        // on slow Slack/Discord/generic receivers. `dispatchWebhooks` traps
+        // its own errors and reports them through `WebhookConfig.onError`.
+        if (webhookList.length > 0) {
+          void dispatchWebhooks(webhookList, feedback);
+        }
 
         return withCors(Response.json(feedback, { status: 201 }), corsHeaders);
       } catch (error) {

--- a/packages/adapter-prisma/src/webhooks.ts
+++ b/packages/adapter-prisma/src/webhooks.ts
@@ -184,10 +184,7 @@ function reportError(config: WebhookConfig, err: Error, feedbackId: string): voi
  * promise on the floor (`void dispatchWebhooks(...)`) so the HTTP response
  * isn't held back on slow receivers.
  */
-export async function dispatchWebhooks(
-  configs: readonly WebhookConfig[],
-  feedback: FeedbackRecord,
-): Promise<void> {
+export async function dispatchWebhooks(configs: readonly WebhookConfig[], feedback: FeedbackRecord): Promise<void> {
   if (configs.length === 0) return;
   await Promise.all(configs.map((c) => dispatchWebhook(c, feedback)));
 }

--- a/packages/adapter-prisma/src/webhooks.ts
+++ b/packages/adapter-prisma/src/webhooks.ts
@@ -1,0 +1,193 @@
+/**
+ * Outgoing webhook notifications for newly-created feedbacks.
+ *
+ * Plug a Slack, Discord, or generic HTTP endpoint into `createSitepingHandler`
+ * to receive a payload whenever a feedback is successfully persisted. Webhooks
+ * are dispatched as fire-and-forget (`void Promise.all(...)`) so a slow or
+ * down receiver never blocks the client response — the feedback is already in
+ * the DB by the time we dial out.
+ *
+ * - **Type-specific formatting**: Slack uses `{ text, blocks }`, Discord uses
+ *   `{ content, embeds }`, generic uses the raw `FeedbackRecord` JSON.
+ * - **Timeout**: 5s by default (overridable per webhook).
+ * - **Error handling**: `config.onError(err, feedback.id)` is invoked when
+ *   present; otherwise we log a one-liner to `console.warn` so the issue is
+ *   surfaced without crashing the request.
+ */
+
+import type { FeedbackRecord } from "@siteping/core";
+
+/**
+ * Outgoing webhook configuration.
+ *
+ * - `url` — required, the HTTPS endpoint to POST to.
+ * - `type` — payload format. Defaults to `"generic"` (raw JSON).
+ * - `headers` — extra headers merged on top of `Content-Type: application/json`.
+ *   Useful for signed-payload schemes (`X-Signature`, bearer tokens, …).
+ * - `timeoutMs` — abort the fetch after this many ms. Defaults to 5000.
+ * - `onError` — invoked with the underlying error and the feedback id when
+ *   the dispatch fails (network error, non-2xx, timeout). The webhook is
+ *   fire-and-forget, so this is your only chance to observe failures.
+ */
+export interface WebhookConfig {
+  url: string;
+  type?: "slack" | "discord" | "generic";
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  onError?: (err: Error, feedbackId: string) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/** Truncate a message for chat-platform previews (Slack/Discord look bad with walls of text). */
+function truncate(text: string, max = 300): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+/** Slack message: text fallback + Block Kit blocks for rich rendering. */
+function buildSlackPayload(feedback: FeedbackRecord): unknown {
+  const preview = truncate(feedback.message);
+  const headline = `New ${feedback.type} feedback from ${feedback.authorName}`;
+  return {
+    text: `${headline}: ${preview}`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: headline, emoji: true },
+      },
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: preview },
+      },
+      {
+        type: "context",
+        elements: [
+          { type: "mrkdwn", text: `*Project:* ${feedback.projectName}` },
+          { type: "mrkdwn", text: `*Type:* ${feedback.type}` },
+          { type: "mrkdwn", text: `*URL:* ${feedback.url}` },
+          { type: "mrkdwn", text: `*From:* ${feedback.authorName} <${feedback.authorEmail}>` },
+        ],
+      },
+    ],
+  };
+}
+
+/** Discord message: content fallback + embed for rich rendering. */
+function buildDiscordPayload(feedback: FeedbackRecord): unknown {
+  const preview = truncate(feedback.message);
+  // Discord embed colors are decimal RGB. Map feedback types to a fixed palette
+  // so receivers can colour-code at a glance.
+  const COLOR: Record<string, number> = {
+    bug: 0xef4444,
+    question: 0x3b82f6,
+    change: 0xf59e0b,
+    other: 0x6b7280,
+  };
+  return {
+    content: `New **${feedback.type}** feedback from **${feedback.authorName}**`,
+    embeds: [
+      {
+        title: `${feedback.type} — ${feedback.projectName}`,
+        description: preview,
+        color: COLOR[feedback.type] ?? 0x6b7280,
+        fields: [
+          { name: "URL", value: feedback.url, inline: false },
+          { name: "Author", value: `${feedback.authorName} (${feedback.authorEmail})`, inline: true },
+          { name: "Viewport", value: feedback.viewport, inline: true },
+        ],
+        timestamp: new Date(feedback.createdAt).toISOString(),
+      },
+    ],
+  };
+}
+
+/**
+ * Build the JSON body for a single webhook based on its `type`.
+ * Exported for tests; not part of the public API.
+ *
+ * @internal
+ */
+export function buildWebhookPayload(type: WebhookConfig["type"], feedback: FeedbackRecord): unknown {
+  switch (type) {
+    case "slack":
+      return buildSlackPayload(feedback);
+    case "discord":
+      return buildDiscordPayload(feedback);
+    default:
+      return feedback;
+  }
+}
+
+/**
+ * Dispatch a single webhook. Fire-and-forget: never throws, never rejects.
+ *
+ * - Builds the type-specific payload.
+ * - POSTs with an `AbortSignal` timeout.
+ * - On any error (network, non-2xx, timeout, exception), invokes
+ *   `config.onError(err, feedbackId)` if provided; otherwise logs a one-liner.
+ */
+export async function dispatchWebhook(config: WebhookConfig, feedback: FeedbackRecord): Promise<void> {
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const body = JSON.stringify(buildWebhookPayload(config.type ?? "generic", feedback));
+
+  // Build merged headers — caller-supplied entries override `Content-Type`
+  // when they explicitly need a different mime (rare for chat webhooks, but
+  // possible for some generic receivers).
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...(config.headers ?? {}) };
+
+  // Use AbortSignal.timeout when available (Node 17.3+, all modern browsers).
+  // Fall back to a manual controller for environments lacking it.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(config.url, {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const err = new Error(`Webhook responded with HTTP ${response.status}`);
+      reportError(config, err, feedback.id);
+    }
+  } catch (rawError) {
+    clearTimeout(timer);
+    const err = rawError instanceof Error ? rawError : new Error(String(rawError));
+    reportError(config, err, feedback.id);
+  }
+}
+
+function reportError(config: WebhookConfig, err: Error, feedbackId: string): void {
+  if (config.onError) {
+    try {
+      config.onError(err, feedbackId);
+    } catch (callbackErr) {
+      // Defense-in-depth: a thrown user callback must not bubble back up
+      // and crash the request that already succeeded persisting the
+      // feedback. Surface the original error too so it isn't silently lost.
+      console.warn(
+        `[siteping] webhook onError() callback threw for feedback ${feedbackId}: ${String(callbackErr)} (original error: ${err.message})`,
+      );
+    }
+    return;
+  }
+  console.warn(`[siteping] webhook to ${config.url} failed for feedback ${feedbackId}: ${err.message}`);
+}
+
+/**
+ * Dispatch every configured webhook in parallel. Awaiting the returned promise
+ * lets tests synchronize on completion, but production callers should drop the
+ * promise on the floor (`void dispatchWebhooks(...)`) so the HTTP response
+ * isn't held back on slow receivers.
+ */
+export async function dispatchWebhooks(
+  configs: readonly WebhookConfig[],
+  feedback: FeedbackRecord,
+): Promise<void> {
+  if (configs.length === 0) return;
+  await Promise.all(configs.map((c) => dispatchWebhook(c, feedback)));
+}


### PR DESCRIPTION
## Why
On the public roadmap. Lets self-hosters surface feedback in their team channel without leaving Slack/Discord.

## What
\`\`\`ts
createSitepingHandler({
  prisma,
  webhooks: [
    { url: process.env.SLACK_WEBHOOK!, type: 'slack' },
    { url: process.env.DISCORD_WEBHOOK!, type: 'discord' },
  ],
})
\`\`\`
- New \`packages/adapter-prisma/src/webhooks.ts\` with \`dispatchWebhook\` / \`dispatchWebhooks\`.
- Three payload formats: \`slack\`, \`discord\`, \`generic\` (raw \`FeedbackRecord\`).
- Fire-and-forget — the widget gets its 201 before any webhook is awaited.
- Per-webhook \`timeoutMs\` (default 5s), \`headers\`, \`onError\` callbacks.
- One failing receiver doesn't stop the others.

## Tests
18 new tests: Slack/Discord/generic shapes, timeout abort, multi-headers, onError on 5xx + network error, parallelism, end-to-end through the handler.

## Docs
README \`Notifications\` section added.