### PR TITLE
chore: align contributor-spotlight labels with existing type: prefix scheme

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,30 +10,30 @@ labels:
   - label: "documentation"
     matcher:
       title: "^docs(\\(.+\\))?!?:.*"
-  - label: "performance"
+  - label: "type:performance"
     matcher:
       title: "^perf(\\(.+\\))?!?:.*"
-  - label: "refactor"
+  - label: "type:refactor"
     matcher:
       title: "^refactor(\\(.+\\))?!?:.*"
-  - label: "test"
+  - label: "type:test"
     matcher:
       title: "^test(\\(.+\\))?!?:.*"
-  - label: "ci"
+  - label: "type:ci"
     matcher:
       title: "^ci(\\(.+\\))?!?:.*"
-  - label: "build"
+  - label: "type:build"
     matcher:
       title: "^build(\\(.+\\))?!?:.*"
   - label: "dependencies"
     matcher:
       title: "^(chore\\(deps\\)|deps)(\\(.+\\))?!?:.*"
-  - label: "chore"
+  - label: "type:chore"
     matcher:
       title: "^chore(?!\\(deps\\))(\\(.+\\))?!?:.*"
-  - label: "i18n"
+  - label: "type:i18n"
     matcher:
       title: "(?i).*(i18n|locale|translation|translate).*"
-  - label: "breaking-change"
+  - label: "type:breaking"
     matcher:
       title: "^[a-z]+(\\(.+\\))?!:.*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-version: v1
+version: 1
 
 labels:
   - label: "enhancement"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,14 @@
+# Label definitions for SitePing.
+#
+# We keep the default GitHub labels (bug, enhancement, documentation,
+# dependencies, good first issue, help wanted) un-prefixed because they are
+# the standard names that Dependabot, badges and the GitHub search syntax
+# expect.
+#
+# All other "type of change" labels live under the `type:` namespace so they
+# group naturally next to the existing `type:performance`, `type:refactor`,
+# `type:breaking`, `type:dx` labels.
+
 - name: enhancement
   color: a2eeef
   description: New feature or request
@@ -10,41 +21,9 @@
   color: 0075ca
   description: Improvements or additions to documentation
 
-- name: performance
-  color: 5319e7
-  description: Performance improvement
-
-- name: refactor
-  color: ffb86c
-  description: Code refactor that doesn't change behavior
-
-- name: test
-  color: 32a852
-  description: Adding or improving tests
-
-- name: ci
-  color: c5def5
-  description: CI / CD configuration changes
-
-- name: build
-  color: c2e0c6
-  description: Build system or bundling changes
-
-- name: chore
-  color: cccccc
-  description: Routine maintenance task
-
 - name: dependencies
   color: 0366d6
   description: Updates to a dependency file
-
-- name: i18n
-  color: ff7eb6
-  description: Internationalization, locales, translations
-
-- name: breaking-change
-  color: b60205
-  description: Introduces a breaking API or behaviour change
 
 - name: good first issue
   color: 7057ff
@@ -53,6 +32,26 @@
 - name: help wanted
   color: 008672
   description: Extra attention is needed
+
+- name: type:test
+  color: 32a852
+  description: Adding or improving tests
+
+- name: type:ci
+  color: c5def5
+  description: CI / CD configuration changes
+
+- name: type:build
+  color: c2e0c6
+  description: Build system or bundling changes
+
+- name: type:chore
+  color: cccccc
+  description: Routine maintenance task
+
+- name: type:i18n
+  color: ff7eb6
+  description: Internationalization, locales, translations
 
 - name: ignore-for-release
   color: e4e669

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,36 +13,35 @@ changelog:
   categories:
     - title: "🚀 Features"
       labels:
-        - feature
         - enhancement
-        - feat
     - title: "🐛 Bug Fixes"
       labels:
         - bug
-        - fix
     - title: "⚡ Performance"
       labels:
-        - performance
-        - perf
+        - type:performance
     - title: "♻️ Refactoring"
       labels:
-        - refactor
+        - type:refactor
     - title: "🧪 Tests"
       labels:
-        - test
-        - tests
+        - type:test
     - title: "📚 Documentation"
       labels:
         - documentation
-        - docs
     - title: "🌍 Locales & i18n"
       labels:
-        - i18n
-        - locale
-        - translation
+        - type:i18n
+    - title: "💥 Breaking Changes"
+      labels:
+        - type:breaking
     - title: "📦 Dependencies"
       labels:
         - dependencies
+    - title: "🛠️ Build & CI"
+      labels:
+        - type:build
+        - type:ci
     - title: "🧰 Other Changes"
       labels:
         - "*"


### PR DESCRIPTION
## Summary

Follow-up to #83. The first pass introduced flat labels (`refactor`, `breaking-change`, `chore`, `ci`, `build`, `test`, `i18n`) which duplicated the repo's pre-existing scoped scheme (`type:refactor`, `type:breaking`, `type:performance`, `type:dx`). This PR aligns everything.

## What changes

| Old (flat) | New (aligned) | Rationale |
|---|---|---|
| `refactor` | `type:refactor` (already existed) | reuse existing |
| `breaking-change` | `type:breaking` (already existed) | reuse existing |
| `performance` | `type:performance` (already existed) | reuse existing |
| `test` | `type:test` | match scope `type:` namespace |
| `ci` | `type:ci` | match scope `type:` namespace |
| `build` | `type:build` | match scope `type:` namespace |
| `chore` | `type:chore` | match scope `type:` namespace |
| `i18n` | `type:i18n` | match scope `type:` namespace |

**Stay un-prefixed** (because Dependabot, GitHub badges and `gh` search syntax assume these exact names):
- `bug`, `enhancement`, `documentation`, `dependencies`, `good first issue`, `help wanted`

## Bonus

- Added a dedicated **💥 Breaking Changes** section in `release.yml`
- Merged `type:build` + `type:ci` into a single **🛠️ Build & CI** category to avoid noisy single-PR sections

## Post-merge cleanup

After this PR merges, the orphaned flat labels need to be deleted:

```bash
gh label delete refactor --yes
gh label delete breaking-change --yes
gh label delete build --yes
gh label delete chore --yes
gh label delete ci --yes
gh label delete i18n --yes
gh label delete test --yes
```

I'll run these after the merge.

## Test plan

- [ ] CI green
- [ ] After merge, `Sync repository labels` creates the new `type:test`, `type:ci`, `type:build`, `type:chore`, `type:i18n` labels
- [ ] After merge, delete the 7 orphaned flat labels (commands above)
- [ ] Open a smoke-test PR with title `test: dummy` → expect label `type:test` (not `test`)