### PR TITLE
test: fix vitest i18n setup (restore green main)

### DIFF
--- a/packages/widget/__tests__/setup-i18n.ts
+++ b/packages/widget/__tests__/setup-i18n.ts
@@ -1,0 +1,14 @@
+import { de } from "../src/i18n/de.js";
+import { es } from "../src/i18n/es.js";
+import { fr } from "../src/i18n/fr.js";
+import { registerLocale } from "../src/i18n/index.js";
+import { it } from "../src/i18n/it.js";
+import { pt } from "../src/i18n/pt.js";
+import { ru } from "../src/i18n/ru.js";
+
+registerLocale("de", de);
+registerLocale("es", es);
+registerLocale("fr", fr);
+registerLocale("it", it);
+registerLocale("pt", pt);
+registerLocale("ru", ru);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   test: {
     include: ["packages/**/__tests__/**/*.test.{ts,tsx}"],
+    setupFiles: ["packages/widget/__tests__/setup-i18n.ts"],
     coverage: {
       provider: "istanbul",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
## Why
Main is currently shipping with **8 failing tests** in `panel-stats`, `panel-sort`, `export-utils`, etc. The cause: wave 2's dynamic `loadLocale()` left the central `LOCALES` registry empty by default, so component tests that pass `createT('fr')` synchronously get English fallback strings — assertions then compare `'Open'` to `'Ouverts'` and fail.

Originally lived inline in the integration branch; got dropped from #67 (fix/i18n-unify-locales) after a merge conflict round.

## Fix
- `packages/widget/__tests__/setup-i18n.ts` — preloads `de/es/fr/it/pt/ru` via `registerLocale` synchronously.
- `vitest.config.ts` — references the setup file so every test run starts with all built-in locales loaded.

## Verification
\`\`\`
Test Files  48 passed (48)
      Tests  1362 passed (1362)
\`\`\`

## Severity
Main is broken without this — please merge ASAP.