### PR TITLE
feat(widget): allow host apps to pre-fill identity via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ initSiteping({
   locale: 'en',                   // 'en' | 'fr' (default: 'en')
   forceShow: false,               // Show in production? Default: false
   debug: false,                   // Enable debug logging
+  identity: {                     // Pre-fill author from the host (SSO apps).
+    name: 'Alice',                // When set, skips localStorage + modal.
+    email: 'alice@example.com',
+  },
 
   // Events
   onOpen: () => {},
@@ -193,6 +197,24 @@ widget.off('feedback:sent', handler)
 // 'panel:open'       — fired when the feedback panel opens
 // 'panel:close'      — fired when the feedback panel closes
 ```
+
+---
+
+## Host-provided identity
+
+Apps with their own authentication (SSO, NextAuth, Symfony Security, …) can pre-fill the feedback author directly:
+
+```ts
+initSiteping({
+  endpoint: '/api/siteping',
+  projectName: 'my-app',
+  identity: { name: currentUser.fullName, email: currentUser.email },
+})
+```
+
+When `identity` is set, the widget skips both the localStorage lookup and the identity modal — useful when the host already knows who the user is. The value is **not persisted**: pass the current user on every render so the widget always reflects the live signed-in state.
+
+When `identity` is unset (default), the widget falls back to the existing behavior — localStorage first, modal as a last resort.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ initSiteping({
 })
 ```
 
-When `identity` is set, the widget skips both the localStorage lookup and the identity modal — useful when the host already knows who the user is. The value is **not persisted**: pass the current user on every render so the widget always reflects the live signed-in state.
+When `identity` is set, the widget skips both the localStorage lookup and the identity modal — useful when the host already knows who the user is. The value is **not persisted** and is read at widget init time, not on every render. Hosts that need to react to live sign-in/sign-out changes should currently remount the widget (e.g. via a React `key` on the wrapping component). See [#85](https://github.com/NeosiaNexus/SitePing/issues/85) for tracking a future enhancement that propagates identity updates without a remount.
 
 When `identity` is unset (default), the widget falls back to the existing behavior — localStorage first, modal as a last resort.
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,24 @@ export interface SitepingConfig {
     | undefined;
   /** Called when the widget is skipped (production mode, mobile viewport) */
   onSkip?: (reason: "production" | "mobile") => void;
+  /**
+   * Pre-fill author identity from the host application — typically the
+   * currently signed-in user. When set, the widget uses these values
+   * directly and never shows the identity modal, even on first feedback.
+   *
+   * Use case: SSO-integrated apps where the end user is already
+   * authenticated by the host. Avoids the awkward "enter your name and
+   * email" prompt for users the host already knows.
+   *
+   * When unset (default), the widget falls back to localStorage and shows
+   * the modal on first feedback as before — existing behavior unchanged.
+   *
+   * Note: `config.identity` is **not** persisted to localStorage. The host
+   * is the source of truth on every render — if the signed-in user
+   * changes, pass the new identity and the widget uses it without stale
+   * data.
+   */
+  identity?: { name: string; email: string } | undefined;
 
   // Events
   /** Called when the feedback panel is opened. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,10 +101,12 @@ export interface SitepingConfig {
    * When unset (default), the widget falls back to localStorage and shows
    * the modal on first feedback as before — existing behavior unchanged.
    *
-   * Note: `config.identity` is **not** persisted to localStorage. The host
-   * is the source of truth on every render — if the signed-in user
-   * changes, pass the new identity and the widget uses it without stale
-   * data.
+   * Note: `config.identity` is **not** persisted to localStorage. It is
+   * read at widget init time, not on every render. Hosts that need live
+   * identity updates after sign-in/sign-out should currently remount the
+   * widget (e.g. via a React `key` on the wrapping component). See
+   * https://github.com/NeosiaNexus/SitePing/issues/85 for tracking a
+   * future enhancement that propagates identity updates without a remount.
    */
   identity?: { name: string; email: string } | undefined;
 

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -80,10 +80,11 @@ vi.mock(new URL("../../src/styles/base.js", import.meta.url).pathname, () => ({
 
 // Mock identity — simulate stored identity by default
 const mockGetIdentity = vi.fn().mockReturnValue({ name: "Test User", email: "test@example.com" });
+const mockSaveIdentity = vi.fn();
 
 vi.mock(new URL("../../src/identity.js", import.meta.url).pathname, () => ({
   getIdentity: (...args: unknown[]) => mockGetIdentity(...args),
-  saveIdentity: vi.fn(),
+  saveIdentity: (...args: unknown[]) => mockSaveIdentity(...args),
 }));
 
 import { launch } from "../../src/launcher.js";
@@ -293,6 +294,101 @@ describe("launcher — annotation:complete integration", () => {
           expect(modal).not.toBeNull();
         }
       });
+
+      instance.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // config.identity option — host-provided identity short-circuits modal/LS
+  // -------------------------------------------------------------------------
+
+  describe("config.identity option", () => {
+    it("uses config.identity without showing the modal when localStorage is empty", async () => {
+      mockGetIdentity.mockReturnValue(null);
+      const response = makeFeedbackResponse({ authorName: "Host User", authorEmail: "host@example.com" });
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch(defaultConfig({ identity: { name: "Host User", email: "host@example.com" } }));
+      expect(capturedBus).not.toBeNull();
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      const payload = mockSendFeedback.mock.calls[0][0];
+      expect(payload.authorName).toBe("Host User");
+      expect(payload.authorEmail).toBe("host@example.com");
+
+      // No identity modal should appear — config short-circuits the prompt
+      const widget = document.querySelector("siteping-widget");
+      const shadow = widget?.shadowRoot;
+      const modal = shadow?.querySelector('[role="dialog"]:not(.sp-detail):not(.sp-shortcuts-overlay)') ?? null;
+      expect(modal).toBeNull();
+
+      instance.destroy();
+    });
+
+    it("config.identity wins over a stored localStorage identity", async () => {
+      mockGetIdentity.mockReturnValue({ name: "LocalStorage User", email: "ls@example.com" });
+      const response = makeFeedbackResponse();
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch(defaultConfig({ identity: { name: "Host User", email: "host@example.com" } }));
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      const payload = mockSendFeedback.mock.calls[0][0];
+      expect(payload.authorName).toBe("Host User");
+      expect(payload.authorEmail).toBe("host@example.com");
+
+      instance.destroy();
+    });
+
+    it("does not write config.identity to localStorage", async () => {
+      mockGetIdentity.mockReturnValue(null);
+      const response = makeFeedbackResponse();
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch(defaultConfig({ identity: { name: "Host User", email: "host@example.com" } }));
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      // Host stays the source of truth — no persistence side-effect.
+      expect(mockSaveIdentity).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("falls back to stored identity when config.identity is unset", async () => {
+      mockGetIdentity.mockReturnValue({ name: "LocalStorage User", email: "ls@example.com" });
+      const response = makeFeedbackResponse({
+        authorName: "LocalStorage User",
+        authorEmail: "ls@example.com",
+      });
+      mockSendFeedback.mockResolvedValue(response);
+
+      const instance = launch(defaultConfig());
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        expect(mockSendFeedback).toHaveBeenCalledOnce();
+      });
+
+      const payload = mockSendFeedback.mock.calls[0][0];
+      expect(payload.authorName).toBe("LocalStorage User");
+      expect(payload.authorEmail).toBe("ls@example.com");
 
       instance.destroy();
     });

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -318,8 +318,10 @@ export function launch(config: SitepingConfig): SitepingInstance {
     try {
       const { annotation, type, message, screenshotDataUrl } = data;
 
-      // Ensure identity
-      let identity = getIdentity();
+      // Ensure identity — config wins (host-provided), then localStorage,
+      // then prompt the user as a last resort. Host-provided identity is
+      // not persisted: the host stays the source of truth on every render.
+      let identity = config.identity ?? getIdentity();
       if (!identity) {
         identity = await promptIdentity(shadow, t);
         if (!identity) return; // User cancelled


### PR DESCRIPTION
## What

Add an optional `identity?: { name: string; email: string }` field to `SitepingConfig`. When set, the widget uses it directly as the feedback author and skips both the localStorage lookup and the identity modal.

Closes #81.

## Why

Host applications that already authenticate the end user (SSO, Symfony Security, NextAuth, …) shouldn't need to re-ask for name and email. Today, the only escape hatches are:

- pre-writing the (currently undocumented) `siteping_identity` localStorage key from the host
- forking the widget

Both are awkward for what should be a one-line config option. The full use-case discussion is in the linked issue.

## Behavior

| Scenario | Result |
|---|---|
| `config.identity` set | Used directly. No localStorage read, no modal, no `saveIdentity` write. |
| `config.identity` unset (default) | Existing behavior unchanged — localStorage lookup, then modal fallback. |

Backward-compatible: no existing consumer is affected. The host stays the source of truth on every render — `config.identity` is intentionally not persisted, so a freshly signed-in user immediately shows up correctly without stale data.

## Changes

- `packages/core/src/types.ts` — new optional `identity` field on `SitepingConfig` with explanatory JSDoc
- `packages/widget/src/launcher.ts` — one-line change: `config.identity ?? getIdentity()` instead of `getIdentity()`
- `README.md` — new "Host-provided identity" section + option in the Configuration code block
- `packages/widget/__tests__/widget/launcher-integration.test.ts` — `mockSaveIdentity` spy plus a new `describe("config.identity option")` block with four scenarios:
  - uses `config.identity` without showing the modal when localStorage is empty
  - `config.identity` wins over a stored localStorage identity
  - does not write `config.identity` to localStorage
  - falls back to stored identity when `config.identity` is unset

## Verification

- `bun run check` — green
- `bun run lint` — green (after `bun run lint:fix` for one Biome formatting suggestion)
- `bunx vitest run packages/widget/__tests__/widget/launcher-integration.test.ts` — 39/39 green, including the four new tests
- `bun run build` — green (all 7 turbo tasks succeed)

Pre-existing note unrelated to this PR: `packages/adapter-localstorage/__tests__/localstorage-store.test.ts` currently fails on `main` (40 tests) because `localStorage` is `undefined` in the test environment — same failures on `main` without my changes. Happy to look at that in a separate PR if you'd like.
