### PR TITLE
fix(widget): re-localize FAB + popup after locale chunk loads

### DIFF
--- a/packages/widget/__tests__/widget/fab.test.ts
+++ b/packages/widget/__tests__/widget/fab.test.ts
@@ -4,7 +4,7 @@ import type { SitepingConfig } from "@siteping/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventBus, type WidgetEvents } from "../../src/events.js";
 import { Fab } from "../../src/fab.js";
-import { createT } from "../../src/i18n/index.js";
+import { createT, type TFunction, type Translations } from "../../src/i18n/index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -505,6 +505,68 @@ describe("Fab", () => {
   // -------------------------------------------------------------------------
   // Toggle-annotations icon swap (line 230 — true branch ICON_EYE)
   // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // refreshLabels — re-localizes the FAB after the locale dictionary lands
+  // -------------------------------------------------------------------------
+
+  describe("refreshLabels", () => {
+    // Tests use a mutable mock `t` (rather than the real i18n loader) so the
+    // LOCALES module state of other test files can't bleed into these
+    // assertions. `refreshLabels()` is a pure DOM re-binding pass over
+    // `this.t`, so the only contract worth testing is "calls t at refresh
+    // time and writes the result into the DOM".
+    function makeMutableT(prefix: { value: string }): TFunction {
+      return ((key: keyof Translations): string => `${prefix.value}:${key}`) as TFunction;
+    }
+
+    it("re-reads `t` at refresh time and writes aria-labels + label spans", () => {
+      const prefix = { value: "INIT" };
+      const mutableT = makeMutableT(prefix);
+
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, defaultConfig(), bus, mutableT);
+
+      // Initial state: labels reflect the first prefix.
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      expect(fabBtn.getAttribute("aria-label")).toBe("INIT:fab.aria");
+
+      // Swap the closure's return value, then refresh — DOM should track it.
+      prefix.value = "SWAPPED";
+      fab.refreshLabels();
+
+      expect(fabBtn.getAttribute("aria-label")).toBe("SWAPPED:fab.aria");
+
+      const items = getRadialItems(shadow);
+      const chatItem = items.find((b) => b.dataset.itemId === "chat")!;
+      const annotateItem = items.find((b) => b.dataset.itemId === "annotate")!;
+      const toggleItem = items.find((b) => b.dataset.itemId === "toggle-annotations")!;
+
+      expect(chatItem.getAttribute("aria-label")).toBe("SWAPPED:fab.messages");
+      expect(annotateItem.getAttribute("aria-label")).toBe("SWAPPED:fab.annotate");
+      expect(toggleItem.getAttribute("aria-label")).toBe("SWAPPED:fab.annotations");
+
+      expect(chatItem.querySelector(".sp-radial-label")?.textContent).toBe("SWAPPED:fab.messages");
+      expect(annotateItem.querySelector(".sp-radial-label")?.textContent).toBe("SWAPPED:fab.annotate");
+      expect(toggleItem.querySelector(".sp-radial-label")?.textContent).toBe("SWAPPED:fab.annotations");
+    });
+
+    it("is idempotent — calling twice with the same `t` is a no-op on values", () => {
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, defaultConfig(), bus, createT("en"));
+
+      fab.refreshLabels();
+      const first = shadow.querySelector<HTMLButtonElement>(".sp-fab")!.getAttribute("aria-label");
+      fab.refreshLabels();
+      const second = shadow.querySelector<HTMLButtonElement>(".sp-fab")!.getAttribute("aria-label");
+
+      expect(second).toBe(first);
+    });
+  });
 
   describe("toggle-annotations icon swap", () => {
     it("two consecutive toggles swap the icon back to ICON_EYE (true branch of cond-expr)", () => {

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -29,6 +29,10 @@ vi.mock(new URL("../../src/api-client.js", import.meta.url).pathname, () => ({
 // The Annotator receives the bus in its constructor — we intercept it.
 let capturedBus: { emit: (event: string, ...args: unknown[]) => void } | null = null;
 
+// Spy on annotator.refreshLabels so the i18n test can assert it gets called
+// once the locale dictionary lands.
+const mockAnnotatorRefreshLabels = vi.fn();
+
 vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
   Annotator: vi.fn().mockImplementation(
     (
@@ -43,6 +47,7 @@ vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
       bus.on("annotation:start", () => {});
       return {
         destroy: vi.fn(),
+        refreshLabels: mockAnnotatorRefreshLabels,
       };
     },
   ),
@@ -1285,6 +1290,47 @@ describe("launcher — annotation:complete integration", () => {
 
       // length === 0 → handler returns early; preventDefault not called
       expect(preventSpy).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Locale dictionary swap — guards against a regression where non-English
+  // labels never reached the FAB and popup because `loadLocale()` resolved
+  // after the synchronous constructor had already baked the English fallback.
+  // -------------------------------------------------------------------------
+
+  describe("locale dictionary loading", () => {
+    it("re-localizes the FAB once the German chunk lands", async () => {
+      const instance = launch(defaultConfig({ locale: "de" }));
+
+      const widget = document.querySelector("siteping-widget")!;
+      const shadow = widget.shadowRoot!;
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+
+      // Wait for the German chunk to resolve and refreshLabels to run.
+      await vi.waitFor(() => {
+        expect(fabBtn.getAttribute("aria-label")).toBe("Siteping — Feedback-Menü");
+        expect(mockAnnotatorRefreshLabels).toHaveBeenCalled();
+      });
+
+      // Radial item labels are German too
+      const chatItem = shadow.querySelector<HTMLButtonElement>('[data-item-id="chat"]')!;
+      expect(chatItem.getAttribute("aria-label")).toBe("Nachrichten");
+      expect(chatItem.querySelector(".sp-radial-label")?.textContent).toBe("Nachrichten");
+
+      instance.destroy();
+    });
+
+    it("does not call refreshLabels when locale is English (no chunk to wait for)", async () => {
+      const instance = launch(defaultConfig({ locale: "en" }));
+
+      // Microtask + an extra tick to let any accidental scheduling run.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mockAnnotatorRefreshLabels).not.toHaveBeenCalled();
 
       instance.destroy();
     });

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -94,6 +94,7 @@ vi.mock(new URL("../../src/identity.js", import.meta.url).pathname, () => ({
   saveIdentity: (...args: unknown[]) => mockSaveIdentity(...args),
 }));
 
+import * as i18n from "../../src/i18n/index.js";
 import { launch } from "../../src/launcher.js";
 
 // ---------------------------------------------------------------------------
@@ -1333,6 +1334,73 @@ describe("launcher — annotation:complete integration", () => {
       expect(mockAnnotatorRefreshLabels).not.toHaveBeenCalled();
 
       instance.destroy();
+    });
+
+    it("still renders markers when loadLocale rejects (the .catch is load-bearing)", async () => {
+      // The launcher does `loadLocale(locale).catch(() => {})` and then
+      // `Promise.all([getFeedbacks, localeReady])`. Without that `.catch`, a
+      // failed locale chunk would reject the `Promise.all` and markers would
+      // silently stop rendering for every non-English locale. Mock the loader
+      // to reject and assert markers STILL render, no error escapes, and the
+      // refresh that follows is a harmless no-op (mocked Annotator).
+      const loadLocaleSpy = vi.spyOn(i18n, "loadLocale").mockRejectedValue(new Error("Failed to fetch locale chunk"));
+      mockGetFeedbacks.mockResolvedValueOnce({
+        feedbacks: [makeFeedbackResponse({ id: "fb-locale-fail" })],
+        total: 1,
+      });
+
+      try {
+        const instance = launch(defaultConfig({ locale: "de" }));
+
+        // Markers render despite the rejected locale chunk — the `.catch`
+        // kept `localeReady` resolved so `Promise.all` settled.
+        await vi.waitFor(() => {
+          expect(mockMarkersRender).toHaveBeenCalled();
+        });
+        expect(loadLocaleSpy).toHaveBeenCalledWith("de");
+
+        // `refreshLabels()` running after a failed load is a no-op — `t` just
+        // keeps returning the English fallback. It must not throw.
+        await vi.waitFor(() => {
+          expect(mockAnnotatorRefreshLabels).toHaveBeenCalled();
+        });
+
+        instance.destroy();
+      } finally {
+        loadLocaleSpy.mockRestore();
+      }
+    });
+
+    it("does not refresh labels when destroy() runs before the locale chunk resolves", async () => {
+      // The `localeReady.then(...)` block is guarded by `destroyed`. If the
+      // widget is torn down while the chunk is still in flight, neither
+      // `fab.refreshLabels()` nor `annotator.refreshLabels()` should run.
+      let resolveLocale!: () => void;
+      const loadLocaleSpy = vi.spyOn(i18n, "loadLocale").mockReturnValue(
+        new Promise((resolve) => {
+          resolveLocale = () => resolve(null);
+        }),
+      );
+
+      try {
+        const instance = launch(defaultConfig({ locale: "de" }));
+
+        // Destroy before the locale promise settles.
+        instance.destroy();
+
+        // Now let the locale chunk resolve — the `destroyed` guard must abort
+        // the refresh block.
+        resolveLocale();
+        await vi.waitFor(() => {
+          expect(loadLocaleSpy).toHaveBeenCalledWith("de");
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockAnnotatorRefreshLabels).not.toHaveBeenCalled();
+      } finally {
+        loadLocaleSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -55,7 +55,7 @@ vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
     ) => {
       annotatorCapture.bus = bus;
       bus.on("annotation:start", () => {});
-      return { destroy: vi.fn() };
+      return { destroy: vi.fn(), refreshLabels: vi.fn() };
     },
   ),
 }));

--- a/packages/widget/__tests__/widget/popup.test.ts
+++ b/packages/widget/__tests__/widget/popup.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createT } from "../../src/i18n/index.js";
+import { createT, type TFunction, type Translations } from "../../src/i18n/index.js";
 import { Popup } from "../../src/popup.js";
 import { buildThemeColors } from "../../src/styles/theme.js";
 
@@ -456,6 +456,72 @@ describe("Popup", () => {
 
       const dialog = document.querySelector<HTMLElement>('[role="dialog"]');
       expect(dialog).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refreshLabels — re-localizes the popup after the locale dictionary lands
+  // -------------------------------------------------------------------------
+
+  describe("refreshLabels", () => {
+    // Tests use a mutable mock `t` (rather than the real i18n loader) so the
+    // LOCALES module state of other test files can't bleed into these
+    // assertions. `refreshLabels()` is a pure DOM re-binding pass over
+    // `this.t`, so the only contract worth testing is "calls t at refresh
+    // time and writes the result into the DOM".
+    function makeMutableT(prefix: { value: string }): TFunction {
+      return ((key: keyof Translations): string => `${prefix.value}:${key}`) as TFunction;
+    }
+
+    it("re-reads `t` at refresh time for dialog, type buttons, textarea, hint, and CTAs", () => {
+      const prefix = { value: "INIT" };
+      const mutableT = makeMutableT(prefix);
+
+      popup.destroy();
+      popup = new Popup(colors, mutableT);
+
+      // Initial state — labels reflect the first prefix.
+      const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!;
+      expect(dialog.getAttribute("aria-label")).toBe("INIT:popup.ariaLabel");
+
+      // Swap the closure's return value, then refresh — DOM should track it.
+      prefix.value = "SWAPPED";
+      popup.refreshLabels();
+
+      expect(dialog.getAttribute("aria-label")).toBe("SWAPPED:popup.ariaLabel");
+
+      const questionBtn = document.querySelector<HTMLButtonElement>('[data-type="question"]')!;
+      const changeBtn = document.querySelector<HTMLButtonElement>('[data-type="change"]')!;
+      const bugBtn = document.querySelector<HTMLButtonElement>('[data-type="bug"]')!;
+      const otherBtn = document.querySelector<HTMLButtonElement>('[data-type="other"]')!;
+      expect(questionBtn.querySelector("span")?.textContent).toBe("SWAPPED:type.question");
+      expect(changeBtn.querySelector("span")?.textContent).toBe("SWAPPED:type.change");
+      expect(bugBtn.querySelector("span")?.textContent).toBe("SWAPPED:type.bug");
+      expect(otherBtn.querySelector("span")?.textContent).toBe("SWAPPED:type.other");
+
+      const textarea = document.querySelector<HTMLTextAreaElement>("textarea")!;
+      expect(textarea.placeholder).toBe("SWAPPED:popup.placeholder");
+      expect(textarea.getAttribute("aria-label")).toBe("SWAPPED:popup.textareaAria");
+
+      // Cancel + submit buttons — find by their data attributes, not text
+      const allButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("button"));
+      const submitBtn = allButtons.find((b) => b.textContent === "SWAPPED:popup.submit");
+      const cancelBtn = allButtons.find((b) => b.textContent === "SWAPPED:popup.cancel");
+      expect(submitBtn).toBeDefined();
+      expect(cancelBtn).toBeDefined();
+    });
+
+    it("is idempotent — calling twice with the same `t` is a no-op on values", () => {
+      popup.destroy();
+      popup = new Popup(colors, createT("en"));
+
+      popup.refreshLabels();
+      const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!;
+      const first = dialog.getAttribute("aria-label");
+      popup.refreshLabels();
+      const second = dialog.getAttribute("aria-label");
+
+      expect(second).toBe(first);
     });
   });
 

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -53,6 +53,15 @@ export class Annotator {
   }
 
   /**
+   * Re-read every `t(...)`-derived label inside the popup. The annotator's
+   * own toolbar text is created fresh on every `activate()` call, so only
+   * the long-lived popup needs explicit re-localization here.
+   */
+  refreshLabels(): void {
+    this.popup.refreshLabels();
+  }
+
+  /**
    * Capture a screenshot of the drawn rect when `enableScreenshot` is on.
    * Returns null on disable / capture failure / missing peer dep — the
    * feedback is always submitted regardless.

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -4,18 +4,21 @@ import type { EventBus, WidgetEvents } from "./events.js";
 import type { TFunction, Translations } from "./i18n/index.js";
 import { ICON_ANNOTATE, ICON_CHAT, ICON_CLOSE, ICON_EYE, ICON_EYE_OFF, ICON_SITEPING } from "./icons.js";
 
+/** Closed set of radial menu item ids — keeps the label lookup exhaustive. */
+type RadialItemId = "chat" | "annotate" | "toggle-annotations";
+
 interface RadialItem {
-  id: string;
+  id: RadialItemId;
   icon: string;
   iconAlt?: string;
-  label: string;
 }
 
 const ITEM_GAP = 54;
 
-// Stable mapping between radial item ids and their translation keys, so
-// `refreshLabels()` can re-localize the existing DOM without re-rendering it.
-const ITEM_LABEL_KEYS: Record<string, keyof Translations> = {
+// Stable mapping between radial item ids and their translation keys. The
+// label is fully derived from this map via `t()`, so the constructor and
+// `applyLabels()` share one source of truth for which node gets which string.
+const ITEM_LABEL_KEYS: Record<RadialItemId, keyof Translations> = {
   chat: "fab.messages",
   annotate: "fab.annotate",
   "toggle-annotations": "fab.annotations",
@@ -47,9 +50,9 @@ export class Fab {
 
     // Vertical stack above the FAB
     this.items = [
-      { id: "chat", icon: ICON_CHAT, label: t("fab.messages") },
-      { id: "annotate", icon: ICON_ANNOTATE, label: t("fab.annotate") },
-      { id: "toggle-annotations", icon: ICON_EYE, iconAlt: ICON_EYE_OFF, label: t("fab.annotations") },
+      { id: "chat", icon: ICON_CHAT },
+      { id: "annotate", icon: ICON_ANNOTATE },
+      { id: "toggle-annotations", icon: ICON_EYE, iconAlt: ICON_EYE_OFF },
     ];
 
     // FAB button — needs position:relative for badge positioning
@@ -57,7 +60,6 @@ export class Fab {
     this.fab.className = `sp-fab sp-fab--${position} sp-anim-fab-in`;
     this.fab.style.position = "fixed"; // ensure fixed even with relative children
     this.fab.appendChild(parseSvg(ICON_SITEPING));
-    this.fab.setAttribute("aria-label", t("fab.aria"));
     this.fab.setAttribute("aria-expanded", "false");
     this.fab.addEventListener("click", () => this.toggle());
 
@@ -74,7 +76,6 @@ export class Fab {
       btn.style.setProperty("--sp-i", String(i));
       btn.appendChild(parseSvg(item.icon));
       btn.setAttribute("role", "menuitem");
-      btn.setAttribute("aria-label", item.label);
       btn.dataset.itemId = item.id;
 
       btn.addEventListener("click", (e) => {
@@ -84,7 +85,6 @@ export class Fab {
 
       const label = document.createElement("span");
       label.className = "sp-radial-label";
-      label.textContent = item.label;
       label.style.cssText = isRight
         ? "position:absolute; right:54px; top:50%; transform:translateY(-50%); white-space:nowrap;"
         : "position:absolute; left:54px; top:50%; transform:translateY(-50%); white-space:nowrap;";
@@ -97,6 +97,10 @@ export class Fab {
     this.root.appendChild(this.radialContainer);
     this.root.appendChild(this.fab);
     shadowRoot.appendChild(this.root);
+
+    // Bind every `t()`-derived string into the freshly-built DOM. Kept as a
+    // single pass so the constructor and `refreshLabels()` never drift.
+    this.applyLabels();
 
     // Close radial menu on click outside.
     const host = shadowRoot.host;
@@ -160,16 +164,22 @@ export class Fab {
    * configured language.
    */
   refreshLabels(): void {
-    this.fab.setAttribute("aria-label", this.t("fab.aria"));
+    this.applyLabels();
+  }
 
-    for (const item of this.items) {
-      const key = ITEM_LABEL_KEYS[item.id];
-      if (key) item.label = this.t(key);
-    }
+  /**
+   * Walk the already-built DOM and bind every translation-derived string —
+   * the FAB `aria-label`, each radial item's `aria-label`, and each
+   * `.sp-radial-label` `textContent`. The single source of truth for which
+   * node gets which `t()` string, shared by the constructor and
+   * `refreshLabels()` so the two can never drift.
+   */
+  private applyLabels(): void {
+    this.fab.setAttribute("aria-label", this.t("fab.aria"));
 
     const buttons = this.radialContainer.querySelectorAll<HTMLButtonElement>(".sp-radial-item");
     for (const btn of buttons) {
-      const id = btn.dataset.itemId;
+      const id = btn.dataset.itemId as RadialItemId | undefined;
       if (!id) continue;
       const key = ITEM_LABEL_KEYS[id];
       if (!key) continue;
@@ -247,7 +257,7 @@ export class Fab {
     if (badge) this.fab.appendChild(badge);
   }
 
-  private handleItemClick(id: string): void {
+  private handleItemClick(id: RadialItemId): void {
     this.close();
 
     switch (id) {

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -1,7 +1,7 @@
 import type { SitepingConfig } from "@siteping/core";
 import { parseSvg, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
-import type { TFunction } from "./i18n/index.js";
+import type { TFunction, Translations } from "./i18n/index.js";
 import { ICON_ANNOTATE, ICON_CHAT, ICON_CLOSE, ICON_EYE, ICON_EYE_OFF, ICON_SITEPING } from "./icons.js";
 
 interface RadialItem {
@@ -12,6 +12,14 @@ interface RadialItem {
 }
 
 const ITEM_GAP = 54;
+
+// Stable mapping between radial item ids and their translation keys, so
+// `refreshLabels()` can re-localize the existing DOM without re-rendering it.
+const ITEM_LABEL_KEYS: Record<string, keyof Translations> = {
+  chat: "fab.messages",
+  annotate: "fab.annotate",
+  "toggle-annotations": "fab.annotations",
+};
 
 /**
  * Floating Action Button with radial menu and notification badge.
@@ -144,6 +152,33 @@ export class Fab {
   }
 
   private onDocumentClick: (e: MouseEvent) => void;
+
+  /**
+   * Re-read every `t(...)`-derived label and aria-label from the active
+   * translation function. Idempotent — call after the locale dictionary has
+   * finished loading so the FAB labels swap from the English fallback to the
+   * configured language.
+   */
+  refreshLabels(): void {
+    this.fab.setAttribute("aria-label", this.t("fab.aria"));
+
+    for (const item of this.items) {
+      const key = ITEM_LABEL_KEYS[item.id];
+      if (key) item.label = this.t(key);
+    }
+
+    const buttons = this.radialContainer.querySelectorAll<HTMLButtonElement>(".sp-radial-item");
+    for (const btn of buttons) {
+      const id = btn.dataset.itemId;
+      if (!id) continue;
+      const key = ITEM_LABEL_KEYS[id];
+      if (!key) continue;
+      const label = this.t(key);
+      btn.setAttribute("aria-label", label);
+      const labelSpan = btn.querySelector<HTMLSpanElement>(".sp-radial-label");
+      if (labelSpan) setText(labelSpan, label);
+    }
+  }
 
   /** Update the badge count. Pass 0 to hide. */
   updateBadge(count: number): void {

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -148,14 +148,18 @@ export function launch(config: SitepingConfig): SitepingInstance {
   }
 
   const locale = config.locale ?? "en";
-  // Kick off the locale fetch immediately so the panel can render in the
-  // resolved language as soon as it mounts. English is bundled synchronously
-  // and used as the fallback while the chunk is in flight.
-  if (locale !== "en") {
-    loadLocale(locale).catch(() => {
-      /* fallback to English — already handled by createT */
-    });
-  }
+  // Kick off the locale fetch immediately. English is bundled synchronously
+  // and used as the fallback while the chunk is in flight. The launcher
+  // awaits `localeReady` before rendering markers and re-localizes the FAB
+  // and popup once the dictionary lands — both are mounted synchronously so
+  // the widget is interactive immediately, but their labels start in the
+  // English fallback until the chunk arrives.
+  const localeReady: Promise<unknown> =
+    locale === "en"
+      ? Promise.resolve()
+      : loadLocale(locale).catch(() => {
+          /* fallback to English — already handled by createT */
+        });
   const t = createT(locale);
 
   // Page scope — concrete URL + optional template, used to keep annotations
@@ -337,6 +341,18 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   const annotator = new Annotator(colors, bus, t, config.enableScreenshot ?? false);
 
+  // Once the locale dictionary lands, swap the FAB + popup labels from the
+  // English fallback to the configured language. `t` already resolves to the
+  // loaded dictionary at call time, so the markers list rendered below (which
+  // calls `t` lazily) only needs to wait on `localeReady` once.
+  if (locale !== "en") {
+    localeReady.then(() => {
+      if (destroyed) return;
+      fab.refreshLabels();
+      annotator.refreshLabels();
+    });
+  }
+
   // Handle annotation completion via event bus (not DOM events)
   // Concurrency guard: prevent duplicate submissions if user draws two annotations quickly
   let submitting = false;
@@ -430,9 +446,13 @@ export function launch(config: SitepingConfig): SitepingInstance {
   const initialScope = getScope();
   const initialOptions = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: initialScope.url } : { limit: PAGE_SIZE };
   const deepLinkOpts = normaliseDeepLinkOptions(config.deepLink);
-  client
-    .getFeedbacks(config.projectName, initialOptions)
-    .then(({ feedbacks }) => {
+  // Render markers only once both the feedbacks and the locale dictionary are
+  // ready. Marker aria-labels are built via `t(...)` at render time — without
+  // this `Promise.all`, a fast HTTP response could outrun a slow locale chunk
+  // and freeze marker labels in the English fallback for non-English locales.
+  Promise.all([client.getFeedbacks(config.projectName, initialOptions), localeReady])
+    .then(([{ feedbacks }]) => {
+      if (destroyed) return;
       // Defensive client-side filter — backend may not yet support the `url` query.
       const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === initialScope.url) : feedbacks;
       markers.render(visible);

--- a/packages/widget/src/popup.ts
+++ b/packages/widget/src/popup.ts
@@ -33,7 +33,6 @@ interface PopupResult {
 
 interface TypeOption {
   type: FeedbackType;
-  label: string;
   icon: string;
 }
 
@@ -82,14 +81,14 @@ export class Popup {
 
     this.root.setAttribute("role", "dialog");
     this.root.setAttribute("aria-modal", "true");
-    this.root.setAttribute("aria-label", this.t("popup.ariaLabel"));
 
-    // Type selector grid (2x2)
+    // Type selector grid (2x2). Labels are bound later by `applyLabels()` —
+    // the constructor only builds the structure (icon + empty label span).
     const typeOptions: TypeOption[] = [
-      { type: "question", label: this.t("type.question"), icon: ICON_QUESTION },
-      { type: "change", label: this.t("type.change"), icon: ICON_CHANGE },
-      { type: "bug", label: this.t("type.bug"), icon: ICON_BUG },
-      { type: "other", label: this.t("type.other"), icon: ICON_OTHER },
+      { type: "question", icon: ICON_QUESTION },
+      { type: "change", icon: ICON_CHANGE },
+      { type: "bug", icon: ICON_BUG },
+      { type: "other", icon: ICON_OTHER },
     ];
     const typeRow = el("div", { style: "display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-bottom:12px;" });
     for (const option of typeOptions) {
@@ -107,9 +106,7 @@ export class Popup {
       const icon = parseSvg(option.icon);
       icon.setAttribute("style", "width:13px;height:13px;flex-shrink:0;");
       btn.appendChild(icon);
-      const labelSpan = document.createElement("span");
-      setText(labelSpan, option.label);
-      btn.appendChild(labelSpan);
+      btn.appendChild(document.createElement("span"));
       btn.dataset.type = option.type;
       btn.setAttribute("aria-pressed", "false");
 
@@ -147,9 +144,7 @@ export class Popup {
       outline:none;transition:all 0.2s ease;
       box-sizing:border-box;
     `;
-    this.textarea.placeholder = this.t("popup.placeholder");
     this.textarea.maxLength = 5000;
-    this.textarea.setAttribute("aria-label", this.t("popup.textareaAria"));
 
     // Keyboard shortcut hint
     this.hint = el("div", {
@@ -160,7 +155,6 @@ export class Popup {
         letter-spacing:0.01em;
       `,
     });
-    setText(this.hint, isMacPlatform() ? this.t("popup.submitHintMac") : this.t("popup.submitHintOther"));
 
     this.textarea.addEventListener("focus", () => {
       this.textarea.style.borderColor = this.colors.accent;
@@ -197,7 +191,6 @@ export class Popup {
       font-size:13px;font-weight:500;cursor:pointer;
       transition:all 0.2s ease;
     `;
-    setText(this.cancelBtn, this.t("popup.cancel"));
     this.cancelBtn.addEventListener("click", () => this.cancel());
     this.cancelBtn.addEventListener("mouseenter", () => {
       this.cancelBtn.style.borderColor = this.colors.accent;
@@ -218,7 +211,6 @@ export class Popup {
       transition:all 0.2s ease;
       box-shadow:0 2px 8px ${this.colors.accentGlow};
     `;
-    setText(this.submitBtn, this.t("popup.submit"));
     this.submitBtn.addEventListener("click", () => this.submit());
 
     btnRow.appendChild(this.cancelBtn);
@@ -229,6 +221,10 @@ export class Popup {
     this.root.appendChild(this.hint);
     this.root.appendChild(btnRow);
     document.body.appendChild(this.root);
+
+    // Bind every `t()`-derived string into the freshly-built DOM. Kept as a
+    // single pass so the constructor and `refreshLabels()` never drift.
+    this.applyLabels();
   }
 
   /**
@@ -238,6 +234,18 @@ export class Popup {
    * fallback to the configured language.
    */
   refreshLabels(): void {
+    this.applyLabels();
+  }
+
+  /**
+   * Walk the already-built DOM and bind every translation-derived string —
+   * the dialog `aria-label`, the four type-button labels, the textarea
+   * `placeholder` + `aria-label`, the `⌘+Enter` / `Ctrl+Enter` hint, and the
+   * cancel/submit `textContent`. The single source of truth for which node
+   * gets which `t()` string, shared by the constructor and `refreshLabels()`
+   * so the two can never drift.
+   */
+  private applyLabels(): void {
     this.root.setAttribute("aria-label", this.t("popup.ariaLabel"));
 
     const typeButtons = this.root.querySelectorAll<HTMLButtonElement>("button[data-type]");

--- a/packages/widget/src/popup.ts
+++ b/packages/widget/src/popup.ts
@@ -1,9 +1,30 @@
 import type { FeedbackType } from "@siteping/core";
 import { Z_INDEX_MAX } from "./constants.js";
 import { el, parseSvg, setText } from "./dom-utils.js";
-import type { TFunction } from "./i18n/index.js";
+import type { TFunction, Translations } from "./i18n/index.js";
 import { ICON_BUG, ICON_CHANGE, ICON_OTHER, ICON_QUESTION } from "./icons.js";
 import { getTypeBgColor, getTypeColor, type ThemeColors } from "./styles/theme.js";
+
+// Map each feedback type to its translation key, so `refreshLabels()` can
+// re-localize the existing type buttons without re-rendering the popup.
+const TYPE_LABEL_KEYS: Record<FeedbackType, keyof Translations> = {
+  question: "type.question",
+  change: "type.change",
+  bug: "type.bug",
+  other: "type.other",
+};
+
+/**
+ * Detect whether the host platform uses ⌘+Enter (macOS) vs Ctrl+Enter.
+ * Resolved at call time so we can recompute the popup hint when the locale
+ * dictionary lands.
+ */
+function isMacPlatform(): boolean {
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  return uaData
+    ? uaData.platform === "macOS"
+    : (navigator.platform?.includes("Mac") ?? /Macintosh|Mac OS X/i.test(navigator.userAgent));
+}
 
 interface PopupResult {
   type: FeedbackType;
@@ -28,6 +49,8 @@ export class Popup {
   private selectedType: FeedbackType | null = null;
   private textarea: HTMLTextAreaElement;
   private submitBtn: HTMLButtonElement;
+  private cancelBtn: HTMLButtonElement;
+  private hint: HTMLElement;
   private resolve: ((result: PopupResult | null) => void) | null = null;
   private previouslyFocused: HTMLElement | null = null;
   private onKeydownTrap: ((e: KeyboardEvent) => void) | null = null;
@@ -129,7 +152,7 @@ export class Popup {
     this.textarea.setAttribute("aria-label", this.t("popup.textareaAria"));
 
     // Keyboard shortcut hint
-    const hint = el("div", {
+    this.hint = el("div", {
       style: `
         font-size:11px;color:${this.colors.textTertiary};
         text-align:right;margin-top:4px;
@@ -137,13 +160,7 @@ export class Popup {
         letter-spacing:0.01em;
       `,
     });
-    // navigator.userAgentData is preferred; navigator.platform is deprecated
-    // but still needed as fallback. If both are unavailable, fall back to user agent string parsing.
-    const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
-    const isMac = uaData
-      ? uaData.platform === "macOS"
-      : (navigator.platform?.includes("Mac") ?? /Macintosh|Mac OS X/i.test(navigator.userAgent));
-    setText(hint, isMac ? this.t("popup.submitHintMac") : this.t("popup.submitHintOther"));
+    setText(this.hint, isMacPlatform() ? this.t("popup.submitHintMac") : this.t("popup.submitHintOther"));
 
     this.textarea.addEventListener("focus", () => {
       this.textarea.style.borderColor = this.colors.accent;
@@ -171,8 +188,8 @@ export class Popup {
     // Button row
     const btnRow = el("div", { style: "display:flex;justify-content:flex-end;gap:8px;margin-top:12px;" });
 
-    const cancelBtn = document.createElement("button");
-    cancelBtn.style.cssText = `
+    this.cancelBtn = document.createElement("button");
+    this.cancelBtn.style.cssText = `
       height:34px;padding:0 16px;border-radius:9999px;
       border:1px solid ${this.colors.border};
       background:${this.colors.glassBg};
@@ -180,15 +197,15 @@ export class Popup {
       font-size:13px;font-weight:500;cursor:pointer;
       transition:all 0.2s ease;
     `;
-    setText(cancelBtn, this.t("popup.cancel"));
-    cancelBtn.addEventListener("click", () => this.cancel());
-    cancelBtn.addEventListener("mouseenter", () => {
-      cancelBtn.style.borderColor = this.colors.accent;
-      cancelBtn.style.color = this.colors.accent;
+    setText(this.cancelBtn, this.t("popup.cancel"));
+    this.cancelBtn.addEventListener("click", () => this.cancel());
+    this.cancelBtn.addEventListener("mouseenter", () => {
+      this.cancelBtn.style.borderColor = this.colors.accent;
+      this.cancelBtn.style.color = this.colors.accent;
     });
-    cancelBtn.addEventListener("mouseleave", () => {
-      cancelBtn.style.borderColor = this.colors.border;
-      cancelBtn.style.color = this.colors.textTertiary;
+    this.cancelBtn.addEventListener("mouseleave", () => {
+      this.cancelBtn.style.borderColor = this.colors.border;
+      this.cancelBtn.style.color = this.colors.textTertiary;
     });
 
     this.submitBtn = document.createElement("button");
@@ -204,14 +221,41 @@ export class Popup {
     setText(this.submitBtn, this.t("popup.submit"));
     this.submitBtn.addEventListener("click", () => this.submit());
 
-    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(this.cancelBtn);
     btnRow.appendChild(this.submitBtn);
 
     this.root.appendChild(typeRow);
     this.root.appendChild(this.textarea);
-    this.root.appendChild(hint);
+    this.root.appendChild(this.hint);
     this.root.appendChild(btnRow);
     document.body.appendChild(this.root);
+  }
+
+  /**
+   * Re-read every `t(...)`-derived label, placeholder, and aria-label from
+   * the active translation function. Idempotent — call after the locale
+   * dictionary has finished loading so the popup swaps from the English
+   * fallback to the configured language.
+   */
+  refreshLabels(): void {
+    this.root.setAttribute("aria-label", this.t("popup.ariaLabel"));
+
+    const typeButtons = this.root.querySelectorAll<HTMLButtonElement>("button[data-type]");
+    for (const btn of typeButtons) {
+      const type = btn.dataset.type as FeedbackType | undefined;
+      if (!type) continue;
+      const key = TYPE_LABEL_KEYS[type];
+      if (!key) continue;
+      const labelSpan = btn.querySelector<HTMLSpanElement>("span");
+      if (labelSpan) setText(labelSpan, this.t(key));
+    }
+
+    this.textarea.placeholder = this.t("popup.placeholder");
+    this.textarea.setAttribute("aria-label", this.t("popup.textareaAria"));
+
+    setText(this.hint, isMacPlatform() ? this.t("popup.submitHintMac") : this.t("popup.submitHintOther"));
+    setText(this.cancelBtn, this.t("popup.cancel"));
+    setText(this.submitBtn, this.t("popup.submit"));
   }
 
   /**


### PR DESCRIPTION
## What

Adds `refreshLabels()` to `Fab` and `Popup` (and a passthrough on `Annotator`) and wires the launcher to call them once `loadLocale(locale)` resolves. The initial markers fetch is also chained behind `Promise.all([getFeedbacks, localeReady])` so marker aria-labels render once for the resolved locale.

Closes #106.

## Why

For any non-English built-in locale (`de`, `fr`, `es`, `it`, `pt`, `ru`), the FAB radial menu (`Messages` / `Annotate` / `Annotations`) and the annotation popup (type buttons, placeholder, `⌘+Enter` hint, `Cancel` / `Send`, dialog `aria-label`) stayed in the English fallback for the whole session. The dictionary actually loaded — `LOCALES.de` was populated, `Tooltip` rendered correctly, `Panel` rendered correctly — but the two synchronously-constructed components had already baked the English fallback into `textContent` / `aria-label` / `placeholder` and never re-read it.

Full root-cause walk-through is in #106. Short version: `launch()` fires `loadLocale(locale)` and *immediately* constructs `new Fab(...)` and `new Annotator(...)` (which builds the `Popup`). `createT(locale)` returns a closure that reads `LOCALES` at call time, so lazy consumers (`Tooltip.render`, `Panel.*`, `MarkerManager.createMarker`) localize correctly. But the constructors of `Fab` and `Popup` capture results into the DOM eagerly, so they freeze in the English fallback before the chunk arrives.

## Behavior

| Scenario | Result |
|---|---|
| `locale: 'en'` (default) | Unchanged. `t(...)` already returns English at construction time, no chunk to wait for, no refresh runs. |
| `locale: 'de'` (or any non-English built-in) | FAB + popup mount with the English fallback (one extra tick of staleness, same as today), then swap to the localized strings once the chunk lands. |
| Custom locale registered via `registerLocale(code, dict)` | Synchronous — `loadLocale` returns the registered dictionary on the same microtask, refresh runs immediately. |
| `instance.destroy()` called before the chunk resolves | Refresh aborts via `destroyed` guard. |
| Initial marker `aria-label`s | Now wait on `Promise.all([getFeedbacks, localeReady])` instead of racing — marker labels render once in the resolved locale instead of sometimes-English / sometimes-German based on network ordering. |

Backward-compatible: no API surface changes, no new config options, no new public methods on `SitepingInstance`. `refreshLabels()` is internal to the relevant component classes.

## Changes

- `packages/widget/src/fab.ts` — `ITEM_LABEL_KEYS` map (item id → translation key) + `refreshLabels()` that re-reads `t(...)` and rewrites the FAB button `aria-label`, each radial item's `aria-label`, and each `.sp-radial-label` `textContent`.
- `packages/widget/src/popup.ts` — `TYPE_LABEL_KEYS` map (feedback type → translation key) + extracted `isMacPlatform()` helper + `refreshLabels()` covering the dialog `aria-label`, the four type-button labels, textarea `placeholder` + `aria-label`, the `⌘+Enter` / `Ctrl+Enter` hint, and the cancel/submit `textContent`. Promotes `cancelBtn` and `hint` to instance fields so refresh can address them without re-querying.
- `packages/widget/src/annotator.ts` — `refreshLabels()` passthrough to the popup. The annotator toolbar itself rebuilds on every `activate()` call, so it doesn't need re-localizing.
- `packages/widget/src/launcher.ts` — introduces `localeReady` (synchronously-resolved for `'en'`, a `loadLocale` promise otherwise). After it resolves, calls `fab.refreshLabels()` + `annotator.refreshLabels()` (guarded by `destroyed`). The initial `client.getFeedbacks(...)` is now `Promise.all([…, localeReady])` so marker `aria-label`s wait for the dictionary too. The eager retry-queue flush is unaffected.
- `packages/widget/__tests__/widget/fab.test.ts` — new `refreshLabels` describe: a mutable mock `t` proves `refreshLabels()` re-reads `this.t` at call time (not just at construction) and re-binds all aria-labels + label spans. Plus an idempotency test.
- `packages/widget/__tests__/widget/popup.test.ts` — symmetric `refreshLabels` describe covering the dialog, four type buttons, textarea (`placeholder` + `aria-label`), hint, cancel, submit. Plus an idempotency test.
- `packages/widget/__tests__/widget/launcher-integration.test.ts` — new `locale dictionary loading` describe: `launch({ locale: 'de' })` ends up with German FAB `aria-label` (`Siteping — Feedback-Menü`), German radial item labels (`Nachrichten` text + aria-label on the `chat` item), and `Annotator.refreshLabels` is invoked exactly once. Sibling test verifies `locale: 'en'` does not schedule a refresh.
- `packages/widget/__tests__/widget/launcher.test.ts` — extends the existing `Annotator` mock with `refreshLabels: vi.fn()` so a future test that passes `locale: 'de'` won't crash.

### Why mock `t` for the unit tests instead of `await loadLocale('de')`

The `LOCALES` registry is module-level state shared across test files within a Vitest worker. Once one test calls `loadLocale('de')`, the German dictionary stays in memory for every subsequent test in the same run. Asserting "labels start in English fallback, then become German after loadLocale" was order-dependent. The mock-`t`-with-mutable-prefix pattern tests the actual `refreshLabels()` contract ("calls `this.t` at refresh time and writes the result back into the DOM") without that hazard. The launcher-integration test still exercises the real `loadLocale('de')` path end-to-end.

## Verification

- `bun run check` — green
- `bun run lint` — green
- `bunx vitest run packages/widget` — 1027 / 1027 green, including the new fab / popup / launcher-integration tests
- `bun run build` — green (all 7 turbo tasks succeed, including the existing 7 i18n chunk outputs `de-…js` / `fr-…js` / etc.)

The pre-existing `packages/adapter-localstorage/__tests__/localstorage-store.test.ts` failures (40 tests, `localStorage` undefined in the test environment) are unchanged by this PR — same failures on `main`, called out in #82.

## Notes / scope

- I considered deferring `Fab` / `Annotator` construction inside `launch()` until `localeReady` resolves. That would have eliminated the "one tick of English" window entirely, but it would also delay first-paint of the FAB and require shimming every method on `SitepingInstance` to queue against a not-yet-constructed UI. The refresh-after-mount approach keeps the widget interactive immediately, matches the existing pattern that `Tooltip` / `Panel` / `MarkerManager` already use (lazy `t(...)` lookups), and stays within the scope of the bug.
- No locale strings were touched — the German `de.ts` already contained every label we surface via `refreshLabels()`. Same for the other five built-ins.
- The Panel and Tooltip already invoke `t(...)` lazily at render time, so they self-heal once the dictionary lands. They needed no changes.