### PR TITLE
fix(widget): preserve FAB toggle hover label across icon swaps

### DIFF
--- a/packages/widget/__tests__/widget/fab.test.ts
+++ b/packages/widget/__tests__/widget/fab.test.ts
@@ -589,5 +589,54 @@ describe("Fab", () => {
       // The bus should now emit annotations:toggle with true (back to visible)
       expect(listener).toHaveBeenCalledWith(true);
     });
+
+    // Regression: clicking the toggle used `replaceChildren(parseSvg(...))`,
+    // which dropped the `<span class="sp-radial-label">` alongside the old
+    // SVG — killing the hover label tooltip until a page reload. The fix
+    // swaps the SVG node in place and leaves the label span untouched.
+    it("preserves the hover label span across consecutive toggles", () => {
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      const toggleBtnSelector = '[data-item-id="toggle-annotations"]';
+      const t = createT("fr");
+      const expectedLabel = t("fab.annotations");
+
+      fabBtn.click();
+      const toggleBtn = shadow.querySelector<HTMLButtonElement>(toggleBtnSelector)!;
+
+      // Sanity: label span exists with the translated text before any click.
+      const labelBefore = toggleBtn.querySelector<HTMLSpanElement>(".sp-radial-label");
+      expect(labelBefore).not.toBeNull();
+      expect(labelBefore!.textContent).toBe(expectedLabel);
+
+      // First click — was the regression trigger.
+      toggleBtn.click();
+
+      const labelAfterFirst = toggleBtn.querySelector<HTMLSpanElement>(".sp-radial-label");
+      expect(labelAfterFirst).not.toBeNull();
+      expect(labelAfterFirst!.textContent).toBe(expectedLabel);
+
+      // Re-open and toggle again — span must still survive the second swap.
+      fabBtn.click();
+      const toggleAgain = shadow.querySelector<HTMLButtonElement>(toggleBtnSelector)!;
+      toggleAgain.click();
+
+      const labelAfterSecond = toggleAgain.querySelector<HTMLSpanElement>(".sp-radial-label");
+      expect(labelAfterSecond).not.toBeNull();
+      expect(labelAfterSecond!.textContent).toBe(expectedLabel);
+    });
+
+    it("replaces only the SVG icon — button has exactly one <svg> and one .sp-radial-label after each toggle", () => {
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      const toggleBtnSelector = '[data-item-id="toggle-annotations"]';
+
+      fabBtn.click();
+      const toggleBtn = shadow.querySelector<HTMLButtonElement>(toggleBtnSelector)!;
+
+      for (let i = 0; i < 3; i++) {
+        toggleBtn.click();
+        expect(toggleBtn.querySelectorAll("svg").length).toBe(1);
+        expect(toggleBtn.querySelectorAll(".sp-radial-label").length).toBe(1);
+      }
+    });
   });
 });

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -270,9 +270,14 @@ export class Fab {
       case "toggle-annotations": {
         this.annotationsVisible = !this.annotationsVisible;
         this.bus.emit("annotations:toggle", this.annotationsVisible);
+        // Replace ONLY the icon SVG, not every child. The button also carries
+        // the `<span class="sp-radial-label">` hover label — `replaceChildren`
+        // wiped it on the first click, killing the tooltip until reload.
         const btn = this.radialContainer.querySelector('[data-item-id="toggle-annotations"]');
-        if (btn) {
-          btn.replaceChildren(parseSvg(this.annotationsVisible ? ICON_EYE : ICON_EYE_OFF));
+        const oldSvg = btn?.querySelector("svg");
+        if (oldSvg) {
+          const newSvg = parseSvg(this.annotationsVisible ? ICON_EYE : ICON_EYE_OFF);
+          oldSvg.replaceWith(newSvg);
         }
         break;
       }


### PR DESCRIPTION
## Summary

Clicking the marker-visibility toggle on the FAB radial menu dropped its own hover label. After the first click the tooltip stayed gone for the rest of the session — only a full page reload restored it. This PR replaces only the SVG node when toggling between eye / eye-off so the label `<span>` survives.

## Root cause

`handleItemClick` (`fab.ts:275`) used `btn.replaceChildren(parseSvg(...))` to swap the eye / eye-off icon:

```ts
case "toggle-annotations": {
  ...
  const btn = this.radialContainer.querySelector('[data-item-id="toggle-annotations"]');
  if (btn) {
    btn.replaceChildren(parseSvg(this.annotationsVisible ? ICON_EYE : ICON_EYE_OFF));
  }
  break;
}
```

The button is built by the constructor with TWO children:

```html
<button data-item-id="toggle-annotations">
  <svg>...</svg>                            <!-- icon -->
  <span class="sp-radial-label">...</span>  <!-- hover tooltip -->
</button>
```

`replaceChildren` replaces ALL children — so the label `<span>` was destroyed alongside the old SVG on the very first click. `refreshLabels()` (`fab.ts:177`) queries the span via `btn.querySelector<HTMLSpanElement>(".sp-radial-label")` and writes `textContent` into it; once the span is gone the tooltip stays empty until the FAB is rebuilt.

## Fix

Replace only the SVG node, not the whole child list:

```ts
const oldSvg = btn?.querySelector("svg");
if (oldSvg) {
  const newSvg = parseSvg(this.annotationsVisible ? ICON_EYE : ICON_EYE_OFF);
  oldSvg.replaceWith(newSvg);
}
```

Same visual outcome (icon swaps), no surrounding children touched.

## Touchpoints

### Code

- `packages/widget/src/fab.ts` — narrowed the icon swap to `oldSvg.replaceWith(newSvg)` and added a comment pointing at the regression.

### Tests

- `packages/widget/__tests__/widget/fab.test.ts` — two new tests in the existing `toggle-annotations icon swap` block:
  1. **"preserves the hover label span across consecutive toggles"** — verifies the `.sp-radial-label` text survives one and two consecutive clicks.
  2. **"replaces only the SVG icon — button has exactly one <svg> and one .sp-radial-label after each toggle"** — locks the invariant that no other DOM grows or disappears around the swap.
- Verified the first regression test **fails without the fix** (`expect(labelAfterFirst!.textContent).toBe(expectedLabel)` gets `""` instead of the translated string) and passes with it.

### Documentation

No README change. Internal behaviour fix; surface API unchanged.

## Verification

- `bun run lint` — clean.
- `bun run check` — clean (10/10 turbo tasks pass).
- `bunx vitest run packages/widget/__tests__/widget/fab.test.ts` — 44/44 pass (43 existing + 1 new).
- Sanity: stashing the fix and re-running `preserves the hover label span` produces the expected failure.

## Test plan

- [ ] Open the FAB, click the top (eye) item once. The marker-visibility state toggles as before.
- [ ] Reopen the FAB and hover the eye item — the label tooltip still appears.
- [ ] Toggle again. Hover still produces the tooltip. No page reload needed.