### PR TITLE
chore: spotlight contributors (auto-label, all-contributors, Repobeats, welcome bot)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,46 @@
+{
+  "projectName": "SitePing",
+  "projectOwner": "NeosiaNexus",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "skipCi": true,
+  "contributors": [
+    {
+      "login": "NeosiaNexus",
+      "name": "Olsen Matheo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/63867369?v=4",
+      "profile": "https://github.com/NeosiaNexus",
+      "contributions": [
+        "code",
+        "maintenance",
+        "doc",
+        "design",
+        "infra",
+        "ideas",
+        "review",
+        "test",
+        "projectManagement"
+      ]
+    },
+    {
+      "login": "alceops",
+      "name": "Alce",
+      "avatar_url": "https://avatars.githubusercontent.com/u/278831803?v=4",
+      "profile": "https://github.com/alceops",
+      "contributions": ["code", "translation", "test"]
+    },
+    {
+      "login": "reikjarloekl",
+      "name": "Jörn Bungartz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/839540?v=4",
+      "profile": "https://github.com/reikjarloekl",
+      "contributions": ["bug", "code"]
+    }
+  ]
+}

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+version: v1
+
+labels:
+  - label: "enhancement"
+    matcher:
+      title: "^feat(\\(.+\\))?!?:.*"
+  - label: "bug"
+    matcher:
+      title: "^fix(\\(.+\\))?!?:.*"
+  - label: "documentation"
+    matcher:
+      title: "^docs(\\(.+\\))?!?:.*"
+  - label: "performance"
+    matcher:
+      title: "^perf(\\(.+\\))?!?:.*"
+  - label: "refactor"
+    matcher:
+      title: "^refactor(\\(.+\\))?!?:.*"
+  - label: "test"
+    matcher:
+      title: "^test(\\(.+\\))?!?:.*"
+  - label: "ci"
+    matcher:
+      title: "^ci(\\(.+\\))?!?:.*"
+  - label: "build"
+    matcher:
+      title: "^build(\\(.+\\))?!?:.*"
+  - label: "dependencies"
+    matcher:
+      title: "^(chore\\(deps\\)|deps)(\\(.+\\))?!?:.*"
+  - label: "chore"
+    matcher:
+      title: "^chore(?!\\(deps\\))(\\(.+\\))?!?:.*"
+  - label: "i18n"
+    matcher:
+      title: "(?i).*(i18n|locale|translation|translate).*"
+  - label: "breaking-change"
+    matcher:
+      title: "^[a-z]+(\\(.+\\))?!:.*"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,59 @@
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+
+- name: performance
+  color: 5319e7
+  description: Performance improvement
+
+- name: refactor
+  color: ffb86c
+  description: Code refactor that doesn't change behavior
+
+- name: test
+  color: 32a852
+  description: Adding or improving tests
+
+- name: ci
+  color: c5def5
+  description: CI / CD configuration changes
+
+- name: build
+  color: c2e0c6
+  description: Build system or bundling changes
+
+- name: chore
+  color: cccccc
+  description: Routine maintenance task
+
+- name: dependencies
+  color: 0366d6
+  description: Updates to a dependency file
+
+- name: i18n
+  color: ff7eb6
+  description: Internationalization, locales, translations
+
+- name: breaking-change
+  color: b60205
+  description: Introduces a breaking API or behaviour change
+
+- name: good first issue
+  color: 7057ff
+  description: Good for newcomers
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
+
+- name: ignore-for-release
+  color: e4e669
+  description: Exclude this PR from auto-generated release notes

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,48 @@
+changelog:
+  exclude:
+    labels:
+      - autorelease: pending
+      - autorelease: tagged
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions
+      - github-actions[bot]
+      - renovate[bot]
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - feature
+        - enhancement
+        - feat
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "⚡ Performance"
+      labels:
+        - performance
+        - perf
+    - title: "♻️ Refactoring"
+      labels:
+        - refactor
+    - title: "🧪 Tests"
+      labels:
+        - test
+        - tests
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+        - docs
+    - title: "🌍 Locales & i18n"
+      labels:
+        - i18n
+        - locale
+        - translation
+    - title: "📦 Dependencies"
+      labels:
+        - dependencies
+    - title: "🧰 Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,26 @@
+name: Auto-label PRs
+
+# Safe: this workflow does not check out PR code and only passes env vars to a
+# pinned third-party action via its documented inputs. No shell interpolation of
+# untrusted user input (PR title/body) into run: steps.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from PR title
+        uses: srvaroa/labeler@0a20eccb8c94a1ee0bed5f16859aece1c45c3e55 # v1.13.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,30 @@
+name: Sync repository labels
+
+# Safe: only reads a static config file from the repo and forwards it to a
+# pinned action. No untrusted user input is interpolated into run: steps.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@de749cf181958193cb7debf1a9c5bb28922f3e1b # v5.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: false

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,44 @@
+name: Welcome new contributors
+
+# Safe: this workflow only sends a static greeting via the official
+# actions/first-interaction action. No untrusted user input (PR/issue title,
+# body, head ref, ...) is ever interpolated into a shell `run:` step.
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greet first-time contributors
+        uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            👋 Welcome to **SitePing**, and thanks for opening your first issue!
+
+            A few quick things that help us help you faster:
+
+            - Make sure the issue title is **descriptive** (e.g. `widget: marker tooltip disappears on focus` rather than `bug`).
+            - If it's a bug, include a **reproduction** (CodeSandbox, minimal repo, or numbered steps) and the package + version (`@siteping/widget`, `@siteping/adapter-prisma`, …).
+            - If it's a feature, describe the **use case** before the implementation — it helps us pick the right shape for the API.
+
+            We try to triage within a few days. In the meantime, browse [`good first issue`](https://github.com/NeosiaNexus/SitePing/labels/good%20first%20issue) if you'd like to ship a fix yourself. 🚀
+          pr-message: |
+            🎉 **Welcome, new contributor!** Thanks for your first pull request to SitePing — this is genuinely exciting.
+
+            A few things to know:
+
+            - We use **Conventional Commits** for PR titles (e.g. `feat(widget): …`, `fix(adapter-prisma): …`). The auto-labeller reads the prefix to categorise your work in the next release.
+            - CI runs **typecheck + tests + Playwright E2E** — give it a few minutes to go green.
+            - Once merged, you'll appear in the next [release notes](https://github.com/NeosiaNexus/SitePing/releases) under **New Contributors**, and a maintainer will add you to our [Contributors](https://github.com/NeosiaNexus/SitePing#contributors) table.
+
+            If something feels off in the review, push back — your perspective is welcome. Thanks again for showing up. 💚

--- a/README.md
+++ b/README.md
@@ -587,6 +587,39 @@ If you maintain a fork that adds features, opening an upstream PR or even just a
 
 ---
 
+## Contributors
+
+Every line of code, locale, doc fix, and bug report makes SitePing better. Huge thanks to everyone who has shown up — first-time contributors especially.
+
+This project follows the [all-contributors](https://allcontributors.org) specification — every kind of contribution counts ([emoji key](https://allcontributors.org/docs/en/emoji-key)).
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/NeosiaNexus"><img src="https://avatars.githubusercontent.com/u/63867369?v=4?s=100" width="100px;" alt="Olsen Matheo"/><br /><sub><b>Olsen Matheo</b></sub></a><br /><a href="https://github.com/NeosiaNexus/SitePing/commits?author=NeosiaNexus" title="Code">💻</a> <a href="#maintenance-NeosiaNexus" title="Maintenance">🚧</a> <a href="https://github.com/NeosiaNexus/SitePing/commits?author=NeosiaNexus" title="Documentation">📖</a> <a href="#design-NeosiaNexus" title="Design">🎨</a> <a href="#infra-NeosiaNexus" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#ideas-NeosiaNexus" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/NeosiaNexus/SitePing/pulls?q=is%3Apr+reviewed-by%3ANeosiaNexus" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/NeosiaNexus/SitePing/commits?author=NeosiaNexus" title="Tests">⚠️</a> <a href="#projectManagement-NeosiaNexus" title="Project Management">📆</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/alceops"><img src="https://avatars.githubusercontent.com/u/278831803?v=4?s=100" width="100px;" alt="Alce"/><br /><sub><b>Alce</b></sub></a><br /><a href="https://github.com/NeosiaNexus/SitePing/commits?author=alceops" title="Code">💻</a> <a href="#translation-alceops" title="Translation">🌍</a> <a href="https://github.com/NeosiaNexus/SitePing/commits?author=alceops" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/reikjarloekl"><img src="https://avatars.githubusercontent.com/u/839540?v=4?s=100" width="100px;" alt="Jörn Bungartz"/><br /><sub><b>Jörn Bungartz</b></sub></a><br /><a href="https://github.com/NeosiaNexus/SitePing/issues?q=author%3Areikjarloekl" title="Bug reports">🐛</a> <a href="https://github.com/NeosiaNexus/SitePing/commits?author=reikjarloekl" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+> Want to be in this list? Code, docs, translations, bug reports, design ideas — all count. See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started. The [@all-contributors](https://allcontributors.org/docs/en/bot/usage) bot can add you automatically when a maintainer comments `@all-contributors please add @your-username for code, doc`.
+
+### Activity
+
+![SitePing activity](https://repobeats.axiom.co/api/embed/REPLACE_WITH_YOUR_REPOBEATS_HASH.svg "Repobeats analytics image")
+
+<sub>Activity graph powered by <a href="https://repobeats.axiom.co">Repobeats</a>. Generate your free embed URL at <a href="https://repobeats.axiom.co">repobeats.axiom.co</a> and replace <code>REPLACE_WITH_YOUR_REPOBEATS_HASH</code> above.</sub>
+
+---
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=NeosiaNexus/SitePing&type=Date)](https://star-history.com/#NeosiaNexus/SitePing&Date)

--- a/README.md
+++ b/README.md
@@ -614,9 +614,9 @@ This project follows the [all-contributors](https://allcontributors.org) specifi
 
 ### Activity
 
-![SitePing activity](https://repobeats.axiom.co/api/embed/REPLACE_WITH_YOUR_REPOBEATS_HASH.svg "Repobeats analytics image")
+![SitePing activity](https://repobeats.axiom.co/api/embed/9ac0c24e3801b4397a9ed90af984dfec23323d1c.svg "Repobeats analytics image")
 
-<sub>Activity graph powered by <a href="https://repobeats.axiom.co">Repobeats</a>. Generate your free embed URL at <a href="https://repobeats.axiom.co">repobeats.axiom.co</a> and replace <code>REPLACE_WITH_YOUR_REPOBEATS_HASH</code> above.</sub>
+<sub>Activity graph powered by <a href="https://repobeats.axiom.co">Repobeats</a>.</sub>
 
 ---
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": true,
   "bump-patch-for-minor-pre-major": true,
+  "changelog-notes-type": "github",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Brings SitePing's contributor recognition up to the "Pro OSS" tier (Vite / TanStack / Hono level). Four building blocks:

- **Auto-categorised release notes** — `release-please-config.json` now uses `changelog-notes-type: "github"`, so each release gets GitHub's auto-generated **"New Contributors"** section. `.github/release.yml` maps PR labels to categories (🚀 Features, 🐛 Bug Fixes, 📚 Documentation, 🌍 Locales & i18n, 📦 Dependencies, …).
- **Auto-labeller** — [`srvaroa/labeler`](https://github.com/srvaroa/labeler) reads each PR's title and applies labels (`feat:` → `enhancement`, `fix:` → `bug`, etc.) so that the release notes above are actually categorised, not all dumped into "Other Changes". Config: `.github/labeler.yml`. Workflow: `.github/workflows/auto-label.yml`.
- **Label sync** — `.github/labels.yml` is the single source of truth for the 15 repo labels. `.github/workflows/sync-labels.yml` reconciles them on every push that touches the file (or via `workflow_dispatch`). `skip-delete: true` so manual labels survive.
- **all-contributors + Repobeats + welcome bot** —
  - `.all-contributorsrc` pre-seeded with the 3 real contributors (`@NeosiaNexus`, `@alceops`, `@reikjarloekl`)
  - `README.md` Contributors section: HTML table rendered now (no bot install required), plus the all-contributors markers for future automated updates
  - Repobeats activity embed below the table (hash needs to be generated on axiom.co — see Test plan)
  - `.github/workflows/welcome.yml` greets first-time issue and PR authors via `actions/first-interaction`

## Why now

Repo just crossed 14★ / 5🍴 and is starting to attract external contributors (already 2 merged: `@alceops` shipped 4 locales + 3 test PRs, `@reikjarloekl` shipped a SQLite filter fix). The lack of any contributor recognition becomes visible at this size.

## Security notes

- All workflows that use `pull_request_target` (`auto-label`, `welcome`) **do not check out PR code**. They only forward the GitHub token to a pinned third-party action via its documented inputs — no shell interpolation of untrusted user input.
- Third-party actions pinned by SHA: `srvaroa/labeler@0a20ec…` (v1.13.0), `crazy-max/ghaction-github-labeler@de749c…` (v5.3.0). Consider adding `package-ecosystem: github-actions` to `dependabot.yml` to keep them current.
- `actions/first-interaction@v1` is a first-party GitHub action; pinned by major.

## Test plan

- [ ] Merge this PR. `sync-labels` runs and creates the 15 labels on the repo.
- [ ] Generate Repobeats embed hash at https://repobeats.axiom.co (free, GitHub OAuth). Replace `REPLACE_WITH_YOUR_REPOBEATS_HASH` in the README via a follow-up commit.
- [ ] Install the @all-contributors bot at https://github.com/apps/allcontributors and grant it access to this repo.
- [ ] Verify the README's Contributors table renders correctly on github.com (avatars load, links work).
- [ ] Open a tiny throwaway PR with title `chore: smoke test auto-label` — expect it to receive the `chore` label automatically.
- [ ] On the next release-please PR, verify that the GitHub Release body includes a "## New Contributors" section if applicable, and that PRs are grouped by category.

## Out of scope (potential follow-ups)

- Enabling GitHub Discussions (requires UI action)
- Sponsors badge in the README header
- Code of Conduct
- Dedicated contributors page on siteping.dev