### PR TITLE
feat(widget): add useSiteping() React hook with StrictMode-safe lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,25 +90,35 @@ npx prisma db push
 
 ### 3. Add the widget
 
-```tsx
-// app/layout.tsx (or any client component)
-'use client'
+#### React (recommended)
 
-import { initSiteping } from '@siteping/widget'
-import { useEffect } from 'react'
+```tsx
+"use client"
+
+import { useSiteping } from "@siteping/widget/react"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    const { destroy } = initSiteping({
-      endpoint: '/api/siteping',
-      projectName: 'my-project',
-    })
-    return destroy
-  }, [])
-
-  return <html><body>{children}</body></html>
+  useSiteping({
+    endpoint: "/api/siteping",
+    projectName: "my-app",
+  })
+  return <>{children}</>
 }
 ```
+
+The `useSiteping` hook handles StrictMode double-mounts safely and tears the widget down on unmount. It returns the live instance so you can drive it programmatically from anywhere:
+
+```tsx
+"use client"
+import { useSiteping } from "@siteping/widget/react"
+
+export function HelpButton() {
+  const widget = useSiteping({ endpoint: "/api/siteping", projectName: "my-app" })
+  return <button onClick={() => widget?.open()}>Need help?</button>
+}
+```
+
+React is declared as an optional peer dep — installing `@siteping/widget` alone won't pull React in, and the `/react` entry only resolves when you actually import it.
 
 #### Vanilla JS / Any framework
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,21 +39,21 @@
     },
     "packages/adapter-localstorage": {
       "name": "@siteping/adapter-localstorage",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "devDependencies": {
         "@siteping/core": "workspace:*",
       },
     },
     "packages/adapter-memory": {
       "name": "@siteping/adapter-memory",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "devDependencies": {
         "@siteping/core": "workspace:*",
       },
     },
     "packages/adapter-prisma": {
       "name": "@siteping/adapter-prisma",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "zod": "^3.24.0",
       },
@@ -66,7 +66,7 @@
     },
     "packages/cli": {
       "name": "@siteping/cli",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "bin": {
         "siteping": "./dist/index.js",
       },
@@ -79,18 +79,29 @@
     },
     "packages/core": {
       "name": "@siteping/core",
-      "version": "0.7.1",
+      "version": "0.7.2",
     },
     "packages/widget": {
       "name": "@siteping/widget",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
       "devDependencies": {
         "@medv/finder": "^3.2.0",
         "@siteping/core": "workspace:*",
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
       },
+      "peerDependencies": {
+        "react": ">=18",
+      },
+      "optionalPeers": [
+        "react",
+      ],
     },
   },
   "packages": {
@@ -127,6 +138,8 @@
     "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
 
     "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -440,6 +453,10 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q=="],
@@ -453,6 +470,8 @@
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
 
     "@types/argparse": ["@types/argparse@1.0.38", "", {}, "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -490,13 +509,15 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -556,9 +577,13 @@
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
@@ -690,6 +715,8 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
@@ -746,11 +773,15 @@
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -924,6 +955,10 @@
 
     "@rushstack/terminal/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
+    "@siteping/widget/react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "@siteping/widget/react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
@@ -952,11 +987,13 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -972,11 +1009,7 @@
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/packages/widget/__tests__/widget/react.test.tsx
+++ b/packages/widget/__tests__/widget/react.test.tsx
@@ -170,9 +170,7 @@ describe("useSiteping", () => {
 
   it("ignores destroyed widget events (cleanup unsubscribes)", () => {
     const onOpen = vi.fn();
-    const { unmount } = render(
-      <Probe config={{ endpoint: "/api/x", projectName: "p", onOpen }} />,
-    );
+    const { unmount } = render(<Probe config={{ endpoint: "/api/x", projectName: "p", onOpen }} />);
     const inst = mockInstances[0]!;
     unmount();
     // Even if a stray event fires after unmount, the user callback never runs.

--- a/packages/widget/__tests__/widget/react.test.tsx
+++ b/packages/widget/__tests__/widget/react.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import type { SitepingConfig, SitepingInstance } from "@siteping/core";
+import { act, render } from "@testing-library/react";
+import { StrictMode, useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock `initSiteping` so we can observe call count, capture listeners, and
+// drive them directly without needing the full widget DOM.
+// ---------------------------------------------------------------------------
+
+type Listener = (...args: unknown[]) => void;
+
+interface MockedInstance extends SitepingInstance {
+  __emit: (event: string, ...args: unknown[]) => void;
+  __destroyed: boolean;
+}
+
+let mockInstances: MockedInstance[] = [];
+let initSpy: ReturnType<typeof vi.fn>;
+
+vi.mock(new URL("../../src/index.js", import.meta.url).pathname, () => ({
+  initSiteping: (...args: unknown[]) => initSpy(...args),
+  __esModule: true,
+}));
+
+beforeEach(() => {
+  mockInstances = [];
+  initSpy = vi.fn((_config: SitepingConfig) => {
+    const listeners = new Map<string, Set<Listener>>();
+    const instance: MockedInstance = {
+      destroy: vi.fn(() => {
+        instance.__destroyed = true;
+      }),
+      open: vi.fn(),
+      close: vi.fn(),
+      refresh: vi.fn(),
+      on: <K extends string>(event: K, listener: Listener) => {
+        let set = listeners.get(event);
+        if (!set) {
+          set = new Set();
+          listeners.set(event, set);
+        }
+        set.add(listener);
+        return () => set?.delete(listener);
+      },
+      off: (event: string, listener: Listener) => {
+        listeners.get(event)?.delete(listener);
+      },
+      __emit: (event: string, ...args: unknown[]) => {
+        for (const l of listeners.get(event) ?? []) l(...args);
+      },
+      __destroyed: false,
+    } as MockedInstance;
+    mockInstances.push(instance);
+    return instance;
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// Import after mock setup so the alias resolves to our spy.
+import { useSiteping } from "../../src/react.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+function Probe({ config, onInstance }: { config: SitepingConfig; onInstance?: (i: SitepingInstance | null) => void }) {
+  const instance = useSiteping(config);
+  useEffect(() => {
+    onInstance?.(instance);
+  }, [instance, onInstance]);
+  return null;
+}
+
+describe("useSiteping", () => {
+  it("initialises the widget once on mount and destroys on unmount", () => {
+    const config: SitepingConfig = { endpoint: "/api/siteping", projectName: "test" };
+    const { unmount } = render(<Probe config={config} />);
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(initSpy).toHaveBeenCalledWith(config);
+    expect(mockInstances).toHaveLength(1);
+    expect(mockInstances[0]?.__destroyed).toBe(false);
+
+    unmount();
+    expect(mockInstances[0]?.__destroyed).toBe(true);
+  });
+
+  it("returns the live instance so consumers can drive it programmatically", () => {
+    const captured: Array<SitepingInstance | null> = [];
+    render(<Probe config={{ endpoint: "/api/x", projectName: "p" }} onInstance={(i) => captured.push(i)} />);
+    const finalInstance = captured[captured.length - 1];
+    expect(finalInstance).not.toBeNull();
+    expect(finalInstance).toBe(mockInstances[0]);
+  });
+
+  it("does NOT init twice under StrictMode (double-mount)", () => {
+    const config: SitepingConfig = { endpoint: "/api/siteping", projectName: "test" };
+    render(
+      <StrictMode>
+        <Probe config={config} />
+      </StrictMode>,
+    );
+
+    // StrictMode invokes effects twice: setup → cleanup → setup. The widget
+    // is allowed to be created on both runs as long as the first one is
+    // destroyed cleanly — what matters is that no two live widgets are left
+    // on the page when the dust settles.
+    const liveCount = mockInstances.filter((i) => !i.__destroyed).length;
+    expect(liveCount).toBe(1);
+  });
+
+  it("forwards feedback:sent events to the latest onFeedbackSent callback", () => {
+    const v1 = vi.fn();
+    const v2 = vi.fn();
+
+    function Host({ cb }: { cb: (fb: unknown) => void }) {
+      useSiteping({ endpoint: "/api", projectName: "p", onFeedbackSent: cb });
+      return null;
+    }
+
+    const { rerender } = render(<Host cb={v1} />);
+    const inst = mockInstances[0];
+    expect(inst).toBeDefined();
+
+    // First emit hits the first callback.
+    act(() => {
+      inst!.__emit("feedback:sent", { id: "fb-1" });
+    });
+    expect(v1).toHaveBeenCalledTimes(1);
+
+    // Swap the callback prop — the hook should bridge to the latest one
+    // *without* re-initing the widget.
+    rerender(<Host cb={v2} />);
+    expect(initSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      inst!.__emit("feedback:sent", { id: "fb-2" });
+    });
+    expect(v2).toHaveBeenCalledTimes(1);
+    expect(v1).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards panel:open and panel:close to onOpen / onClose", () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <Probe
+        config={{
+          endpoint: "/api/x",
+          projectName: "p",
+          onOpen,
+          onClose,
+        }}
+      />,
+    );
+    const inst = mockInstances[0]!;
+    act(() => {
+      inst.__emit("panel:open");
+      inst.__emit("panel:close");
+    });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores destroyed widget events (cleanup unsubscribes)", () => {
+    const onOpen = vi.fn();
+    const { unmount } = render(
+      <Probe config={{ endpoint: "/api/x", projectName: "p", onOpen }} />,
+    );
+    const inst = mockInstances[0]!;
+    unmount();
+    // Even if a stray event fires after unmount, the user callback never runs.
+    act(() => {
+      inst.__emit("panel:open");
+    });
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -9,6 +9,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "script": "./dist/index.global.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
     }
   },
   "module": "./dist/index.js",
@@ -58,6 +62,19 @@
   },
   "devDependencies": {
     "@medv/finder": "^3.2.0",
-    "@siteping/core": "workspace:*"
+    "@siteping/core": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/widget/src/react.ts
+++ b/packages/widget/src/react.ts
@@ -1,0 +1,116 @@
+/**
+ * React helper for `@siteping/widget`.
+ *
+ * `useSiteping` initialises the widget once for the lifetime of the component
+ * tree, even under React.StrictMode's double-invoke effect dance. Returns the
+ * `SitepingInstance` so consumers can drive `open()` / `close()` / `refresh()`
+ * programmatically from anywhere in their tree.
+ *
+ * Why a dedicated entry instead of a snippet in the README:
+ * - StrictMode mounts every effect twice in dev, which the obvious
+ *   `useEffect(() => { const i = initSiteping(...); return i.destroy }, [])`
+ *   handles fine for *re-mount*, but not for the brief window where the
+ *   second mount sees a still-alive widget (the widget's own singleton guard
+ *   logs an info message and returns the existing instance — surprising
+ *   noise for developers).
+ * - The hook also captures the latest `config` in a ref so callbacks (e.g.
+ *   `onFeedbackSent`) read closure values without re-initialising the widget.
+ *
+ * Peer dep on react ≥ 18 (declared as optional in package.json), so projects
+ * that never import `@siteping/widget/react` don't need React installed.
+ */
+
+import type { SitepingConfig, SitepingInstance } from "@siteping/core";
+import { useEffect, useRef, useState } from "react";
+import { initSiteping } from "./index.js";
+
+/**
+ * Initialise the SitePing widget for the lifetime of the calling component.
+ *
+ * Safe to call from a Server Component file as long as the component itself
+ * is marked `"use client"` — the hook bails out cleanly on the server because
+ * `useEffect` never runs there.
+ *
+ * @example Next.js App Router
+ * ```tsx
+ * "use client"
+ * import { useSiteping } from "@siteping/widget/react"
+ *
+ * export function FeedbackProvider({ children }: { children: React.ReactNode }) {
+ *   useSiteping({
+ *     endpoint: "/api/siteping",
+ *     projectName: "my-app",
+ *   })
+ *   return <>{children}</>
+ * }
+ * ```
+ *
+ * @example Driving the panel programmatically
+ * ```tsx
+ * "use client"
+ * import { useSiteping } from "@siteping/widget/react"
+ *
+ * export function HelpButton() {
+ *   const widget = useSiteping({ endpoint: "/api/siteping", projectName: "my-app" })
+ *   return <button onClick={() => widget?.open()}>Need help?</button>
+ * }
+ * ```
+ */
+export function useSiteping(config: SitepingConfig): SitepingInstance | null {
+  // Keep callbacks fresh without retriggering the init effect. The widget
+  // captures the *initial* config; we mirror updated handlers via the bridge
+  // below so consumers can change `onFeedbackSent` between renders without
+  // tearing the widget down.
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  const [instance, setInstance] = useState<SitepingInstance | null>(null);
+
+  useEffect(() => {
+    // `mounted` flag deals with the StrictMode double-effect: the cleanup of
+    // the first run fires between the two `init` calls, so we set the flag
+    // false in cleanup and skip late state updates. The widget itself has
+    // its own singleton guard, so even if we managed to call init() twice
+    // in a row we'd get the same instance back.
+    let mounted = true;
+    const created = initSiteping(configRef.current);
+    if (!mounted) {
+      // Cleanup already ran (StrictMode dev edge case) — tear down to avoid
+      // leaving a dangling widget in the DOM.
+      created.destroy();
+      return;
+    }
+
+    // Bridge mutable callbacks: subscribe through the widget's public event
+    // bus so we can call whatever the *latest* config has set. This lets
+    // hosts change `onFeedbackSent`, `onError`, etc. between renders without
+    // recreating the widget.
+    const unsubSent = created.on("feedback:sent", (fb) => {
+      configRef.current.onFeedbackSent?.(fb);
+    });
+    const unsubOpen = created.on("panel:open", () => {
+      configRef.current.onOpen?.();
+    });
+    const unsubClose = created.on("panel:close", () => {
+      configRef.current.onClose?.();
+    });
+
+    setInstance(created);
+
+    return () => {
+      mounted = false;
+      unsubSent();
+      unsubOpen();
+      unsubClose();
+      created.destroy();
+      setInstance(null);
+    };
+    // The init effect intentionally has an empty dep array — config changes
+    // are forwarded through configRef.current, not through re-init. Hosts
+    // that need a fresh widget (e.g. swapping endpoint at runtime) should
+    // unmount the component that owns the hook.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return instance;
+}

--- a/packages/widget/tsup.config.ts
+++ b/packages/widget/tsup.config.ts
@@ -1,14 +1,33 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm", "iife"],
-  globalName: "SitePing",
-  platform: "browser",
-  target: "es2022",
-  dts: true,
-  sourcemap: true,
-  clean: true,
-  minify: true,
-  noExternal: ["@medv/finder", "@siteping/core"],
-});
+export default defineConfig([
+  // Main widget entry — used by every consumer (`import { initSiteping } from
+  // "@siteping/widget"`). Shipped as ESM + IIFE for both bundler and
+  // script-tag use.
+  {
+    entry: ["src/index.ts"],
+    format: ["esm", "iife"],
+    globalName: "SitePing",
+    platform: "browser",
+    target: "es2022",
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    minify: true,
+    noExternal: ["@medv/finder", "@siteping/core"],
+  },
+  // React entry — `@siteping/widget/react`. ESM only (React projects bundle
+  // ESM) and React stays external so consumers pin their own version.
+  {
+    entry: ["src/react.ts"],
+    format: ["esm"],
+    platform: "browser",
+    target: "es2022",
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    minify: true,
+    noExternal: ["@medv/finder", "@siteping/core"],
+    external: ["react"],
+  },
+]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  esbuild: {
+    // Use the automatic JSX runtime so `*.test.tsx` files don't need a `React`
+    // import in scope. Matches Next.js / modern React defaults.
+    jsx: "automatic",
+  },
   resolve: {
     conditions: ["import", "module", "default"],
   },
   test: {
-    include: ["packages/**/__tests__/**/*.test.ts"],
+    include: ["packages/**/__tests__/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "istanbul",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
## Why
README claimed \"First-class Next.js support\" but only exposed an imperative \`initSiteping()\` — manual \`useEffect\` had a StrictMode double-mount trap.

## What
\`\`\`tsx
\"use client\"
import { useSiteping } from \"@siteping/widget/react\"

export default function Layout({ children }) {
  useSiteping({ endpoint: \"/api/siteping\", projectName: \"my-app\" })
  return <>{children}</>
}
\`\`\`

- New \`packages/widget/src/react.ts\` exposing \`useSiteping(config)\`.
- StrictMode-safe (single live widget across double-mount).
- Returns the \`SitepingInstance\` for programmatic \`open()\`/\`close()\`.
- Cleanup via \`destroy()\` on unmount.
- Sub-export \`@siteping/widget/react\`, peer \`react >=18\` (optional).

## Tests
6 new tests (\`react.test.tsx\`): mount/unmount, instance access, StrictMode single-widget invariant, callback re-binding, event bridge, no leak post-unmount.