### PR TITLE
feat(widget): add showAnnotationsToggle config to hide the FAB marker-visibility item

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ initSiteping({
   locale: 'en',                   // 'en' | 'fr' (default: 'en')
   forceShow: false,               // Show in production? Default: false
   debug: false,                   // Enable debug logging
+  showAnnotationsToggle: true,    // Show the "toggle markers visibility" item
+                                  // in the FAB radial menu. Default: true. Set
+                                  // to false for hosts that always want markers
+                                  // visible or find the eye icon redundant.
   enableScreenshot: false,        // Capture a JPEG of the annotated area on
                                   // submit. Off by default — see "Screenshot
                                   // capture" below for the masking story.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,6 +54,20 @@ export interface SitepingConfig {
   store?: SitepingStore | undefined;
   /** FAB position — defaults to 'bottom-right' */
   position?: SitepingPosition;
+  /**
+   * Show the "toggle markers visibility" item in the FAB radial menu.
+   * Defaults to `true` (current behavior). Set to `false` to hide that
+   * item entirely — useful for hosts that always want markers visible
+   * (e.g. dedicated review tools) or that find the eye icon redundant
+   * when no marker is on screen.
+   *
+   * Hiding the item also removes its keyboard navigation slot — the
+   * remaining two items still respond to ArrowUp/ArrowDown/Home/End.
+   * The marker-visibility state itself is unaffected; markers stay
+   * visible (the previous default state) and `annotations:toggle` is
+   * simply never emitted from the FAB.
+   */
+  showAnnotationsToggle?: boolean | undefined;
   /** Accent color for the widget UI — defaults to '#0066ff' */
   accentColor?: string;
   /** Show the widget even in production — defaults to false */

--- a/packages/widget/__tests__/widget/fab.test.ts
+++ b/packages/widget/__tests__/widget/fab.test.ts
@@ -104,6 +104,82 @@ describe("Fab", () => {
   });
 
   // -------------------------------------------------------------------------
+  // showAnnotationsToggle — opt-out for the marker-visibility radial item
+  // -------------------------------------------------------------------------
+
+  describe("config.showAnnotationsToggle", () => {
+    it("defaults to true — toggle-annotations item is present when the option is omitted", () => {
+      // The shared `beforeEach` builds the FAB with defaultConfig() (no
+      // showAnnotationsToggle key) — so this asserts the default branch.
+      const items = getRadialItems(shadow);
+      const ids = items.map((btn) => btn.dataset.itemId);
+      expect(ids).toContain("toggle-annotations");
+      expect(items.length).toBe(3);
+    });
+
+    it("`true` (explicit) keeps the toggle-annotations item", () => {
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, { ...defaultConfig(), showAnnotationsToggle: true }, bus, createT("fr"));
+
+      const ids = getRadialItems(shadow).map((btn) => btn.dataset.itemId);
+      expect(ids).toEqual(["chat", "annotate", "toggle-annotations"]);
+    });
+
+    it("`false` hides the toggle-annotations item entirely — no DOM, no click handler", () => {
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, { ...defaultConfig(), showAnnotationsToggle: false }, bus, createT("fr"));
+
+      const ids = getRadialItems(shadow).map((btn) => btn.dataset.itemId);
+      expect(ids).toEqual(["chat", "annotate"]);
+      expect(shadow.querySelector('[data-item-id="toggle-annotations"]')).toBeNull();
+    });
+
+    it("`false` — `annotations:toggle` is never emitted from the FAB even when the menu is opened and the bottom items are clicked", () => {
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, { ...defaultConfig(), showAnnotationsToggle: false }, bus, createT("fr"));
+
+      const listener = vi.fn();
+      bus.on("annotations:toggle", listener);
+
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      fabBtn.click(); // open
+      shadow.querySelector<HTMLButtonElement>('[data-item-id="chat"]')!.click();
+      fabBtn.click(); // reopen
+      shadow.querySelector<HTMLButtonElement>('[data-item-id="annotate"]')!.click();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("`false` — keyboard navigation still cycles through the remaining two items", () => {
+      fab.destroy();
+      shadow.host.remove();
+      shadow = createShadowRoot();
+      fab = new Fab(shadow, { ...defaultConfig(), showAnnotationsToggle: false }, bus, createT("fr"));
+
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      fabBtn.click(); // open
+
+      const items = getRadialItems(shadow);
+      const radial = shadow.querySelector<HTMLElement>('[role="menu"]')!;
+      expect(items.length).toBe(2);
+
+      items[0]!.focus();
+      radial.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      expect(shadow.activeElement).toBe(items[1]);
+
+      // ArrowDown again wraps back to the first item (last → first)
+      radial.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      expect(shadow.activeElement).toBe(items[0]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Open / Close (radial menu toggle)
   // -------------------------------------------------------------------------
 

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -48,12 +48,17 @@ export class Fab {
     const position = config.position ?? "bottom-right";
     const isRight = position === "bottom-right";
 
-    // Vertical stack above the FAB
+    // Vertical stack above the FAB. The marker-visibility toggle is opt-out
+    // via `config.showAnnotationsToggle`: default `true` preserves historical
+    // behavior, `false` removes the item from the menu entirely (no DOM, no
+    // keyboard slot, no click handler).
     this.items = [
       { id: "chat", icon: ICON_CHAT },
       { id: "annotate", icon: ICON_ANNOTATE },
-      { id: "toggle-annotations", icon: ICON_EYE, iconAlt: ICON_EYE_OFF },
     ];
+    if (config.showAnnotationsToggle !== false) {
+      this.items.push({ id: "toggle-annotations", icon: ICON_EYE, iconAlt: ICON_EYE_OFF });
+    }
 
     // FAB button — needs position:relative for badge positioning
     this.fab = document.createElement("button");


### PR DESCRIPTION
## Summary

Adds an opt-out switch for the marker-visibility (eye) item in the FAB radial menu. Some hosts always want markers visible — dedicated review tools, dashboards where the markers are core content — or find the eye icon redundant when there is no marker on screen yet.

Default behaviour is unchanged. Setting `showAnnotationsToggle: false` removes the item entirely: no DOM node is created, no keyboard slot, no click handler.

```ts
// default — current behaviour, eye item present
initSiteping({ endpoint: '/api/siteping', projectName: 'my-project' })

// opt-out — only sidebar + create-annotation items in the FAB
initSiteping({
  endpoint: '/api/siteping',
  projectName: 'my-project',
  showAnnotationsToggle: false,
})
```

## Design choices

- **Opt-out, not opt-in.** Keeps backwards compatibility with every existing integration. A switch to opt-in would silently hide the item on every existing host on upgrade.
- **Item removal, not just visibility.** Hiding via CSS would leave a keyboard slot the user can tab into and a click handler that emits `annotations:toggle`. Removing from `this.items` cleanly avoids both.
- **Marker visibility state is not coupled to the option.** The FAB is just one entry point; markers stay at their previous default (visible). `annotations:toggle` is simply never emitted from the FAB when the option is `false`. If a host wants markers hidden by default while keeping the toggle hidden, they can listen for any DOM-ready signal and emit the event themselves on the bus — that is out of scope for this PR.

## Touchpoints

### Code

- `packages/core/src/types.ts` — added `showAnnotationsToggle?: boolean | undefined` to `SitepingConfig`. JSDoc explains the default, the side effects (no DOM, no keyboard slot, no handler) and the unaffected marker-visibility state.
- `packages/widget/src/fab.ts` — replaced the static `this.items = [...]` initialiser with a conditional push for the toggle entry. Added a comment that the radial-menu item is opt-out via the new config key.

### Tests

- `packages/widget/__tests__/widget/fab.test.ts` — new `config.showAnnotationsToggle` describe block with five tests:
  1. **default (omitted)** keeps all three items — current behaviour preserved.
  2. **explicit `true`** keeps all three items — symmetric to omitted.
  3. **`false`** hides the item — `data-item-id="toggle-annotations"` query returns null and `getRadialItems()` is length 2 with ids `["chat", "annotate"]`.
  4. **`false`** — clicking the remaining items never emits `annotations:toggle` (the option also unwires the bus channel from the FAB).
  5. **`false`** — keyboard navigation (ArrowDown + wrap) still cycles through the remaining two items correctly.

### Documentation

- `README.md` — added the option to the Configuration code block with an inline explanation. Sits between `debug` and `enableScreenshot` to match the file order of the type definition.

## Verification

- `bun run lint` — clean.
- `bun run check` — clean (10/10 turbo tasks pass).
- `bunx vitest run packages/widget packages/core` — **1134/1134 pass** across 37 test files, including the 5 new tests in `fab.test.ts`.

## Test plan

- [ ] Default behaviour: a host with no `showAnnotationsToggle` key still sees the eye item in the FAB (no regression for existing integrations).
- [ ] `showAnnotationsToggle: false` removes the top item from the FAB — only the bottom two are present.
- [ ] With the option `false`, tabbing into the FAB and using ArrowUp/ArrowDown cycles only between the two remaining items.
- [ ] With the option `false`, markers stay visible (default state) — no `annotations:toggle(false)` is dispatched on init or click.
- [ ] Setting `showAnnotationsToggle: true` explicitly produces the same DOM as omitting the option.