### PR TITLE
fix(widget): opaque backdrop-filter fallback for .sp-detail

### DIFF
--- a/packages/widget/__tests__/widget/panel-detail.test.ts
+++ b/packages/widget/__tests__/widget/panel-detail.test.ts
@@ -3,7 +3,7 @@
 import type { AnnotationResponse, FeedbackResponse } from "@siteping/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createT } from "../../src/i18n/index.js";
-import { type DetailCallbacks, DetailView } from "../../src/panel-detail.js";
+import { DETAIL_CSS, type DetailCallbacks, DetailView } from "../../src/panel-detail.js";
 import { buildThemeColors } from "../../src/styles/theme.js";
 
 // ---------------------------------------------------------------------------
@@ -1093,6 +1093,39 @@ describe("DetailView", () => {
       setup.view.show(fb, 1);
       const status = setup.view.element.querySelector(".sp-detail-diag-net-status");
       expect(status?.textContent).toBe("ERR");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CSS — backdrop-filter fallback (regression guard for the Safari 18.6
+  // compositing bug + Firefox <=102 / legacy engines). Asserts both
+  // disjoint @supports blocks remain in DETAIL_CSS so the translucent
+  // default doesn't sneak back in during a refactor.
+  // ---------------------------------------------------------------------------
+
+  describe("DETAIL_CSS — backdrop-filter fallback", () => {
+    it("emits an @supports block for engines with no backdrop-filter at all", () => {
+      expect(DETAIL_CSS).toMatch(
+        /@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\)/,
+      );
+    });
+
+    it("emits an @supports block for engines that only advertise the -webkit- prefix", () => {
+      expect(DETAIL_CSS).toMatch(
+        /@supports \(-webkit-backdrop-filter: blur\(1px\)\) and \(not \(backdrop-filter: blur\(1px\)\)\)/,
+      );
+    });
+
+    it("both fallback blocks override .sp-detail to an opaque var(--sp-bg)", () => {
+      // Strip whitespace before matching so cosmetic formatting can change
+      // without breaking the test.
+      const compact = DETAIL_CSS.replace(/\s+/g, " ");
+      expect(compact).toContain(
+        "@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) { .sp-detail { background: var(--sp-bg); } }",
+      );
+      expect(compact).toContain(
+        "@supports (-webkit-backdrop-filter: blur(1px)) and (not (backdrop-filter: blur(1px))) { .sp-detail { background: var(--sp-bg); } }",
+      );
     });
   });
 });

--- a/packages/widget/src/panel-detail.ts
+++ b/packages/widget/src/panel-detail.ts
@@ -71,6 +71,39 @@ export const DETAIL_CSS = /* css */ `
     transform: translateX(0);
   }
 
+  /* Fallback for browsers that cannot deliver a readable "frosted glass":
+     drop the translucent background to a solid one so the underlying list
+     does not bleed through. Two disjoint cohorts:
+
+       1. No backdrop-filter at all (Firefox <=102, legacy Edge / IE,
+          older Chromium on Linux).
+       2. Safari / iOS Safari where backdrop-filter is detectable only
+          via the -webkit- prefix. Empirically this still includes recent
+          Safari (observed on macOS Safari 18.6 in 2026, where
+          CSS.supports('backdrop-filter', 'blur(...)') returns false even
+          though the unprefixed property has shipped). On these builds the
+          long-standing nested-backdrop + transform compositing bug
+          silently no-ops the blur on .sp-detail (which is transformed and
+          lives inside another backdrop-filter ancestor, .sp-panel), so
+          the translucent default is unreadable. Detection is a pure
+          feature query: prefixed supported AND unprefixed not. No
+          user-agent sniffing.
+
+     Browsers where the glass effect renders correctly (most Chromium,
+     modern Firefox, any engine that advertises both property names via
+     CSS.supports) are unaffected. */
+  @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+    .sp-detail {
+      background: var(--sp-bg);
+    }
+  }
+
+  @supports (-webkit-backdrop-filter: blur(1px)) and (not (backdrop-filter: blur(1px))) {
+    .sp-detail {
+      background: var(--sp-bg);
+    }
+  }
+
   /* ---- Header ---- */
 
   .sp-detail-header {


### PR DESCRIPTION
## Summary

The detail-card overlay (`.sp-detail`) uses a translucent background (`var(--sp-glass-bg)`) plus `backdrop-filter: blur(var(--sp-blur-heavy))` to render a frosted-glass panel-in-panel on top of the feedback list. On browsers where the blur cannot be applied, the translucency alone leaves the underlying list **clearly visible through** the detail card — making it hard to read.

This PR adds two additive `@supports` fallback blocks that switch the background to `var(--sp-bg)` (opaque) for those browsers. Engines that render the glass correctly are untouched — pure feature query, no UA sniffing, additive only.

## Affected cohorts

| Cohort | Symptom | Detection |
|---|---|---|
| **No `backdrop-filter` at all** | Firefox ≤102, legacy Edge / IE, older Chromium on Linux | `@supports not ((backdrop-filter) or (-webkit-backdrop-filter))` |
| **`-webkit-` prefix only** | Safari / iOS Safari — incl. recent builds. Confirmed on **macOS Safari 18.6 (2026)** where `CSS.supports('backdrop-filter', 'blur(...)')` returns `false` even after the unprefixed property has shipped. On those builds the long-standing nested-backdrop + `transform` compositing bug silently no-ops the blur on `.sp-detail` (transformed, nested inside another backdrop-filter ancestor `.sp-panel`). | `@supports (-webkit-backdrop-filter) and (not (backdrop-filter))` |

## Files

- `packages/widget/src/panel-detail.ts` — `+33` lines: two `@supports` blocks + extensive comment block explaining the cohorts and the Safari bug.
- `packages/widget/__tests__/widget/panel-detail.test.ts` — `+34` lines: three regression-guard tests asserting both `@supports` rules remain in `DETAIL_CSS` and both override `.sp-detail` to opaque `var(--sp-bg)`. Locks the fallback in against accidental removal during a refactor.

## Verification

- [x] `bun run lint` — clean (biome)
- [x] `bun run check` — clean (10/10 packages)
- [x] `bun run test:run` — **1390/1390 passing** (+3 new tests)
- [x] `bun run build` — clean (7/7 packages)
- [x] `bun run size` — ESM widget **24.96 kB** gzip (54 kB budget), IIFE **104.53 kB** gzip (110 kB budget) — comfortably under
- [ ] Manual QA on macOS Safari 18.6 — list no longer bleeds through the detail card (to confirm post-merge on real device)
- [ ] Manual QA on Chrome / modern Firefox — frosted glass unchanged (to confirm post-merge)

## Attribution

The fix itself was originally proposed by **@grizodubov** in PR #62, which they closed because they had opened it against the wrong repo by accident. The bug and the fix are sound, and the PR was never re-submitted here — so this is a clean re-port with proper `Co-authored-by:` attribution on the commit. The `@supports` blocks and explanatory comment are taken from that PR verbatim, since the analysis was already empirically validated.

Refs: #62