### PR TITLE
fix(widget): avoid stale identity retry replay

### DIFF
--- a/packages/widget/__tests__/widget/api-client.test.ts
+++ b/packages/widget/__tests__/widget/api-client.test.ts
@@ -418,6 +418,7 @@ describe("flushRetryQueue", () => {
 
   beforeEach(() => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 201 }));
+    vi.spyOn(console, "debug").mockImplementation(() => {});
     // Mock localStorage with a real-ish store
     const store: Record<string, string> = {};
     vi.stubGlobal("localStorage", {
@@ -472,6 +473,40 @@ describe("flushRetryQueue", () => {
     expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
   });
 
+  it("preserves legacy replay behavior when current identity is omitted", async () => {
+    const payload1 = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "from alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "Alice",
+      authorEmail: "alice@example.com",
+      annotations: [],
+      clientId: "legacy-1",
+    };
+    const payload2 = {
+      ...payload1,
+      message: "from bob",
+      authorName: "Bob",
+      authorEmail: "bob@example.com",
+      clientId: "legacy-2",
+    };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(
+      JSON.stringify([
+        { endpoint, payload: payload1 },
+        { endpoint, payload: payload2 },
+      ]),
+    );
+
+    await flushRetryQueue(endpoint);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
   it("drops stale queued feedback when the current identity differs", async () => {
     const payload = {
       projectName: "test",
@@ -492,6 +527,11 @@ describe("flushRetryQueue", () => {
 
     expect(fetch).not.toHaveBeenCalled();
     expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+    expect(console.debug).toHaveBeenCalledWith(
+      "[siteping] flushRetryQueue: dropped",
+      1,
+      "stale entries (identity changed)",
+    );
   });
 
   it("retries queued feedback when the current identity matches", async () => {
@@ -515,6 +555,76 @@ describe("flushRetryQueue", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
+  it("retries queued feedback when email casing differs only by case", async () => {
+    const payload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "from alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: " Alice ",
+      authorEmail: "Alice@Example.COM ",
+      annotations: [],
+      clientId: "case-1",
+    };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify([{ endpoint, payload }]));
+    vi.mocked(fetch).mockResolvedValue(new Response("", { status: 201 }));
+
+    await flushRetryQueue(endpoint, { name: "Alice", email: "alice@example.com" });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
+  it("drops only stale same-endpoint entries while retrying matching ones", async () => {
+    const matchingPayload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "matching alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "Alice",
+      authorEmail: "alice@example.com",
+      annotations: [],
+      clientId: "mixed-1",
+    };
+    const stalePayload = {
+      ...matchingPayload,
+      message: "stale bob",
+      authorName: "Bob",
+      authorEmail: "bob@example.com",
+      clientId: "mixed-2",
+    };
+    const otherEndpoint = "http://localhost/api/other";
+    const otherPayload = { ...matchingPayload, message: "other", clientId: "mixed-other" };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(
+      JSON.stringify([
+        { endpoint, payload: matchingPayload },
+        { endpoint, payload: stalePayload },
+        { endpoint: otherEndpoint, payload: otherPayload },
+      ]),
+    );
+    vi.mocked(fetch).mockResolvedValue(new Response("", { status: 201 }));
+
+    await flushRetryQueue(endpoint, { name: "Alice", email: "alice@example.com" });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(vi.mocked(fetch).mock.calls[0][1]!.body as string).clientId).toBe("mixed-1");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "siteping_retry_queue",
+      JSON.stringify([{ endpoint: otherEndpoint, payload: otherPayload }]),
+    );
+    expect(console.debug).toHaveBeenCalledWith(
+      "[siteping] flushRetryQueue: dropped",
+      1,
+      "stale entries (identity changed)",
+    );
   });
 
   it("preserves unrelated endpoint entries when dropping stale feedback", async () => {

--- a/packages/widget/__tests__/widget/api-client.test.ts
+++ b/packages/widget/__tests__/widget/api-client.test.ts
@@ -472,6 +472,83 @@ describe("flushRetryQueue", () => {
     expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
   });
 
+  it("drops stale queued feedback when the current identity differs", async () => {
+    const payload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "from alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "Alice",
+      authorEmail: "alice@example.com",
+      annotations: [],
+      clientId: "stale-1",
+    };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify([{ endpoint, payload }]));
+
+    await flushRetryQueue(endpoint, { name: "Bob", email: "bob@example.com" });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
+  it("retries queued feedback when the current identity matches", async () => {
+    const payload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "from alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "Alice",
+      authorEmail: "alice@example.com",
+      annotations: [],
+      clientId: "match-1",
+    };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify([{ endpoint, payload }]));
+    vi.mocked(fetch).mockResolvedValue(new Response("", { status: 201 }));
+
+    await flushRetryQueue(endpoint, { name: "Alice", email: "alice@example.com" });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
+  it("preserves unrelated endpoint entries when dropping stale feedback", async () => {
+    const payload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "from alice",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "Alice",
+      authorEmail: "alice@example.com",
+      annotations: [],
+      clientId: "stale-2",
+    };
+    const otherEndpoint = "http://localhost/api/other";
+    const otherPayload = { ...payload, message: "other", clientId: "other-1" };
+
+    vi.mocked(localStorage.getItem).mockReturnValue(
+      JSON.stringify([
+        { endpoint, payload },
+        { endpoint: otherEndpoint, payload: otherPayload },
+      ]),
+    );
+
+    await flushRetryQueue(endpoint, { name: "Bob", email: "bob@example.com" });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "siteping_retry_queue",
+      JSON.stringify([{ endpoint: otherEndpoint, payload: otherPayload }]),
+    );
+  });
+
   it("keeps failed items in queue after partial failure", async () => {
     const payload1 = {
       projectName: "test",

--- a/packages/widget/src/api-client.ts
+++ b/packages/widget/src/api-client.ts
@@ -122,6 +122,7 @@ async function resilientFetch(url: string, init: RequestInit, retries = MAX_RETR
 // ---------------------------------------------------------------------------
 
 type RetryEntry = { endpoint: string; payload: FeedbackPayload };
+type RetryIdentity = { name: string; email: string };
 
 const LOCK_NAME = "siteping_retry_queue";
 
@@ -157,7 +158,12 @@ function queueForRetry(endpoint: string, payload: FeedbackPayload): void {
   });
 }
 
-export async function flushRetryQueue(endpoint: string): Promise<void> {
+function matchesRetryIdentity(entry: RetryEntry, currentIdentity: RetryIdentity | null | undefined): boolean {
+  if (!currentIdentity) return true;
+  return entry.payload.authorName === currentIdentity.name && entry.payload.authorEmail === currentIdentity.email;
+}
+
+export async function flushRetryQueue(endpoint: string, currentIdentity?: RetryIdentity | null): Promise<void> {
   await withRetryLock(async () => {
     try {
       const raw = localStorage.getItem(RETRY_QUEUE_KEY);
@@ -166,8 +172,9 @@ export async function flushRetryQueue(endpoint: string): Promise<void> {
       const parsed: unknown = JSON.parse(raw);
       const queue: RetryEntry[] = Array.isArray(parsed) ? (parsed as RetryEntry[]) : [];
 
-      const toRetry = queue.filter((e) => e.endpoint === endpoint);
-      if (toRetry.length === 0) return;
+      const matchingEndpoint = queue.filter((e) => e.endpoint === endpoint);
+      if (matchingEndpoint.length === 0) return;
+      const toRetry = matchingEndpoint.filter((e) => matchesRetryIdentity(e, currentIdentity));
 
       // Process items sequentially to avoid overwhelming the server
       const failed: RetryEntry[] = [];

--- a/packages/widget/src/api-client.ts
+++ b/packages/widget/src/api-client.ts
@@ -8,6 +8,7 @@ import {
   SitepingNetworkError,
   SitepingValidationError,
 } from "@siteping/core";
+import type { Identity } from "./identity.js";
 
 /**
  * Map a non-OK Response to the appropriate typed error.
@@ -122,7 +123,6 @@ async function resilientFetch(url: string, init: RequestInit, retries = MAX_RETR
 // ---------------------------------------------------------------------------
 
 type RetryEntry = { endpoint: string; payload: FeedbackPayload };
-type RetryIdentity = { name: string; email: string };
 
 const LOCK_NAME = "siteping_retry_queue";
 
@@ -158,12 +158,22 @@ function queueForRetry(endpoint: string, payload: FeedbackPayload): void {
   });
 }
 
-function matchesRetryIdentity(entry: RetryEntry, currentIdentity: RetryIdentity | null | undefined): boolean {
-  if (!currentIdentity) return true;
-  return entry.payload.authorName === currentIdentity.name && entry.payload.authorEmail === currentIdentity.email;
+function normalizeName(value: string): string {
+  return value.trim();
 }
 
-export async function flushRetryQueue(endpoint: string, currentIdentity?: RetryIdentity | null): Promise<void> {
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Flush queued feedbacks for `endpoint`. When `currentIdentity` is provided,
+ * entries whose stored author doesn't match it are dropped rather than replayed.
+ * This prevents user A's offline feedback from being POSTed under user B's
+ * identity after a session change. When omitted, all entries are replayed to
+ * preserve the legacy behavior for callers that don't track identity.
+ */
+export async function flushRetryQueue(endpoint: string, currentIdentity?: Identity | null): Promise<void> {
   await withRetryLock(async () => {
     try {
       const raw = localStorage.getItem(RETRY_QUEUE_KEY);
@@ -172,9 +182,32 @@ export async function flushRetryQueue(endpoint: string, currentIdentity?: RetryI
       const parsed: unknown = JSON.parse(raw);
       const queue: RetryEntry[] = Array.isArray(parsed) ? (parsed as RetryEntry[]) : [];
 
-      const matchingEndpoint = queue.filter((e) => e.endpoint === endpoint);
-      if (matchingEndpoint.length === 0) return;
-      const toRetry = matchingEndpoint.filter((e) => matchesRetryIdentity(e, currentIdentity));
+      const toRetry: RetryEntry[] = [];
+      const unrelated: RetryEntry[] = [];
+      let dropped = 0;
+
+      for (const entry of queue) {
+        if (entry.endpoint !== endpoint) {
+          unrelated.push(entry);
+          continue;
+        }
+
+        if (
+          !currentIdentity ||
+          (normalizeName(entry.payload.authorName) === normalizeName(currentIdentity.name) &&
+            normalizeEmail(entry.payload.authorEmail) === normalizeEmail(currentIdentity.email))
+        ) {
+          toRetry.push(entry);
+        } else {
+          dropped += 1;
+        }
+      }
+
+      if (toRetry.length === 0 && dropped === 0) return;
+
+      if (dropped > 0) {
+        console.debug("[siteping] flushRetryQueue: dropped", dropped, "stale entries (identity changed)");
+      }
 
       // Process items sequentially to avoid overwhelming the server
       const failed: RetryEntry[] = [];
@@ -194,7 +227,7 @@ export async function flushRetryQueue(endpoint: string, currentIdentity?: RetryI
       }
 
       // Rebuild queue: keep unrelated entries + failed retries
-      const remaining = queue.filter((e) => e.endpoint !== endpoint).concat(failed);
+      const remaining = unrelated.concat(failed);
       if (remaining.length > 0) {
         localStorage.setItem(RETRY_QUEUE_KEY, JSON.stringify(remaining));
       } else {

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -451,7 +451,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   // Flush retry queue on load (HTTP mode only — store mode has no retry queue)
   if (config.endpoint) {
-    flushRetryQueue(config.endpoint)
+    flushRetryQueue(config.endpoint, config.identity ?? getIdentity())
       .then(() => log("Retry queue flushed"))
       .catch(() => {});
   }


### PR DESCRIPTION
## Summary

Fixes retry queue replay so stale queued feedback is not POSTed with a previous user's `authorName` / `authorEmail` after the widget launches under a different identity.

Fixes #86

## Changes

- [x] Added regression coverage for stale queued feedback, matching current identity, and unrelated endpoint preservation.
- [x] Updated `flushRetryQueue` to accept an optional current identity and drop stale same-endpoint entries instead of replaying them.
- [x] Passed the launch-time identity (`config.identity ?? getIdentity()`) into the HTTP retry queue flush.

## Test plan

- `bun install`
- `bun run test:run -- packages/widget/__tests__/widget/api-client.test.ts -t "stale"` before the fix: failed because Alice's queued payload was POSTed while the current identity was Bob
- `bun run test:run -- packages/widget/__tests__/widget/api-client.test.ts -t "stale"`
- `bun run test:run -- packages/widget/__tests__/widget/api-client.test.ts -t "flushRetryQueue|stale"`
- `bun run test:run -- packages/widget/__tests__/widget/api-client.test.ts`
- `bun run test:run`
- `bun run check`
- `bun run build`
- `bun run lint`
- `git diff --check`

Note: the originally planned `-t "retry queue"` filter matched no tests in this file, so I used `-t "flushRetryQueue|stale"` for the focused retry queue run.

Note: I used Codex to help inspect the retry path and draft the regression tests, then reviewed the final diff and ran the listed verification commands locally.

## Checklist

- [x] Tests pass (`bun run test:run`)
- [x] Types pass (`bun run check`)
- [x] No dead code or unused imports
- [x] Commit messages follow Conventional Commits (`type(scope): description`)
