### PR TITLE
ci: auto-credit contributors in release notes

### DIFF
--- a/.github/workflows/enrich-release.yml
+++ b/.github/workflows/enrich-release.yml
@@ -1,0 +1,178 @@
+name: Enrich release notes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to (re-)enrich (e.g. widget-v0.9.9)'
+        required: true
+        type: string
+      force:
+        description: 'Re-enrich even if marker is present'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: enrich-release-${{ github.event.release.id || inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append contributors section to release notes
+        uses: actions/github-script@v7
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_FORCE: ${{ inputs.force }}
+        with:
+          script: |
+            const ENRICHED_MARKER = '<!-- contributors-enriched -->';
+            const BOT_LOGINS = new Set([
+              'github-actions[bot]',
+              'allcontributors[bot]',
+              'release-please[bot]',
+              'dependabot[bot]',
+              'renovate[bot]',
+              'pre-commit-ci[bot]',
+              'codecov[bot]',
+            ]);
+
+            const { owner, repo } = context.repo;
+
+            let release;
+            const force = process.env.INPUT_FORCE === 'true';
+            if (context.eventName === 'workflow_dispatch') {
+              const inputTag = process.env.INPUT_RELEASE_TAG;
+              if (!inputTag) {
+                core.setFailed('release_tag input is required for manual dispatch');
+                return;
+              }
+              const { data } = await github.rest.repos.getReleaseByTag({ owner, repo, tag: inputTag });
+              release = data;
+            } else {
+              release = context.payload.release;
+            }
+
+            const tag = release.tag_name;
+            const currentBody = release.body || '';
+
+            if (currentBody.includes(ENRICHED_MARKER) && !force) {
+              core.info(`Release ${tag} already enriched — skipping. Use workflow_dispatch with force=true to re-enrich.`);
+              return;
+            }
+
+            // Strip any prior enriched section so re-runs don't duplicate it.
+            const bodyWithoutPrior = currentBody.split(/\n\n---\n\n## 👥 Contributors/)[0].trimEnd();
+
+            // Tag prefix isolates per-package releases in this monorepo.
+            // e.g. "widget-v0.9.9" → prefix "widget-", "v1.2.3" → prefix "v"
+            const prefixMatch = tag.match(/^(.*?)v?\d+\.\d+\.\d+/);
+            const prefix = prefixMatch ? prefixMatch[1] : '';
+
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner, repo, per_page: 100,
+            });
+
+            const previous = releases.find(r =>
+              r.tag_name !== tag &&
+              r.tag_name.startsWith(prefix) &&
+              !r.draft &&
+              new Date(r.created_at) < new Date(release.created_at)
+            );
+
+            if (!previous) {
+              core.info(`No previous release found with prefix "${prefix}" — first release of this package, skipping contributor enrichment.`);
+              return;
+            }
+
+            const previousTag = previous.tag_name;
+            core.info(`Comparing ${previousTag}...${tag}`);
+
+            const { data: compare } = await github.rest.repos.compareCommitsWithBasehead({
+              owner, repo,
+              basehead: `${previousTag}...${tag}`,
+            });
+
+            const authors = new Map();
+            for (const commit of compare.commits) {
+              const login = commit.author?.login;
+              if (!login || BOT_LOGINS.has(login)) continue;
+              if (!authors.has(login)) {
+                authors.set(login, {
+                  login,
+                  html_url: commit.author.html_url,
+                  count: 0,
+                });
+              }
+              authors.get(login).count += 1;
+
+              // Co-authored-by trailers (carries credit for pair programming, etc.)
+              const coAuthorRegex = /^Co-authored-by:\s*([^<]+?)\s*<([^>]+)>/gim;
+              const message = commit.commit?.message || '';
+              let m;
+              while ((m = coAuthorRegex.exec(message)) !== null) {
+                const email = m[2].trim().toLowerCase();
+                if (email.includes('noreply.github.com')) {
+                  const loginMatch = email.match(/^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/);
+                  const coLogin = loginMatch ? loginMatch[1] : null;
+                  if (coLogin && !BOT_LOGINS.has(coLogin) && !authors.has(coLogin)) {
+                    authors.set(coLogin, {
+                      login: coLogin,
+                      html_url: `https://github.com/${coLogin}`,
+                      count: 1,
+                      coAuthor: true,
+                    });
+                  }
+                }
+              }
+            }
+
+            // Pull GitHub's own "New Contributors" section — it knows the full history.
+            let newContribSection = '';
+            try {
+              const { data: generated } = await github.rest.repos.generateReleaseNotes({
+                owner, repo,
+                tag_name: tag,
+                previous_tag_name: previousTag,
+              });
+              const match = generated.body.match(/##+\s*New Contributors[\s\S]*?(?=\n##|$)/);
+              if (match) newContribSection = match[0].trim();
+            } catch (err) {
+              core.warning(`generateReleaseNotes failed: ${err.message}`);
+            }
+
+            let section = `\n\n---\n\n## 👥 Contributors\n\n`;
+
+            if (authors.size === 0) {
+              section += `_Maintainer-only release._\n`;
+            } else {
+              section += `Thanks to everyone whose work shipped in this release:\n\n`;
+              const sorted = [...authors.values()].sort((a, b) => b.count - a.count || a.login.localeCompare(b.login));
+              for (const a of sorted) {
+                const suffix = a.coAuthor ? ' _(co-author)_' : ` (${a.count} commit${a.count > 1 ? 's' : ''})`;
+                section += `- [@${a.login}](${a.html_url})${suffix}\n`;
+              }
+            }
+
+            if (newContribSection) {
+              const reformatted = newContribSection
+                .replace(/##+\s*New Contributors/, '### 🎉 First-time contributors');
+              section += `\n${reformatted}\n`;
+            }
+
+            section += `\n${ENRICHED_MARKER}`;
+
+            await github.rest.repos.updateRelease({
+              owner, repo,
+              release_id: release.id,
+              body: bodyWithoutPrior + section,
+            });
+
+            core.info(`Enriched ${tag} with ${authors.size} contributor(s)${newContribSection ? ' + first-time section' : ''}.`);


### PR DESCRIPTION
## Summary

Adds a workflow (`.github/workflows/enrich-release.yml`) that automatically appends a **👥 Contributors** section to every GitHub release published — no more manually editing release notes to credit external contributors.

Triggered on `release: published`, so it runs after release-please creates each per-package release.

## What gets added to release notes

```markdown
---

## 👥 Contributors

Thanks to everyone whose work shipped in this release:

- [@andinger](https://github.com/andinger) (1 commit)
- [@some-other-user](https://github.com/some-other-user) (3 commits) _(co-author)_

### 🎉 First-time contributors

* @andinger made their first contribution in #82
```

## Design choices

- **Per-package isolation** — tag prefix matching (`widget-`, `cli-`, …) so each release only credits commits in *its own* release window. No cross-contamination between packages bumped at the same time.
- **Co-authored-by trailers** are parsed and credited (with a `_(co-author)_` tag) when the email is a `users.noreply.github.com` form. Useful for pair programming or AI-assisted commits.
- **Bot allowlist** excludes `github-actions[bot]`, `allcontributors[bot]`, `release-please[bot]`, `dependabot[bot]`, `renovate[bot]`, `pre-commit-ci[bot]`, `codecov[bot]`.
- **Idempotent** — `<!-- contributors-enriched -->` HTML marker prevents double-appending if the workflow re-runs.
- **First-time contributors** subsection — pulls from GitHub's own `generateReleaseNotes` API, which knows the full history, so a user's first-ever commit gets the 🎉.

## Manual backfill

Includes a `workflow_dispatch` trigger:
- `release_tag` (required) — e.g. `widget-v0.9.9`
- `force` (default false) — re-enrich even if the marker is present

Useful to backfill past releases or re-run after fixing data.

## Test plan

- [ ] Workflow YAML is valid (verified locally with `python3 -c yaml.safe_load`)
- [ ] After merge, manually dispatch on `widget-v0.9.9` to verify enrichment renders correctly
- [ ] Next real release (any package) triggers the workflow automatically and prepends the Contributors section
- [ ] Verify bots are filtered out and first-time contributors get the 🎉 subsection

## Why now

PR #82 (@andinger's first contribution) shipped in widget-v0.9.9 yesterday. The release notes had to be edited manually to credit them — exactly the kind of friction this workflow eliminates. Going forward, every contributor — first-timer or returning — gets credit on the release page without maintainer effort.