### PR TITLE
fix(widget): raise identity prompt above the in-flight feedback popup

### DIFF
--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -313,6 +313,49 @@ describe("launcher — annotation:complete integration", () => {
 
       instance.destroy();
     });
+
+    // Regression: issue #126. The popup stays visible during submission since
+    // #114, and both the popup and the shadow host sit at Z_INDEX_MAX on
+    // document.body. Equal z-index resolves by source order, so without the
+    // re-append the popup (mounted after the host during init) would render
+    // above the identity prompt that lives inside the shadow root.
+    it("moves the shadow host to the end of <body> so identity prompt wins z-index over the popup", async () => {
+      mockGetIdentity.mockReturnValue(null);
+
+      const instance = launch(defaultConfig());
+      expect(capturedBus).not.toBeNull();
+
+      // Simulate a popup-like sibling already on document.body, mounted after
+      // the host (this is exactly the layout the real Popup creates — see
+      // popup.ts:258). Z_INDEX_MAX matches the host's z-index.
+      const fakePopup = document.createElement("div");
+      fakePopup.setAttribute("data-test-id", "fake-popup");
+      fakePopup.style.cssText = "position:fixed;z-index:2147483647;";
+      document.body.appendChild(fakePopup);
+
+      const hostBefore = document.querySelector("siteping-widget")!;
+      const hostIndexBefore = Array.from(document.body.children).indexOf(hostBefore);
+      const popupIndexBefore = Array.from(document.body.children).indexOf(fakePopup);
+      expect(popupIndexBefore).toBeGreaterThan(hostIndexBefore);
+
+      capturedBus!.emit("annotation:complete", makeAnnotationCompleteData());
+
+      await vi.waitFor(() => {
+        const widget = document.querySelector("siteping-widget")!;
+        const shadow = widget.shadowRoot;
+        expect(shadow?.querySelector('[role="dialog"]')).not.toBeNull();
+      });
+
+      // After promptIdentity runs, the host must be the LAST sibling so the
+      // identity prompt inside its stacking context renders above the popup.
+      const hostAfter = document.querySelector("siteping-widget")!;
+      const hostIndexAfter = Array.from(document.body.children).indexOf(hostAfter);
+      const popupIndexAfter = Array.from(document.body.children).indexOf(fakePopup);
+      expect(hostIndexAfter).toBeGreaterThan(popupIndexAfter);
+
+      fakePopup.remove();
+      instance.destroy();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -594,6 +594,17 @@ function promptIdentity(shadowRoot: ShadowRoot, t: TFunction): Promise<Identity 
     // Save the currently focused element to restore on close
     const previouslyFocused = (shadowRoot.activeElement ?? document.activeElement) as HTMLElement | null;
 
+    // Move the shadow host to the end of <body> so the identity prompt wins
+    // the source-order tiebreak against the feedback popup. Both elements
+    // already sit at `Z_INDEX_MAX` (max int32 — no \"higher\"), and since #114
+    // the popup stays visible during submission, so it can be on screen at
+    // the moment `promptIdentity` runs. The popup is appended to `document.body`
+    // later than the host during init, which made it win when z-indices tied.
+    // Re-appending an existing node just moves it; no remount, no listener
+    // loss, no visual jitter when the popup isn't open. See issue #126.
+    const host = shadowRoot.host;
+    if (host.parentNode) host.parentNode.appendChild(host);
+
     const backdrop = document.createElement("div");
     backdrop.style.cssText = `
       position:fixed;inset:0;


### PR DESCRIPTION
## Summary

Closes #126. Regression from #114.

When the popup stays visible during submission (intentional, per #114), the identity prompt that opens for hosts without a stored identity is rendered *behind* the popup. The user cannot operate the name/e-mail form because the popup obscures it.

The fix re-appends the shadow host to `document.body` right before showing the identity prompt. Both elements sit at `Z_INDEX_MAX` (max int32 — no "higher"), and making the host the last sibling lets it win the source-order tiebreak. The identity prompt inside the host's stacking context then renders above the popup.

## Root cause

Inventory of competing z-indices, all on `document.body`:

| Element | z-index | Mount location | Mounted at |
|---|---|---|---|
| `<siteping-widget>` (shadow host) | `Z_INDEX_MAX` | `document.body` | init (`launcher.ts:267`) |
| feedback popup | `Z_INDEX_MAX` | `document.body` | `Annotator` constructor (`popup.ts:258`) |
| identity prompt backdrop | `Z_INDEX_MAX` | **shadow root** | when `promptIdentity` is called |

Host and popup are siblings at the same z-index; equal z-index resolves by source order, popup wins. The identity prompt inside the host's stacking context inherits the host's effective stacking level and cannot escape past the popup. Before #114 the popup was closed by the time `promptIdentity` ran, so the conflict never showed up.

## Why this fix and not a z-index change

- `Z_INDEX_MAX` is max int32 — there is no "higher" z-index to assign.
- Lowering the popup z-index would cascade through annotator overlay / toolbar / drawing-rect ordering (overlay is at `Z_INDEX_MAX - 1` and depends on the popup being above it on the same parent).
- Re-appending the host is **scoped to the identity-prompt code path**, changes nothing visible when no popup is open, preserves event listeners, and does not detach or remount the shadow root.

## Touchpoints

### Code

- `packages/widget/src/launcher.ts` — in `promptIdentity`, re-append `shadowRoot.host` to its parent before creating the backdrop. Comment explains the source-order rationale and points at #114 + #126.

### Tests

- `packages/widget/__tests__/widget/launcher-integration.test.ts` — new regression test under `identity modal`:
  - Mounts a fake popup-like sibling on `document.body` with `z-index: 2147483647` after the host (mirroring real `Popup` layout).
  - Asserts the host index is **less than** the popup index before the identity prompt opens.
  - Triggers `annotation:complete` to open the identity prompt.
  - Asserts the host is now the **last** sibling (host index > popup index) so the identity prompt inside its stacking context wins by source order.
- Verified the test **fails without the fix** (stashed `launcher.ts`, ran the focused test, got the expected `expect(hostIndexAfter).toBeGreaterThan(popupIndexAfter)` failure) and passes with it.

### Documentation

No README or public-API change. The behaviour is internal to the launcher's identity-prompt flow; the rationale lives in the source comment.

## Verification

- `bun run lint` — clean.
- `bun run check` — clean (10/10 turbo tasks pass).
- `bunx vitest run packages/widget` — **1055/1055 pass** across 34 widget test files, including the new regression test in `launcher-integration.test.ts` (56/56 in that file).
- Sanity-check: stashing the fix and re-running the new test produces the expected failure on the source-order assertion.

## Test plan

- [ ] Initialize the widget without a stored identity (`localStorage.removeItem("siteping_identity")` and no `config.identity`).
- [ ] Trigger an annotation, write a message, click **Send**.
- [ ] Identity prompt appears **above** the still-open popup (popup is darkened by the backdrop).
- [ ] Name + e-mail inputs are focusable; submitting the identity completes the feedback flow as before.
- [ ] Cancel button / Escape / backdrop-click all still close the identity prompt and emit `submission:cancelled`.
- [ ] No visual regression when identity is already stored (no popup-host reorder happens in that path).