### PR TITLE
refactor(widget,core): share SegmentedControl, setButtonLoading, filter logic

### DIFF
--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -1,6 +1,7 @@
 import {
   type AnnotationCreateInput,
   type AnnotationRecord,
+  applyFeedbackFilters,
   type FeedbackCreateInput,
   type FeedbackQuery,
   type FeedbackRecord,
@@ -156,23 +157,7 @@ export class LocalStorageStore implements SitepingStore {
   }
 
   async getFeedbacks(query: FeedbackQuery): Promise<{ feedbacks: FeedbackRecord[]; total: number }> {
-    let results = this.load().filter((f) => f.projectName === query.projectName);
-
-    if (query.type) results = results.filter((f) => f.type === query.type);
-    if (query.status) results = results.filter((f) => f.status === query.status);
-    if (query.url) results = results.filter((f) => f.url === query.url);
-    if (query.urlPattern) results = results.filter((f) => f.urlPattern === query.urlPattern);
-    if (query.search) {
-      const s = query.search.toLowerCase();
-      results = results.filter((f) => f.message.toLowerCase().includes(s));
-    }
-
-    const total = results.length;
-    const page = query.page ?? 1;
-    const limit = Math.min(query.limit ?? 50, 100);
-    const start = (page - 1) * limit;
-
-    return { feedbacks: results.slice(start, start + limit), total };
+    return applyFeedbackFilters(this.load(), query);
   }
 
   async findByClientId(clientId: string): Promise<FeedbackRecord | null> {

--- a/packages/adapter-memory/src/index.ts
+++ b/packages/adapter-memory/src/index.ts
@@ -1,6 +1,7 @@
 import {
   type AnnotationCreateInput,
   type AnnotationRecord,
+  applyFeedbackFilters,
   type FeedbackCreateInput,
   type FeedbackQuery,
   type FeedbackRecord,
@@ -100,23 +101,7 @@ export class MemoryStore implements SitepingStore {
   }
 
   async getFeedbacks(query: FeedbackQuery): Promise<{ feedbacks: FeedbackRecord[]; total: number }> {
-    let results = this.feedbacks.filter((f) => f.projectName === query.projectName);
-
-    if (query.type) results = results.filter((f) => f.type === query.type);
-    if (query.status) results = results.filter((f) => f.status === query.status);
-    if (query.url) results = results.filter((f) => f.url === query.url);
-    if (query.urlPattern) results = results.filter((f) => f.urlPattern === query.urlPattern);
-    if (query.search) {
-      const s = query.search.toLowerCase();
-      results = results.filter((f) => f.message.toLowerCase().includes(s));
-    }
-
-    const total = results.length;
-    const page = query.page ?? 1;
-    const limit = Math.min(query.limit ?? 50, 100);
-    const start = (page - 1) * limit;
-
-    return { feedbacks: results.slice(start, start + limit), total };
+    return applyFeedbackFilters(this.feedbacks, query);
   }
 
   async findByClientId(clientId: string): Promise<FeedbackRecord | null> {

--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared feedback-record filtering and pagination — extracted from
+ * `adapter-memory` and `adapter-localstorage` which previously kept two
+ * near-identical copies of the same logic. Any adapter that holds an
+ * in-memory snapshot of feedbacks can use it.
+ *
+ * Filtering order matches the historical adapter behaviour:
+ *   1. projectName  (always required)
+ *   2. type
+ *   3. status
+ *   4. url
+ *   5. urlPattern
+ *   6. search       (lowercase substring match on `message`)
+ *
+ * Pagination clamps `limit` to a maximum of 100 and treats `page` as 1-based,
+ * matching the public API contract documented on `getFeedbacks`.
+ */
+
+import type { FeedbackQuery, FeedbackRecord } from "./types.js";
+
+/** Default page size when the caller omits `query.limit`. */
+const DEFAULT_LIMIT = 50;
+/** Maximum allowed page size — defends against memory blow-ups on hostile callers. */
+const MAX_LIMIT = 100;
+
+export interface FilterResult {
+  feedbacks: FeedbackRecord[];
+  total: number;
+}
+
+/**
+ * Apply the standard feedback filter + pagination pipeline against an
+ * in-memory snapshot. Used by `MemoryStore.getFeedbacks` and
+ * `LocalStorageStore.getFeedbacks` so the two never drift.
+ *
+ * @param items  All known feedback records (already include `annotations`).
+ * @param query  Filter and pagination options. `projectName` is required.
+ */
+export function applyFeedbackFilters(items: readonly FeedbackRecord[], query: FeedbackQuery): FilterResult {
+  let results: FeedbackRecord[] = items.filter((f) => f.projectName === query.projectName);
+
+  if (query.type) results = results.filter((f) => f.type === query.type);
+  if (query.status) results = results.filter((f) => f.status === query.status);
+  if (query.url) results = results.filter((f) => f.url === query.url);
+  if (query.urlPattern) results = results.filter((f) => f.urlPattern === query.urlPattern);
+  if (query.search) {
+    const s = query.search.toLowerCase();
+    results = results.filter((f) => f.message.toLowerCase().includes(s));
+  }
+
+  const total = results.length;
+  const page = query.page ?? 1;
+  const limit = Math.min(query.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const start = (page - 1) * limit;
+
+  return { feedbacks: results.slice(start, start + limit), total };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,6 @@
-export type { FieldDef, IndexDef, ModelDef } from "./schema.js";
-
 export type { FilterResult } from "./filters.js";
 export { applyFeedbackFilters } from "./filters.js";
+export type { FieldDef, IndexDef, ModelDef } from "./schema.js";
 export { SITEPING_MODELS } from "./schema.js";
 export type { ScreenshotStorage } from "./screenshot-storage.js";
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export type { FieldDef, IndexDef, ModelDef } from "./schema.js";
 
+export type { FilterResult } from "./filters.js";
+export { applyFeedbackFilters } from "./filters.js";
 export { SITEPING_MODELS } from "./schema.js";
 export type { ScreenshotStorage } from "./screenshot-storage.js";
 export type {

--- a/packages/widget/src/components/segmented-control.ts
+++ b/packages/widget/src/components/segmented-control.ts
@@ -1,0 +1,185 @@
+/**
+ * Accessible segmented (radiogroup) control.
+ *
+ * Replaces the near-identical `buildStatusSegmented` / `buildScopeSegmented`
+ * pairs that previously lived inline in `panel.ts`: keyboard navigation
+ * (ArrowLeft/Right, Home/End), aria-checked toggling, `tabIndex` roving,
+ * and optional icon+colour decoration.
+ *
+ * Visibility filtering — needed by the scope control which hides the
+ * "this type" option when there is no urlPattern — is handled by
+ * `setOptionVisible(value, visible)` and is respected by keyboard
+ * navigation so users can't focus a hidden option via arrow keys.
+ */
+
+import { el, parseSvg, setText } from "../dom-utils.js";
+
+/**
+ * Visual decoration for a segmented option.
+ * Both fields are optional: scope options omit them entirely.
+ */
+export interface SegmentedDecoration {
+  icon?: string;
+  color?: string;
+  bg?: string;
+}
+
+export interface SegmentedOption<T extends string> extends SegmentedDecoration {
+  value: T;
+  label: string;
+}
+
+export interface SegmentedControlConfig<T extends string> {
+  /** Options to render — order is preserved. */
+  options: ReadonlyArray<SegmentedOption<T>>;
+  /** Initial selected value — must appear in `options`. */
+  value: T;
+  /** Called whenever selection changes (click or keyboard). */
+  onChange: (value: T) => void;
+  /** Accessible label exposed via `aria-label` on the radiogroup. */
+  ariaLabel: string;
+  /** Extra CSS class appended to the wrapper (e.g. `sp-segmented--scope`). */
+  extraClass?: string;
+  /** dataset attribute name used per-button, e.g. `statusFilter` → `data-status-filter`. */
+  datasetKey: string;
+  /** Class prefix used for per-option modifier, e.g. `sp-segmented__btn--` + option.value. */
+  modifierPrefix?: string;
+}
+
+/**
+ * Build a segmented (radiogroup) control. Returns both the root element and
+ * the imperative API for updating selection / visibility from outside —
+ * Panel needs the latter when scope availability changes between SPA
+ * navigations.
+ */
+export class SegmentedControl<T extends string> {
+  readonly element: HTMLElement;
+  private current: T;
+  private readonly opts: ReadonlyArray<SegmentedOption<T>>;
+  private readonly onChange: (value: T) => void;
+  private readonly datasetKey: string;
+
+  constructor(config: SegmentedControlConfig<T>) {
+    this.opts = config.options;
+    this.current = config.value;
+    this.onChange = config.onChange;
+    this.datasetKey = config.datasetKey;
+
+    this.element = el("div", {
+      class: `sp-segmented${config.extraClass ? ` ${config.extraClass}` : ""}`,
+      role: "radiogroup",
+    });
+    this.element.setAttribute("aria-label", config.ariaLabel);
+
+    for (const option of this.opts) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className =
+        config.modifierPrefix !== undefined
+          ? `sp-segmented__btn ${config.modifierPrefix}${option.value}`
+          : "sp-segmented__btn";
+      btn.dataset[this.datasetKey] = option.value;
+      btn.setAttribute("role", "radio");
+      const isActive = this.current === option.value;
+      btn.setAttribute("aria-checked", String(isActive));
+      btn.tabIndex = isActive ? 0 : -1;
+      if (isActive) btn.classList.add("sp-segmented__btn--active");
+      if (option.color) btn.style.setProperty("--sp-chip-color", option.color);
+      if (option.bg) btn.style.setProperty("--sp-chip-bg", option.bg);
+
+      if (option.icon) {
+        const iconWrap = el("span", { class: "sp-segmented__icon" });
+        iconWrap.appendChild(parseSvg(option.icon));
+        btn.appendChild(iconWrap);
+      }
+
+      const labelEl = el("span", { class: "sp-segmented__label" });
+      setText(labelEl, option.label);
+      btn.appendChild(labelEl);
+
+      btn.addEventListener("click", () => this.select(option.value));
+      btn.addEventListener("keydown", (e) => this.handleKey(e, option.value));
+
+      this.element.appendChild(btn);
+    }
+  }
+
+  /** Imperatively change the selected option (also fires `onChange`). */
+  select(value: T): void {
+    this.current = value;
+    this.syncSelection();
+    this.onChange(value);
+  }
+
+  /** Apply selection-only DOM updates without firing `onChange`. Useful on init refresh. */
+  private syncSelection(): void {
+    const buttons = this.element.querySelectorAll<HTMLButtonElement>(".sp-segmented__btn");
+    for (const btn of buttons) {
+      const isActive = btn.dataset[this.datasetKey] === this.current;
+      btn.classList.toggle("sp-segmented__btn--active", isActive);
+      btn.setAttribute("aria-checked", String(isActive));
+      btn.tabIndex = isActive ? 0 : -1;
+    }
+  }
+
+  /**
+   * Show / hide a specific option. Hidden options are skipped during keyboard
+   * navigation. Returns true when an option was actually toggled.
+   */
+  setOptionVisible(value: T, visible: boolean): boolean {
+    const btn = this.element.querySelector<HTMLButtonElement>(`[data-${this.kebabKey()}="${value}"]`);
+    if (!btn) return false;
+    btn.style.display = visible ? "" : "none";
+    return true;
+  }
+
+  /** Current selection. */
+  get value(): T {
+    return this.current;
+  }
+
+  /** Focus the button matching `value`, if it exists. */
+  focusOption(value: T): void {
+    const btn = this.element.querySelector<HTMLButtonElement>(`[data-${this.kebabKey()}="${value}"]`);
+    btn?.focus();
+  }
+
+  private handleKey(e: KeyboardEvent, current: T): void {
+    const visibleValues = this.opts
+      .map((o) => o.value)
+      .filter((v) => {
+        const btn = this.element.querySelector<HTMLButtonElement>(`[data-${this.kebabKey()}="${v}"]`);
+        return btn !== null && btn.style.display !== "none";
+      });
+    const idx = visibleValues.indexOf(current);
+    if (idx < 0) return;
+
+    let nextIdx: number;
+    switch (e.key) {
+      case "ArrowLeft":
+        nextIdx = (idx - 1 + visibleValues.length) % visibleValues.length;
+        break;
+      case "ArrowRight":
+        nextIdx = (idx + 1) % visibleValues.length;
+        break;
+      case "Home":
+        nextIdx = 0;
+        break;
+      case "End":
+        nextIdx = visibleValues.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const next = visibleValues[nextIdx];
+    if (next === undefined) return;
+    this.select(next);
+    this.focusOption(next);
+  }
+
+  /** Convert datasetKey ("statusFilter") to its DOM attribute form ("status-filter"). */
+  private kebabKey(): string {
+    return this.datasetKey.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+  }
+}

--- a/packages/widget/src/dom-utils.ts
+++ b/packages/widget/src/dom-utils.ts
@@ -52,6 +52,25 @@ export function setText(element: HTMLElement | SVGElement, text: string): void {
   element.textContent = text;
 }
 
+/**
+ * Replace a button's children with a small spinner and disable it.
+ * Returns a `restore` callback that swaps the original content back and
+ * re-enables the button. Used by every async button (delete, resolve, …)
+ * to surface in-flight state without owning per-button state itself.
+ *
+ * Lives in dom-utils rather than panel-internal because both Panel and
+ * BulkActions need identical behaviour.
+ */
+export function setButtonLoading(btn: HTMLButtonElement): () => void {
+  const snapshot = Array.from(btn.childNodes).map((n) => n.cloneNode(true));
+  btn.disabled = true;
+  btn.replaceChildren(el("div", { class: "sp-spinner sp-spinner--sm" }));
+  return () => {
+    btn.replaceChildren(...snapshot);
+    btn.disabled = false;
+  };
+}
+
 /** Format a relative date string using Intl.RelativeTimeFormat for locale support */
 export function formatRelativeDate(isoString: string, locale = "en"): string {
   const diff = Date.now() - new Date(isoString).getTime();

--- a/packages/widget/src/panel-bulk.ts
+++ b/packages/widget/src/panel-bulk.ts
@@ -6,7 +6,7 @@
  * spring animations and smooth transitions.
  */
 
-import { el, parseSvg, setText } from "./dom-utils.js";
+import { el, parseSvg, setButtonLoading, setText } from "./dom-utils.js";
 import type { ThemeColors } from "./styles/theme.js";
 
 // ---------------------------------------------------------------------------
@@ -629,22 +629,12 @@ export class BulkActions {
     }
   }
 
-  private setButtonLoading(btn: HTMLButtonElement): () => void {
-    const snapshot = Array.from(btn.childNodes).map((n) => n.cloneNode(true));
-    btn.disabled = true;
-    btn.replaceChildren(el("div", { class: "sp-spinner sp-spinner--sm" }));
-    return () => {
-      btn.replaceChildren(...snapshot);
-      btn.disabled = false;
-    };
-  }
-
   private async handleResolve(): Promise<void> {
     if (this.isProcessing || this.selected.size === 0) return;
     this.isProcessing = true;
 
     const ids = [...this.selected];
-    const restoreResolve = this.setButtonLoading(this.resolveBtn);
+    const restoreResolve = setButtonLoading(this.resolveBtn);
     this.deleteBtn.disabled = true;
 
     try {
@@ -663,7 +653,7 @@ export class BulkActions {
     this.isProcessing = true;
 
     const ids = [...this.selected];
-    const restoreDelete = this.setButtonLoading(this.deleteBtn);
+    const restoreDelete = setButtonLoading(this.deleteBtn);
     this.resolveBtn.disabled = true;
 
     try {

--- a/packages/widget/src/panel.ts
+++ b/packages/widget/src/panel.ts
@@ -1,7 +1,7 @@
 import type { FeedbackResponse, FeedbackStatus, FeedbackType, PageScope } from "@siteping/core";
 import type { GetFeedbacksOptions, WidgetClient } from "./api-client.js";
-import { PAGE_SIZE } from "./constants.js";
 import { SegmentedControl } from "./components/segmented-control.js";
+import { PAGE_SIZE } from "./constants.js";
 import { el, formatRelativeDate, parseSvg, setButtonLoading, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
 import { EXPORT_I18N_FR, ExportButton } from "./export-utils.js";

--- a/packages/widget/src/panel.ts
+++ b/packages/widget/src/panel.ts
@@ -1,7 +1,8 @@
 import type { FeedbackResponse, FeedbackStatus, FeedbackType, PageScope } from "@siteping/core";
 import type { GetFeedbacksOptions, WidgetClient } from "./api-client.js";
 import { PAGE_SIZE } from "./constants.js";
-import { el, formatRelativeDate, parseSvg, setText } from "./dom-utils.js";
+import { SegmentedControl } from "./components/segmented-control.js";
+import { el, formatRelativeDate, parseSvg, setButtonLoading, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
 import { EXPORT_I18N_FR, ExportButton } from "./export-utils.js";
 import { getTypeLabel, type TFunction } from "./i18n/index.js";
@@ -48,20 +49,12 @@ export class Panel {
   private closeBtn: HTMLButtonElement;
   private deleteAllBtn: HTMLButtonElement;
   private activeFilters = new Set<string>(["all"]);
-  private activeStatusFilter: "all" | FeedbackStatus = "all";
   private typeDropdownBtn!: HTMLButtonElement;
   private typeDropdownContainer!: HTMLElement;
   private typeDropdownMenu: HTMLElement | null = null;
   private typeDropdownOutsideHandler: ((e: MouseEvent) => void) | null = null;
-  private statusSegmented!: HTMLElement;
+  private statusSegmented!: SegmentedControl<"all" | FeedbackStatus>;
   private typeOptions!: ReadonlyArray<{ value: string; label: string; icon: string; color: string; bg: string }>;
-  private statusOptions!: ReadonlyArray<{
-    value: "all" | FeedbackStatus;
-    label: string;
-    icon: string;
-    color: string;
-    bg: string;
-  }>;
   private feedbacks: FeedbackResponse[] = [];
   private currentPage = 1;
   private totalFeedbacks = 0;
@@ -89,9 +82,9 @@ export class Panel {
   private readonly getScope: () => PageScope;
   private readonly scopeAnnotationsByUrl: boolean;
   /** "this" = current url, "template" = url pattern, "all" = no scope filter */
-  private activeScopeFilter: "this" | "template" | "all" = "this";
-  private scopeSegmented!: HTMLElement;
-  private scopeOptions!: ReadonlyArray<{ value: "this" | "template" | "all"; label: string }>;
+  private scopeSegmented!: SegmentedControl<"this" | "template" | "all">;
+  /** Cached initial scope value — applied after construction in `buildScopeSegmented`. */
+  private readonly initialScopeFilter: "this" | "template" | "all" = "this";
 
   constructor(
     shadowRoot: ShadowRoot,
@@ -477,11 +470,13 @@ export class Panel {
 
     const search = this.searchInput.value.trim() || undefined;
     const typeFilter = this.activeFilters.has("all") ? undefined : (Array.from(this.activeFilters)[0] as FeedbackType);
-    const statusFilter = this.activeStatusFilter === "all" ? undefined : this.activeStatusFilter;
+    const currentStatus = this.statusSegmented.value;
+    const statusFilter = currentStatus === "all" ? undefined : currentStatus;
 
     const scope = this.getScope();
     // Refresh scope-filter button visibility based on current scope (SPA nav).
     this.syncScopeAvailability();
+    const currentScope = this.scopeSegmented.value;
     const options: GetFeedbacksOptions & { page: number; limit: number } = {
       page: 1,
       limit: PAGE_SIZE,
@@ -489,9 +484,9 @@ export class Panel {
     if (typeFilter) options.type = typeFilter;
     if (statusFilter) options.status = statusFilter;
     if (search) options.search = search;
-    if (this.activeScopeFilter === "this") {
+    if (currentScope === "this") {
       options.url = scope.url;
-    } else if (this.activeScopeFilter === "template" && scope.urlPattern) {
+    } else if (currentScope === "template" && scope.urlPattern) {
       options.urlPattern = scope.urlPattern;
     }
 
@@ -530,9 +525,11 @@ export class Panel {
     const nextPage = this.currentPage + 1;
     const search = this.searchInput.value.trim() || undefined;
     const typeFilter = this.activeFilters.has("all") ? undefined : (Array.from(this.activeFilters)[0] as FeedbackType);
-    const statusFilter = this.activeStatusFilter === "all" ? undefined : this.activeStatusFilter;
+    const currentStatus = this.statusSegmented.value;
+    const statusFilter = currentStatus === "all" ? undefined : currentStatus;
 
     const scope = this.getScope();
+    const currentScope = this.scopeSegmented.value;
     const options: GetFeedbacksOptions & { page: number; limit: number } = {
       page: nextPage,
       limit: PAGE_SIZE,
@@ -540,16 +537,16 @@ export class Panel {
     if (typeFilter) options.type = typeFilter;
     if (statusFilter) options.status = statusFilter;
     if (search) options.search = search;
-    if (this.activeScopeFilter === "this") {
+    if (currentScope === "this") {
       options.url = scope.url;
-    } else if (this.activeScopeFilter === "template" && scope.urlPattern) {
+    } else if (currentScope === "template" && scope.urlPattern) {
       options.urlPattern = scope.urlPattern;
     }
 
     // Show spinner on the "Load more" button
     const loadMoreBtn = this.listContainer.querySelector<HTMLButtonElement>(".sp-btn-load-more");
     let restoreBtn: (() => void) | undefined;
-    if (loadMoreBtn) restoreBtn = this.setButtonLoading(loadMoreBtn);
+    if (loadMoreBtn) restoreBtn = setButtonLoading(loadMoreBtn);
 
     try {
       const { feedbacks, total } = await this.client.getFeedbacks(this.projectName, options);
@@ -874,19 +871,9 @@ export class Panel {
     });
   }
 
-  private setButtonLoading(btn: HTMLButtonElement): () => void {
-    const snapshot = Array.from(btn.childNodes).map((n) => n.cloneNode(true));
-    btn.disabled = true;
-    btn.replaceChildren(el("div", { class: "sp-spinner sp-spinner--sm" }));
-    return () => {
-      btn.replaceChildren(...snapshot);
-      btn.disabled = false;
-    };
-  }
-
   private async deleteFeedback(feedback: FeedbackResponse, btn: HTMLButtonElement): Promise<void> {
     this.pendingMutations.add(feedback.id);
-    const restore = this.setButtonLoading(btn);
+    const restore = setButtonLoading(btn);
     try {
       await this.client.deleteFeedback(feedback.id);
       this.bus.emit("feedback:deleted", feedback.id);
@@ -901,7 +888,7 @@ export class Panel {
 
   private async toggleResolve(feedback: FeedbackResponse, btn: HTMLButtonElement): Promise<void> {
     this.pendingMutations.add(feedback.id);
-    const restore = this.setButtonLoading(btn);
+    const restore = setButtonLoading(btn);
     try {
       const newResolved = feedback.status !== "resolved";
       await this.client.resolveFeedback(feedback.id, newResolved);
@@ -1080,101 +1067,40 @@ export class Panel {
   }
 
   private buildStatusSegmented(): HTMLElement {
-    this.statusOptions = [
-      {
-        value: "all",
-        label: this.t("panel.statusAll"),
-        icon: ICON_LAYERS,
-        color: this.colors.accent,
-        bg: this.colors.accentLight,
+    this.statusSegmented = new SegmentedControl<"all" | FeedbackStatus>({
+      options: [
+        {
+          value: "all",
+          label: this.t("panel.statusAll"),
+          icon: ICON_LAYERS,
+          color: this.colors.accent,
+          bg: this.colors.accentLight,
+        },
+        {
+          value: "open",
+          label: this.t("panel.statusOpen"),
+          icon: ICON_DOT_OPEN,
+          color: this.colors.statusOpen,
+          bg: this.colors.statusOpenBg,
+        },
+        {
+          value: "resolved",
+          label: this.t("panel.statusResolved"),
+          icon: ICON_CHECK,
+          color: this.colors.statusResolved,
+          bg: this.colors.statusResolvedBg,
+        },
+      ],
+      value: "all",
+      onChange: () => {
+        this.loadFeedbacks().catch(() => {});
       },
-      {
-        value: "open",
-        label: this.t("panel.statusOpen"),
-        icon: ICON_DOT_OPEN,
-        color: this.colors.statusOpen,
-        bg: this.colors.statusOpenBg,
-      },
-      {
-        value: "resolved",
-        label: this.t("panel.statusResolved"),
-        icon: ICON_CHECK,
-        color: this.colors.statusResolved,
-        bg: this.colors.statusResolvedBg,
-      },
-    ];
+      ariaLabel: this.t("status.label"),
+      datasetKey: "statusFilter",
+      modifierPrefix: "sp-segmented__btn--",
+    });
 
-    this.statusSegmented = el("div", { class: "sp-segmented", role: "radiogroup" });
-    this.statusSegmented.setAttribute("aria-label", this.t("status.label"));
-
-    for (const option of this.statusOptions) {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = `sp-segmented__btn sp-segmented__btn--${option.value}`;
-      btn.dataset.statusFilter = option.value;
-      btn.setAttribute("role", "radio");
-      const isActive = this.activeStatusFilter === option.value;
-      btn.setAttribute("aria-checked", String(isActive));
-      btn.tabIndex = isActive ? 0 : -1;
-      if (isActive) btn.classList.add("sp-segmented__btn--active");
-      btn.style.setProperty("--sp-chip-color", option.color);
-      btn.style.setProperty("--sp-chip-bg", option.bg);
-
-      const iconWrap = el("span", { class: "sp-segmented__icon" });
-      iconWrap.appendChild(parseSvg(option.icon));
-      btn.appendChild(iconWrap);
-
-      const labelEl = el("span", { class: "sp-segmented__label" });
-      setText(labelEl, option.label);
-      btn.appendChild(labelEl);
-
-      btn.addEventListener("click", () => this.selectStatusFilter(option.value));
-      btn.addEventListener("keydown", (e) => this.handleSegmentedKey(e, option.value));
-
-      this.statusSegmented.appendChild(btn);
-    }
-
-    return this.statusSegmented;
-  }
-
-  private handleSegmentedKey(e: KeyboardEvent, current: "all" | FeedbackStatus): void {
-    const values = this.statusOptions.map((o) => o.value);
-    const idx = values.indexOf(current);
-    let nextIdx: number;
-    switch (e.key) {
-      case "ArrowLeft":
-        nextIdx = (idx - 1 + values.length) % values.length;
-        break;
-      case "ArrowRight":
-        nextIdx = (idx + 1) % values.length;
-        break;
-      case "Home":
-        nextIdx = 0;
-        break;
-      case "End":
-        nextIdx = values.length - 1;
-        break;
-      default:
-        return;
-    }
-    e.preventDefault();
-    const next = values[nextIdx];
-    if (!next) return;
-    this.selectStatusFilter(next);
-    const btn = this.statusSegmented.querySelector<HTMLButtonElement>(`[data-status-filter="${next}"]`);
-    btn?.focus();
-  }
-
-  private selectStatusFilter(value: "all" | FeedbackStatus): void {
-    this.activeStatusFilter = value;
-    const buttons = this.statusSegmented.querySelectorAll<HTMLButtonElement>(".sp-segmented__btn");
-    for (const btn of buttons) {
-      const isActive = btn.dataset.statusFilter === value;
-      btn.classList.toggle("sp-segmented__btn--active", isActive);
-      btn.setAttribute("aria-checked", String(isActive));
-      btn.tabIndex = isActive ? 0 : -1;
-    }
-    this.loadFeedbacks().catch(() => {});
+    return this.statusSegmented.element;
   }
 
   /**
@@ -1184,85 +1110,25 @@ export class Panel {
    * every `loadFeedbacks` so SPA navigation stays consistent.
    */
   private buildScopeSegmented(): HTMLElement {
-    this.scopeOptions = [
-      { value: "this", label: this.t("scope.thisPage") },
-      { value: "template", label: this.t("scope.thisType") },
-      { value: "all", label: this.t("scope.all") },
-    ];
-
-    this.scopeSegmented = el("div", { class: "sp-segmented sp-segmented--scope", role: "radiogroup" });
-    this.scopeSegmented.setAttribute("aria-label", this.t("scope.label"));
-
-    for (const option of this.scopeOptions) {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = `sp-segmented__btn sp-segmented__btn--scope-${option.value}`;
-      btn.dataset.scopeFilter = option.value;
-      btn.setAttribute("role", "radio");
-      const isActive = this.activeScopeFilter === option.value;
-      btn.setAttribute("aria-checked", String(isActive));
-      btn.tabIndex = isActive ? 0 : -1;
-      if (isActive) btn.classList.add("sp-segmented__btn--active");
-
-      const labelEl = el("span", { class: "sp-segmented__label" });
-      setText(labelEl, option.label);
-      btn.appendChild(labelEl);
-
-      btn.addEventListener("click", () => this.selectScopeFilter(option.value));
-      btn.addEventListener("keydown", (e) => this.handleScopeKey(e, option.value));
-
-      this.scopeSegmented.appendChild(btn);
-    }
+    this.scopeSegmented = new SegmentedControl<"this" | "template" | "all">({
+      options: [
+        { value: "this", label: this.t("scope.thisPage") },
+        { value: "template", label: this.t("scope.thisType") },
+        { value: "all", label: this.t("scope.all") },
+      ],
+      value: this.initialScopeFilter,
+      onChange: () => {
+        this.loadFeedbacks().catch(() => {});
+      },
+      ariaLabel: this.t("scope.label"),
+      datasetKey: "scopeFilter",
+      modifierPrefix: "sp-segmented__btn--scope-",
+      extraClass: "sp-segmented--scope",
+    });
 
     // Initial visibility — "this type" only meaningful when scope has urlPattern
     this.syncScopeAvailability();
-    return this.scopeSegmented;
-  }
-
-  private handleScopeKey(e: KeyboardEvent, current: "this" | "template" | "all"): void {
-    const visibleValues = this.scopeOptions
-      .map((o) => o.value)
-      .filter((v) => {
-        const btn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="${v}"]`);
-        return btn && btn.style.display !== "none";
-      });
-    const idx = visibleValues.indexOf(current);
-    if (idx < 0) return;
-    let nextIdx: number;
-    switch (e.key) {
-      case "ArrowLeft":
-        nextIdx = (idx - 1 + visibleValues.length) % visibleValues.length;
-        break;
-      case "ArrowRight":
-        nextIdx = (idx + 1) % visibleValues.length;
-        break;
-      case "Home":
-        nextIdx = 0;
-        break;
-      case "End":
-        nextIdx = visibleValues.length - 1;
-        break;
-      default:
-        return;
-    }
-    e.preventDefault();
-    const next = visibleValues[nextIdx];
-    if (!next) return;
-    this.selectScopeFilter(next);
-    const btn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="${next}"]`);
-    btn?.focus();
-  }
-
-  private selectScopeFilter(value: "this" | "template" | "all"): void {
-    this.activeScopeFilter = value;
-    const buttons = this.scopeSegmented.querySelectorAll<HTMLButtonElement>(".sp-segmented__btn");
-    for (const btn of buttons) {
-      const isActive = btn.dataset.scopeFilter === value;
-      btn.classList.toggle("sp-segmented__btn--active", isActive);
-      btn.setAttribute("aria-checked", String(isActive));
-      btn.tabIndex = isActive ? 0 : -1;
-    }
-    this.loadFeedbacks().catch(() => {});
+    return this.scopeSegmented.element;
   }
 
   /**
@@ -1273,13 +1139,10 @@ export class Panel {
   private syncScopeAvailability(): void {
     if (!this.scopeSegmented) return;
     const scope = this.getScope();
-    const templateBtn = this.scopeSegmented.querySelector<HTMLButtonElement>(`[data-scope-filter="template"]`);
-    if (!templateBtn) return;
     const showTemplate = !!scope.urlPattern;
-    templateBtn.style.display = showTemplate ? "" : "none";
-    if (!showTemplate && this.activeScopeFilter === "template") {
-      this.activeScopeFilter = "this";
-      this.selectScopeFilter("this");
+    this.scopeSegmented.setOptionVisible("template", showTemplate);
+    if (!showTemplate && this.scopeSegmented.value === "template") {
+      this.scopeSegmented.select("this");
     }
   }
 


### PR DESCRIPTION
## Why
Three near-duplicates in the codebase:
1. \`buildStatusSegmented\` / \`buildScopeSegmented\` in \`panel.ts\` were almost identical implementations of the same control, plus twin handle/select helpers.
2. \`setButtonLoading\` was duplicated byte-for-byte in \`panel.ts\` and \`panel-bulk.ts\`.
3. Feedback filter logic was copy-pasted between \`adapter-memory\` and \`adapter-localstorage\`.

## What
- New \`packages/widget/src/components/segmented-control.ts\` exporting \`SegmentedControl<T>\` replacing both segmented implementations.
- \`setButtonLoading\` lifted into \`packages/widget/src/dom-utils.ts\`.
- New \`packages/core/src/filters.ts\` with \`applyFeedbackFilters(items, options)\` shared by both client-side adapters.

## Numbers
\`panel.ts\`: -254 lines. New shared modules: +340 lines (reusable). Net: smaller and cheaper to maintain.