### PR TITLE
feat(widget): deep-link to annotations via URL query + focusFeedback API

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,44 @@ When `identity` is unset (default), the widget falls back to the existing behavi
 
 ---
 
+## Deep-linking to annotations
+
+When a feedback is created, downstream tools (Zammad tickets, Slack notifications, email digests, internal dashboards) usually want to link back to the exact pixel — not just the page. Set `deepLink: true` and the widget will pick up a `?siteping=<feedbackId>` query parameter on initial load, scroll the matching annotation into view, pin its highlight, and pulse the marker.
+
+```ts
+initSiteping({
+  endpoint: '/api/siteping',
+  projectName: 'my-app',
+  deepLink: true,
+})
+```
+
+```ts
+// On the receiving side (Zammad webhook, Slack handler, …), build the link:
+const url = `${feedback.url}?siteping=${feedback.id}`
+```
+
+When the recipient clicks the link, the widget opens on the original page with the annotation already in focus. Use a custom query key if `siteping` clashes with a host-app parameter:
+
+```ts
+deepLink: { param: 'fb' }   // → ?fb=<feedbackId>
+```
+
+**Only the initial page load triggers focus.** SPA navigations and `history.pushState` updates are ignored on purpose — re-scrolling during normal browsing would be surprising. Hosts that need to drive focus after a route change can call the imperative counterpart instead:
+
+```ts
+const widget = initSiteping({ endpoint: '/api/siteping', projectName: 'my-app' })
+
+// Inside a notification handler, after navigating to feedback.url:
+const matched = widget.focusFeedback(feedback.id)
+// Returns false when no visible marker matches (unknown ID, filtered by
+// scopeAnnotationsByUrl, or markers not yet loaded — initial fetch is async).
+```
+
+Both entry points share the same focus implementation — only the trigger differs.
+
+---
+
 ## Diagnostics capture
 
 Turn on `captureDiagnostics` and every feedback ships with the last few `console.*` messages and failed network requests (HTTP ≥ 400 or network error). Closes the loop on the dreaded *"this page just doesn't work"* report.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,6 +90,30 @@ export interface SitepingConfig {
   /** Called when the widget is skipped (production mode, mobile viewport) */
   onSkip?: (reason: "production" | "mobile") => void;
   /**
+   * Auto-focus a specific annotation when its ID appears in the URL query
+   * string. Lets hosts deeplink directly into a feedback from external
+   * systems (Zammad tickets, Slack notifications, dashboard rows).
+   *
+   * When enabled, the widget reads the configured query parameter from
+   * `window.location.search` right after the initial markers load. If the
+   * value matches a visible feedback ID, the widget scrolls the annotation
+   * into view, pins its highlight, and pulses the marker — the same visual
+   * affordance a marker click produces.
+   *
+   * - `false` / `undefined` (default): no URL parsing. Existing behavior
+   *   unchanged, no host URL inspection.
+   * - `true`: enabled with default query parameter name `siteping`.
+   * - object: enabled with a custom parameter name. Use this to avoid
+   *   clashes with host-app query keys.
+   *
+   * Only the initial load triggers focus. Subsequent URL changes (SPA
+   * navigation, `history.pushState`, hash updates) are ignored —
+   * deliberate, to avoid surprising re-scrolls during normal browsing.
+   * Hosts that need re-focus on route change can call
+   * `instance.focusFeedback(id)` explicitly.
+   */
+  deepLink?: boolean | { param?: string } | undefined;
+  /**
    * Pre-fill author identity from the host application — typically the
    * currently signed-in user. When set, the widget uses these values
    * directly and never shows the identity modal, even on first feedback.
@@ -144,6 +168,17 @@ export interface SitepingInstance {
   close: () => void;
   /** Reload feedbacks from server */
   refresh: () => void;
+  /**
+   * Scroll the matching annotation into view, pin its highlight, and
+   * pulse its marker. Returns `true` when a visible feedback matched the
+   * given ID, `false` otherwise (unknown ID, feedback on another URL when
+   * `scopeAnnotationsByUrl` filtered it out, or markers not yet loaded).
+   *
+   * Counterpart to the `deepLink` config option for hosts that prefer to
+   * drive focus from JS (e.g., a notification click handler) instead of a
+   * URL query parameter.
+   */
+  focusFeedback: (feedbackId: string) => boolean;
   /** Subscribe to a public widget event */
   on: <K extends keyof SitepingPublicEvents>(
     event: K,

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -75,6 +75,8 @@ All configuration options for `initSiteping()`:
 | `locale` | `'en' \| 'fr' \| 'de' \| 'es' \| 'it' \| 'pt' \| 'ru'` | `'en'` | Widget UI language. Unknown locales fall back to English |
 | `forceShow` | `boolean` | `false` | Show the widget in production (hidden by default) |
 | `debug` | `boolean` | `false` | Enable debug logging to console |
+| `identity` | `{ name: string; email: string }` | — | Pre-fill author identity from the host (SSO). When set, the widget skips the identity modal |
+| `deepLink` | `boolean \| { param?: string }` | `false` | On initial load, focus the annotation referenced by `?siteping=<id>` (or a custom query key). SPA navigations are ignored — use `focusFeedback()` for route-change focus |
 
 > **Custom translations** — Use `registerLocale(code, translations)` to add your own locale at runtime.
 
@@ -121,6 +123,14 @@ widget.open()       // Open the feedback panel
 widget.close()      // Close the feedback panel
 widget.refresh()    // Refresh feedbacks from the server
 widget.destroy()    // Remove the widget and clean up all DOM elements + listeners
+
+// Scroll a specific annotation into view, pin its highlight, and pulse the
+// marker. Counterpart to the `deepLink` config option for hosts that drive
+// focus from JS (e.g. a notification click handler) instead of a URL query.
+// Returns `false` when no visible marker matches the given ID (unknown ID,
+// filtered by `scopeAnnotationsByUrl`, or markers not yet loaded — initial
+// fetch is async).
+widget.focusFeedback('feedback-id') // => boolean
 ```
 
 ## Event system

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -52,6 +52,7 @@ vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
 // instance that launch() created. Reset by `vi.clearAllMocks` in afterEach.
 const mockMarkersAddFeedback = vi.fn();
 const mockMarkersRender = vi.fn();
+const mockMarkersFocusFeedback = vi.fn().mockReturnValue(false);
 
 vi.mock(new URL("../../src/markers.js", import.meta.url).pathname, () => ({
   MarkerManager: vi.fn().mockImplementation(() => ({
@@ -59,6 +60,7 @@ vi.mock(new URL("../../src/markers.js", import.meta.url).pathname, () => ({
     highlight: vi.fn(),
     pinHighlight: vi.fn(),
     addFeedback: mockMarkersAddFeedback,
+    focusFeedback: mockMarkersFocusFeedback,
     destroy: vi.fn(),
     count: 0,
   })),
@@ -163,6 +165,11 @@ describe("launcher — annotation:complete integration", () => {
     capturedBus = null;
     vi.clearAllMocks();
     mockGetIdentity.mockReturnValue({ name: "Test User", email: "test@example.com" });
+    mockMarkersFocusFeedback.mockReturnValue(false);
+    // Reset any test-set URL — jsdom keeps it across cases otherwise.
+    if (window.location.search) {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
   });
 
   // -------------------------------------------------------------------------
@@ -389,6 +396,131 @@ describe("launcher — annotation:complete integration", () => {
       const payload = mockSendFeedback.mock.calls[0][0];
       expect(payload.authorName).toBe("LocalStorage User");
       expect(payload.authorEmail).toBe("ls@example.com");
+
+      instance.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deepLink option — auto-focus annotation when ?siteping=<id> is set
+  // -------------------------------------------------------------------------
+
+  describe("deepLink option", () => {
+    it("does not read the URL when deepLink is omitted (default off)", async () => {
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-deep-1" })],
+        total: 1,
+      });
+      window.history.replaceState(null, "", "/?siteping=fb-deep-1");
+
+      const instance = launch(defaultConfig());
+
+      // Initial getFeedbacks resolves and renders markers — wait for that.
+      await vi.waitFor(() => {
+        expect(mockMarkersRender).toHaveBeenCalled();
+      });
+
+      expect(mockMarkersFocusFeedback).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("calls focusFeedback with the id from ?siteping=<id> when deepLink is true", async () => {
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-deep-1" })],
+        total: 1,
+      });
+      mockMarkersFocusFeedback.mockReturnValueOnce(true);
+      window.history.replaceState(null, "", "/?siteping=fb-deep-1");
+
+      const instance = launch(defaultConfig({ deepLink: true }));
+
+      await vi.waitFor(() => {
+        expect(mockMarkersFocusFeedback).toHaveBeenCalledWith("fb-deep-1");
+      });
+
+      instance.destroy();
+    });
+
+    it("uses the custom param name when deepLink: { param: 'fb' }", async () => {
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-deep-2" })],
+        total: 1,
+      });
+      mockMarkersFocusFeedback.mockReturnValueOnce(true);
+      window.history.replaceState(null, "", "/?fb=fb-deep-2&siteping=ignored");
+
+      const instance = launch(defaultConfig({ deepLink: { param: "fb" } }));
+
+      await vi.waitFor(() => {
+        expect(mockMarkersFocusFeedback).toHaveBeenCalledWith("fb-deep-2");
+      });
+      // The default "siteping" key must not leak in when a custom param is configured.
+      expect(mockMarkersFocusFeedback).not.toHaveBeenCalledWith("ignored");
+
+      instance.destroy();
+    });
+
+    it("does not call focusFeedback when the configured param is absent", async () => {
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-deep-3" })],
+        total: 1,
+      });
+      // URL carries some other key but not `siteping`.
+      window.history.replaceState(null, "", "/?other=value");
+
+      const instance = launch(defaultConfig({ deepLink: true }));
+
+      await vi.waitFor(() => {
+        expect(mockMarkersRender).toHaveBeenCalled();
+      });
+
+      expect(mockMarkersFocusFeedback).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("calls focusFeedback even when the id does not match (false return is OK)", async () => {
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-deep-4" })],
+        total: 1,
+      });
+      mockMarkersFocusFeedback.mockReturnValueOnce(false);
+      window.history.replaceState(null, "", "/?siteping=does-not-exist");
+
+      const instance = launch(defaultConfig({ deepLink: true }));
+
+      // Still calls focusFeedback — the manager decides whether the id resolves.
+      await vi.waitFor(() => {
+        expect(mockMarkersFocusFeedback).toHaveBeenCalledWith("does-not-exist");
+      });
+
+      instance.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // instance.focusFeedback — imperative entry point
+  // -------------------------------------------------------------------------
+
+  describe("instance.focusFeedback", () => {
+    it("delegates to the MarkerManager and returns its result", () => {
+      mockMarkersFocusFeedback.mockReturnValueOnce(true);
+      const instance = launch(defaultConfig());
+
+      const result = instance.focusFeedback("fb-imperative-1");
+
+      expect(mockMarkersFocusFeedback).toHaveBeenCalledWith("fb-imperative-1");
+      expect(result).toBe(true);
+
+      instance.destroy();
+    });
+
+    it("returns false when the MarkerManager has no matching entry", () => {
+      mockMarkersFocusFeedback.mockReturnValueOnce(false);
+      const instance = launch(defaultConfig());
+
+      expect(instance.focusFeedback("unknown-id")).toBe(false);
 
       instance.destroy();
     });

--- a/packages/widget/__tests__/widget/markers.test.ts
+++ b/packages/widget/__tests__/widget/markers.test.ts
@@ -337,6 +337,44 @@ describe("MarkerManager", () => {
   });
 
   // -------------------------------------------------------------------------
+  // focusFeedback — deep-link entry point
+  // -------------------------------------------------------------------------
+
+  describe("focusFeedback", () => {
+    it("returns false when no feedback matches the given id", () => {
+      markers.render([makeFeedback({ id: "fb-1" })]);
+      expect(markers.focusFeedback("does-not-exist")).toBe(false);
+    });
+
+    it("returns true and scrolls the marker into view when the id matches", () => {
+      markers.render([makeFeedback({ id: "fb-1" })]);
+      const marker = document.querySelector<HTMLElement>('[data-feedback-id="fb-1"]')!;
+      // jsdom does not implement scrollIntoView — install a spy before calling.
+      const scrollSpy = vi.fn();
+      marker.scrollIntoView = scrollSpy;
+
+      expect(markers.focusFeedback("fb-1")).toBe(true);
+
+      expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    });
+
+    it("pins the highlight overlay and pulses the marker on match", () => {
+      markers.render([makeFeedback({ id: "fb-1" })]);
+      const marker = document.querySelector<HTMLElement>('[data-feedback-id="fb-1"]')!;
+      marker.scrollIntoView = vi.fn();
+
+      markers.focusFeedback("fb-1");
+
+      // pinHighlight renders one highlight div per annotation inside the
+      // markers container. pulse animation is set on the marker element.
+      const container = document.getElementById("siteping-markers")!;
+      const highlights = container.querySelectorAll<HTMLElement>(":scope > div:not([data-feedback-id])");
+      expect(highlights.length).toBeGreaterThan(0);
+      expect(marker.style.animation).toContain("sp-pulse-ring");
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Annotations toggle via event bus
   // -------------------------------------------------------------------------
 

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -493,11 +493,11 @@ export function launch(config: SitepingConfig): SitepingInstance {
       }
     },
     focusFeedback: (feedbackId: string) => {
-      // Delegate to MarkerManager — returns false when no entry matches
-      // (unknown ID, feedback on another URL when `scopeAnnotationsByUrl`
-      // filtered it out, or markers not yet loaded). Hosts driving focus
-      // from a notification handler can either wait for `feedback:sent`
-      // (rare race) or accept the false return and retry.
+      // Returns false when no entry matches — unknown ID, feedback filtered
+      // out by `scopeAnnotationsByUrl`, or markers not yet loaded (the
+      // initial getFeedbacks is async, and the widget exposes no public
+      // "markers ready" event today). Hosts that race against initial load
+      // can retry, or trigger focus from a user gesture instead.
       return markers.focusFeedback(feedbackId);
     },
     refresh: () => {

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -65,9 +65,29 @@ function skippedInstance(): SitepingInstance {
     open: noop,
     close: noop,
     refresh: noop,
+    focusFeedback: () => false,
     on: () => noop,
     off: noop,
   };
+}
+
+interface NormalisedDeepLink {
+  enabled: boolean;
+  param: string;
+}
+
+/**
+ * Resolve `SitepingConfig.deepLink` into a normalised shape.
+ *
+ * - `undefined` / `false` → disabled, no URL parsing.
+ * - `true` → enabled with default param name `siteping`.
+ * - object → enabled with optional custom param name. A bare empty object
+ *   `{}` falls back to the default param so callers never need to repeat it.
+ */
+function normaliseDeepLinkOptions(value: SitepingConfig["deepLink"]): NormalisedDeepLink {
+  if (value === undefined || value === false) return { enabled: false, param: "siteping" };
+  if (value === true) return { enabled: true, param: "siteping" };
+  return { enabled: true, param: value.param ?? "siteping" };
 }
 
 /**
@@ -401,12 +421,29 @@ export function launch(config: SitepingConfig): SitepingInstance {
   // on another (when CSS selectors happen to match unrelated elements).
   const initialScope = getScope();
   const initialOptions = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: initialScope.url } : { limit: PAGE_SIZE };
+  const deepLinkOpts = normaliseDeepLinkOptions(config.deepLink);
   client
     .getFeedbacks(config.projectName, initialOptions)
     .then(({ feedbacks }: { feedbacks: FeedbackResponse[] }) => {
       // Defensive client-side filter — backend may not yet support the `url` query.
       const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === initialScope.url) : feedbacks;
       markers.render(visible);
+      // Apply deeplink focus once markers exist. Failures here are
+      // non-fatal — a malformed URL or an unknown ID just leaves the page
+      // as the user found it, so log and move on.
+      if (deepLinkOpts.enabled) {
+        try {
+          const focusId = new URLSearchParams(window.location.search).get(deepLinkOpts.param);
+          if (focusId) {
+            const matched = markers.focusFeedback(focusId);
+            log(
+              `deepLink ?${deepLinkOpts.param}=${focusId} ${matched ? "focused" : "did not match a visible feedback"}`,
+            );
+          }
+        } catch (e) {
+          log("deepLink parsing failed:", e);
+        }
+      }
     })
     .catch((err) => {
       log("Failed to load initial markers:", err);
@@ -454,6 +491,14 @@ export function launch(config: SitepingConfig): SitepingInstance {
         // Cancel a pending open before the panel has loaded.
         pendingOpen = false;
       }
+    },
+    focusFeedback: (feedbackId: string) => {
+      // Delegate to MarkerManager — returns false when no entry matches
+      // (unknown ID, feedback on another URL when `scopeAnnotationsByUrl`
+      // filtered it out, or markers not yet loaded). Hosts driving focus
+      // from a notification handler can either wait for `feedback:sent`
+      // (rare race) or accept the false return and retry.
+      return markers.focusFeedback(feedbackId);
     },
     refresh: () => {
       // When the panel is open, its `refresh()` already runs `loadFeedbacks()`

--- a/packages/widget/src/markers.ts
+++ b/packages/widget/src/markers.ts
@@ -534,6 +534,31 @@ export class MarkerManager {
     return marker;
   }
 
+  /**
+   * Scroll the annotation into view, pin its highlight, and pulse its marker.
+   *
+   * Powers the `deepLink` config option and the public
+   * `instance.focusFeedback(id)` method. Returns `false` when no entry
+   * matches — caller logs that case, the manager stays silent.
+   *
+   * Scrolling uses the marker element's current document position via
+   * `scrollIntoView`, not the original `scrollX/scrollY` captured at
+   * annotation time. That keeps the focus correct after layout changes
+   * (responsive breakpoints, lazy-loaded content) because the marker has
+   * already been re-positioned to track the live anchor.
+   */
+  focusFeedback(feedbackId: string): boolean {
+    const entry = this.entries.find((e) => e.feedback.id === feedbackId);
+    if (!entry) return false;
+    const markerEl = entry.elements[0];
+    if (markerEl) {
+      markerEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+    this.pinHighlight(entry.feedback);
+    this.highlight(feedbackId);
+    return true;
+  }
+
   highlight(feedbackId: string): void {
     for (const entry of this.entries) {
       if (entry.feedback.id === feedbackId) {


### PR DESCRIPTION
Closes #90.

## Summary

- Adds `deepLink?: boolean | { param?: string }` to `SitepingConfig`. When enabled, the widget reads a query parameter from `window.location.search` after the initial markers load and focuses the matching feedback — scrolls it into view, pins the highlight, pulses the marker. Default `false`, so existing consumers see no change.
- Adds `instance.focusFeedback(feedbackId): boolean` as an imperative counterpart for hosts that prefer driving focus from JS (notification click handlers, in-app navigation) instead of a URL.
- Adds `MarkerManager.focusFeedback(id)` which both entry points delegate to — single source of truth for the focus behavior.

## Why

Use case: deep-link into a feedback annotation from external systems — ticket bodies (Zammad, Linear, Jira), Slack notifications, dashboard rows. Today reviewers have to open the page and hunt for the right marker among many. With a deep-link they land on the exact page with the exact spot highlighted in one click.

The widget already has all the primitives — `pinHighlight` + `highlight` are what a marker click triggers internally. The PR wires those to a URL query parameter and exposes a public method.

## Behavior

- `deepLink: undefined | false` (default): no URL parsing, no behavior change.
- `deepLink: true`: enabled with default param name `siteping`.
- `deepLink: { param: 'fb' }`: enabled with a custom name (avoid clashes with host-app keys).
- Only the initial load triggers focus. SPA navigations and `history.pushState` are ignored — deliberate, to avoid surprise re-scrolls during normal browsing.
- Scrolling uses `marker.scrollIntoView({ behavior: 'smooth', block: 'center' })` on the live marker element. That keeps focus correct after layout changes (responsive breakpoints, lazy content) because the marker tracks the re-resolved anchor on every reposition pass.
- Failures are non-fatal: malformed URLs, unknown IDs, or feedbacks filtered out by `scopeAnnotationsByUrl` just log (when `debug: true`) and leave the page untouched. No throws on the init path.

## API additions

```ts
// packages/core/src/types.ts
interface SitepingConfig {
  // ...
  deepLink?: boolean | { param?: string } | undefined;
}

interface SitepingInstance {
  // ...
  focusFeedback: (feedbackId: string) => boolean;
}
```

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run check` — clean
- [x] `bun run test:run` — 8 new tests passing (3 markers + 5 launcher-integration + 2 instance.focusFeedback); pre-existing localStorage adapter failures unchanged (40 on `main`, 40 with this PR — outside this PR's scope)
- [x] `bun run build` — clean (7/7 packages)
- [x] `bun run size` — ESM widget 25.12 kB gzip (54 kB budget), IIFE 103.76 kB gzip (110 kB budget) — comfortably under
- [x] Manual smoke: open a page with the widget, append `?siteping=<id>` for a known feedback, reload — annotation auto-focuses and stays highlighted until clicked away
- [x] Manual smoke: same with `deepLink: false` (default) — URL ignored, no behavior change
- [x] Manual smoke: `instance.focusFeedback(id)` from the JS console scrolls + highlights as expected