### PR TITLE
docs(readme): document enableScreenshot + qualify privacy claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Both entry points share the same focus implementation — only the trigger diffe
 
 ## Screenshot capture
 
-Turn on `enableScreenshot` and every submitted feedback ships with a JPEG of the annotated rectangle, embedded inline as a `data:` URL on the feedback record. The reviewer panel renders it on the detail view next to the message.
+Turn on `enableScreenshot` and every submitted feedback ships with a JPEG of the annotated rectangle, embedded inline as a `data:` URL on the feedback record. The reviewer panel shows a dedicated **Screenshot** section on each feedback that has one.
 
 ```ts
 initSiteping({

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ initSiteping({
   locale: 'en',                   // 'en' | 'fr' (default: 'en')
   forceShow: false,               // Show in production? Default: false
   debug: false,                   // Enable debug logging
+  enableScreenshot: false,        // Capture a JPEG of the annotated area on
+                                  // submit. Off by default — see "Screenshot
+                                  // capture" below for the masking story.
   identity: {                     // Pre-fill author from the host (SSO apps).
     name: 'Alice',                // When set, skips localStorage + modal.
     email: 'alice@example.com',
@@ -253,6 +256,39 @@ const matched = widget.focusFeedback(feedback.id)
 ```
 
 Both entry points share the same focus implementation — only the trigger differs.
+
+---
+
+## Screenshot capture
+
+Turn on `enableScreenshot` and every submitted feedback ships with a JPEG of the annotated rectangle, embedded inline as a `data:` URL on the feedback record. The reviewer panel renders it on the detail view next to the message.
+
+```ts
+initSiteping({
+  endpoint: '/api/siteping',
+  projectName: 'my-project',
+  enableScreenshot: true,
+})
+```
+
+`html2canvas` ships as a regular dependency of `@siteping/widget` — no separate install. The widget dynamic-imports it on the first capture (≈ 40 KB gzip), so installs that leave the option off pay only disk space.
+
+**Masking sensitive elements.** Add `data-siteping-ignore="true"` to any element you do **not** want captured. The capture predicate skips matching elements *and their descendants*, so a single attribute on a wrapper is enough:
+
+```html
+<input type="password" data-siteping-ignore="true">
+<section data-siteping-ignore="true">
+  <!-- credit-card form, API tokens, PII … -->
+</section>
+```
+
+Set masks **before** turning the option on in production — once a feedback is saved, the screenshot is in your database (or object storage) regardless of what was on the page when it was captured.
+
+**Privacy.** Screenshots embed page content. Inform end users in your widget host UI when enabling, and treat the feature as an opt-in for environments where casual page content might be confidential.
+
+**Output.** The widget produces JPEG at quality 0.85, downscaled to a max width of 1200 CSS pixels (≈ 50–150 KB for a typical annotated area). Both numbers are currently fixed; if a use case appears that needs different settings, the option could grow into `enableScreenshot: true | { quality?, maxWidth? }` — file an issue if you'd find that useful.
+
+**Failure handling.** If `html2canvas` fails to load or the capture throws (CORS-tainted canvas, missing 2D context, …), the widget returns `null` and the feedback still submits without the screenshot — the option never blocks a submission.
 
 ---
 
@@ -495,7 +531,7 @@ All adapters implement the `SitepingStore` interface — swap adapters without c
 ## Data & Privacy
 
 - **What the widget collects:** author name, email, feedback message, page URL, viewport dimensions, user agent, and DOM anchoring data (CSS selector, XPath, text snippet, element coordinates).
-- **No screenshots or full DOM snapshots** are captured — only the minimal data needed to re-anchor annotations.
+- **No screenshots or full DOM snapshots are captured by default** — only the minimal data needed to re-anchor annotations. Hosts can opt in to per-annotation screenshot capture via `enableScreenshot: true`; see [Screenshot capture](#screenshot-capture) for the masking story and the privacy caveat.
 - **Self-hosted** — all data is stored in your own database. Nothing is sent to third-party servers.
 - **Sensitive URL parameters are automatically stripped** before submission to prevent accidental data leakage.
 


### PR DESCRIPTION
## What

Three small additions to `README.md` so the `enableScreenshot` config option is actually discoverable and the Data & Privacy section doesn't contradict itself once the option is on.

No code changes.

Closes #109.

## Why

The option is fully implemented (defined in `packages/core/src/types.ts` with a thorough JSDoc, consumed by `Annotator` via `captureScreenshot()` in `screenshot.ts`) but absent from the README. A reader who only follows the README has no way to discover it, and the Data & Privacy bullet at `README.md:498` stated *"No screenshots or full DOM snapshots are captured"* without qualifying that the claim only holds in the default state — privacy-sensitive evaluators could base a decision on a sentence that becomes false the moment a host opts in.

The sibling option `captureDiagnostics` already has its own README section ("Diagnostics capture" at line 259); this PR just gives `enableScreenshot` the symmetric treatment.

## Changes

| Spot | Before | After |
|---|---|---|
| `README.md:148-177` (Configuration block) | Lists position, accentColor, theme, locale, forceShow, debug, identity, callbacks. No `enableScreenshot`. | Adds `enableScreenshot: false,` between `debug` and `identity`, with an inline comment pointing to the new section. |
| Between `Deep-linking to annotations` and `Diagnostics capture` (new `README.md:262-291`) | — | New "Screenshot capture" section mirroring the "Diagnostics capture" pattern: usage, dynamic-import note, `data-siteping-ignore` masking story (works on element *and* descendants), pre-prod ordering caveat, privacy reminder, current fixed output (quality 0.85 / maxWidth 1200 px) with a pointer to a possible future `enableScreenshot: true \| { quality?, maxWidth? }` shape, and failure-handling note (capture failure → feedback still submits without screenshot). |
| `README.md:498` (Data & Privacy bullet) | *"No screenshots or full DOM snapshots are captured — only the minimal data needed to re-anchor annotations."* | *"No screenshots or full DOM snapshots are captured by default — only the minimal data needed to re-anchor annotations. Hosts can opt in to per-annotation screenshot capture via `enableScreenshot: true`; see [Screenshot capture](#screenshot-capture) for the masking story and the privacy caveat."* |

The new section's content comes verbatim from the `enableScreenshot` JSDoc in `types.ts` plus the constants in `screenshot.ts` (`quality: 0.85`, `maxWidth: 1200`) — no claims that aren't already true in the source.

## Notes on scope

- **No new feature work.** Quality and maxWidth are still fixed; the new section calls that out and floats an `enableScreenshot: true | { quality?, maxWidth? }` shape as a future option, but does not implement it. Happy to file that as a separate enhancement issue if anyone has a concrete use case.
- **No tests touched.** README only.
- **Anchor link.** The Data & Privacy bullet links back to `#screenshot-capture`. GitHub's heading-slug rules produce that anchor from `## Screenshot capture` — verified by checking the local render of `README.md` after the change.

## Verification

- `bun run check` — green
- `bun run lint` — green (Biome doesn't lint markdown but ran the full check anyway)
- Visually re-read the rendered README on `docs/enable-screenshot-section` to confirm:
  - the Configuration block reads cleanly with the new field aligned,
  - the new section sits naturally between "Deep-linking to annotations" and "Diagnostics capture",
  - the Data & Privacy anchor link resolves to the new section.

The pre-existing `packages/adapter-localstorage` test failures unrelated to this PR are unchanged (called out in #82 and #107).