### PR TITLE
fix(widget): exclude annotator overlay from captured screenshots

### DIFF
--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -188,6 +188,41 @@ describe("Annotator", () => {
 
       expect(countOverlays()).toBe(1);
     });
+
+    // Regression: issue #124 — the annotator's chrome lives on document.body
+    // (outside the siteping-widget shadow host), so the screenshot predicate
+    // can't reach it via the shadow-host check. Each piece must carry
+    // `data-siteping-ignore="true"` or it gets baked into the JPEG.
+    it("overlay carries data-siteping-ignore so it is excluded from screenshots", () => {
+      bus.emit("annotation:start");
+
+      const overlay = findOverlay()!;
+      expect(overlay.getAttribute("data-siteping-ignore")).toBe("true");
+    });
+
+    it("toolbar carries data-siteping-ignore so it is excluded from screenshots", () => {
+      bus.emit("annotation:start");
+
+      // The toolbar is the sibling of the overlay — pick the one that hosts
+      // the cancel button (the toolbar) rather than the overlay itself.
+      const cancelBtn = Array.from(document.body.querySelectorAll("button")).find(
+        (btn) => btn.textContent === t("annotator.cancel"),
+      )!;
+      const toolbar = cancelBtn.closest("div[data-siteping-ignore]");
+      expect(toolbar).not.toBeNull();
+      expect(toolbar!.getAttribute("data-siteping-ignore")).toBe("true");
+    });
+
+    it("drawing rect carries data-siteping-ignore so the selection border is excluded from screenshots", () => {
+      bus.emit("annotation:start");
+
+      const overlay = findOverlay()!;
+      overlay.dispatchEvent(new MouseEvent("mousedown", { clientX: 50, clientY: 50, bubbles: true }));
+
+      const drawingRect = overlay.querySelector<HTMLElement>("div")!;
+      expect(drawingRect).not.toBeNull();
+      expect(drawingRect.getAttribute("data-siteping-ignore")).toBe("true");
+    });
   });
 
   describe("deactivate", () => {

--- a/packages/widget/__tests__/widget/screenshot.test.ts
+++ b/packages/widget/__tests__/widget/screenshot.test.ts
@@ -28,6 +28,14 @@ describe("captureScreenshot — graceful degrade", () => {
   beforeEach(() => {
     _resetScreenshotCacheForTests();
     mockHtml2Canvas.mockReset();
+    // Default success stub — give html2canvas a real-looking canvas so tests
+    // that focus on the ignoreElements predicate can complete without
+    // tripping the graceful-degrade path.
+    mockHtml2Canvas.mockResolvedValue({
+      width: 100,
+      height: 100,
+      toDataURL: () => "data:image/jpeg;base64,STUB",
+    });
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -36,6 +44,7 @@ describe("captureScreenshot — graceful degrade", () => {
   });
 
   it("returns null when html2canvas rejects (covers all runtime capture failures)", async () => {
+    mockHtml2Canvas.mockReset();
     mockHtml2Canvas.mockRejectedValue(new Error("canvas tainted"));
 
     const result = await captureScreenshot(new DOMRect(0, 0, 100, 100));
@@ -49,6 +58,7 @@ describe("captureScreenshot — graceful degrade", () => {
     // Simulate a bundler/transform that exposes html2canvas as `undefined`
     // (rare but possible with some interop modes). The captureScreenshot
     // catch should swallow the resulting TypeError.
+    mockHtml2Canvas.mockReset();
     mockHtml2Canvas.mockImplementation(() => {
       throw new TypeError("html2canvas is not a function");
     });
@@ -59,10 +69,73 @@ describe("captureScreenshot — graceful degrade", () => {
   });
 
   it("never propagates an exception out of captureScreenshot", async () => {
+    mockHtml2Canvas.mockReset();
     mockHtml2Canvas.mockRejectedValue(new Error("any failure"));
 
     // The caller is `annotator.finishDrawing` — feedback submission must
     // not be aborted because the screenshot failed.
     await expect(captureScreenshot(new DOMRect(0, 0, 100, 100))).resolves.not.toThrow();
+  });
+});
+
+// -----------------------------------------------------------------------
+// ignoreElements predicate — masking contract for screenshots.
+//
+// The predicate is the only thing standing between widget chrome (annotator
+// overlay, drawing rect, popup) and the captured JPEG, and between host-
+// marked sensitive elements and the captured JPEG. Both code paths share
+// the same `data-siteping-ignore="true"` attribute, so we verify both here.
+// Regression for issue #124 (annotator selection overlay leaking into the
+// screenshot).
+// -----------------------------------------------------------------------
+
+describe("captureScreenshot — ignoreElements predicate", () => {
+  beforeEach(() => {
+    _resetScreenshotCacheForTests();
+    mockHtml2Canvas.mockReset();
+    mockHtml2Canvas.mockResolvedValue({
+      width: 100,
+      height: 100,
+      toDataURL: () => "data:image/jpeg;base64,STUB",
+    });
+  });
+
+  type IgnoreFn = (element: Element) => boolean;
+
+  async function getIgnorePredicate(): Promise<IgnoreFn> {
+    await captureScreenshot(new DOMRect(0, 0, 100, 100));
+    const opts = mockHtml2Canvas.mock.calls[0]?.[1] as { ignoreElements?: IgnoreFn } | undefined;
+    expect(opts?.ignoreElements).toBeTypeOf("function");
+    return opts!.ignoreElements as IgnoreFn;
+  }
+
+  it("excludes the siteping-widget shadow host (widget's own DOM)", async () => {
+    const ignore = await getIgnorePredicate();
+    const host = document.createElement("siteping-widget");
+    expect(ignore(host)).toBe(true);
+  });
+
+  it("excludes descendants of the siteping-widget shadow host", async () => {
+    const ignore = await getIgnorePredicate();
+    const host = document.createElement("siteping-widget");
+    const child = document.createElement("div");
+    host.appendChild(child);
+    document.body.appendChild(host);
+    expect(ignore(child)).toBe(true);
+    host.remove();
+  });
+
+  it("excludes elements explicitly marked data-siteping-ignore=true (host masking + annotator chrome)", async () => {
+    const ignore = await getIgnorePredicate();
+    const masked = document.createElement("div");
+    masked.setAttribute("data-siteping-ignore", "true");
+    expect(ignore(masked)).toBe(true);
+  });
+
+  it("does NOT exclude regular page elements", async () => {
+    const ignore = await getIgnorePredicate();
+    const regular = document.createElement("p");
+    regular.textContent = "Plain page content";
+    expect(ignore(regular)).toBe(false);
   });
 });

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -100,7 +100,13 @@ export class Annotator {
     this.savedOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
 
-    // Overlay — subtle blue tint for depth
+    // Overlay — subtle blue tint for depth.
+    //
+    // Overlay, toolbar and the drawn rectangle live on document.body, outside
+    // the siteping-widget shadow host. Without the `data-siteping-ignore`
+    // marker the screenshot predicate in screenshot.ts cannot reach them —
+    // and the accent-colored selection border plus the page tint end up
+    // baked into the captured JPEG. See issue #124.
     this.overlay = el("div", {
       style: `
         position:fixed;inset:0;
@@ -110,6 +116,7 @@ export class Annotator {
       `,
     });
     this.overlay.setAttribute("aria-hidden", "true");
+    this.overlay.setAttribute("data-siteping-ignore", "true");
 
     // Toolbar — glassmorphism bar
     this.toolbar = el("div", {
@@ -128,6 +135,7 @@ export class Annotator {
         -webkit-font-smoothing:antialiased;
       `,
     });
+    this.toolbar.setAttribute("data-siteping-ignore", "true");
 
     const dot = el("span", {
       style: `
@@ -303,6 +311,8 @@ export class Annotator {
         transition:box-shadow 0.15s ease;
       `,
     });
+    // Excluded from screenshot capture (see overlay creation in activate()).
+    this.drawingRect.setAttribute("data-siteping-ignore", "true");
     this.overlay?.appendChild(this.drawingRect);
   }
 

--- a/packages/widget/src/screenshot.ts
+++ b/packages/widget/src/screenshot.ts
@@ -86,6 +86,17 @@ export async function captureScreenshot(rect: DOMRect, options?: CaptureOptions)
       allowTaint: true,
       logging: false,
       ignoreElements: (element: Element) => {
+        // Matched elements (and their descendants) are removed from the
+        // render pass — the page underneath shows through. Two layers of
+        // exclusion:
+        //
+        // 1. The widget's own shadow host (`<siteping-widget>`).
+        // 2. Anything carrying `data-siteping-ignore="true"` — the
+        //    documented host-facing masking attribute AND how widget
+        //    chrome that lives OUTSIDE the shadow host (annotator overlay
+        //    + toolbar + drawing rect, popup) opts itself out of capture.
+        //    Without (2) the accent-colored selection border ends up
+        //    baked into the JPEG.
         return (
           element.tagName === "SITEPING-WIDGET" ||
           element.closest?.("siteping-widget") !== null ||


### PR DESCRIPTION
## Summary

Closes #124.

When `enableScreenshot: true`, the captured JPEG carried the annotator's accent-colored selection border (and a faint page tint) along the edges of the screenshot — visible in every saved feedback. This PR adds the `data-siteping-ignore="true"` marker to the annotator's three chrome elements so the screenshot predicate filters them out.

## Root cause

`Annotator.activate()` (`packages/widget/src/annotator.ts`) appends three full-page elements directly to `document.body`:

- `overlay` (full-page tint),
- `toolbar` (top-of-viewport actions),
- `drawingRect` (the rectangle the user just drew, with a 2 px accent border + 12 % accent fill).

The screenshot predicate in `packages/widget/src/screenshot.ts` skipped elements only when they were the `siteping-widget` shadow host *or* carried `data-siteping-ignore="true"`. The annotator's chrome lives on `document.body` (outside the shadow host) and never had the attribute — so html2canvas rendered it into the JPEG.

`Popup` already uses the same escape hatch (`popup.ts:80`) for the same reason. The annotator was a missed touchpoint of that pattern, and now matches.

## Why this fix and not a structural change

`data-siteping-ignore="true"` is already the **documented**, **publicly supported** masking mechanism (`packages/core/src/types.ts`, README "Screenshot capture", `packages/adapter-prisma/README.md`). Marking widget-internal chrome with the same attribute is consistent with the existing pattern, doesn't introduce a second exclusion mechanism, and html2canvas's `ignoreElements` removes the elements (and their subtrees) from the render pass — so the page content underneath captures cleanly.

## Touchpoints

### Code

- `packages/widget/src/annotator.ts` — set `data-siteping-ignore="true"` on `overlay`, `toolbar`, and `drawingRect` at creation. Added a comment in `activate()` explaining why this is necessary for elements that live outside the shadow host.
- `packages/widget/src/screenshot.ts` — expanded the inline comment on the `ignoreElements` predicate to make it explicit that the attribute serves two purposes: host-facing masking AND opt-out for widget chrome outside the shadow host.

### Tests

- `packages/widget/__tests__/widget/annotator.test.ts` — three new regression tests asserting that `overlay`, `toolbar`, and `drawingRect` all carry `data-siteping-ignore="true"`.
- `packages/widget/__tests__/widget/screenshot.test.ts` — new `ignoreElements predicate` suite verifying both code paths (shadow host + attribute) and the negative case (regular page elements are kept). Adjusted the existing graceful-degrade suite to keep a default success stub for the new tests; pre-existing degrade tests now opt into their own failure stubs.

### Documentation

No README change required — the existing "Screenshot capture" section already documents the `data-siteping-ignore` mechanism for host-side masking, and the new internal usage is invisible to integrators. The widget-internal contract is documented in the source comments (`annotator.ts` + `screenshot.ts`).

## Verification

- `bun run lint` — clean.
- `bun run check` — clean (10/10 turbo tasks pass).
- `bunx vitest run packages/widget/__tests__/widget/annotator.test.ts packages/widget/__tests__/widget/screenshot.test.ts` — 54/54 pass (47 annotator + 7 screenshot, including 3 + 4 new regression tests).
- Unrelated `packages/adapter-localstorage/__tests__/localstorage-store.test.ts` failures (40) are pre-existing on `main` (jsdom localStorage stub issue) and untouched by this PR — confirmed by running the suite on `main` with this branch stashed.

## Test plan

- [ ] Initialize the widget with `enableScreenshot: true`, draw a rectangle, submit, open the saved feedback. Captured JPEG no longer contains the accent-colored selection border or the page tint.
- [ ] Sensitive elements carrying `data-siteping-ignore="true"` on the host page continue to be removed from the capture (no regression of the documented masking contract).
- [ ] No visual change to the annotator chrome itself (overlay, toolbar, drawing rect) — only the html2canvas predicate behavior changes.