### PR TITLE
chore(ci): exclude majors from dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,14 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+        update-types:
+          - "minor"
+          - "patch"
       production-dependencies:
         dependency-type: production
+        update-types:
+          - "minor"
+          - "patch"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Restrict `dev-dependencies` and `production-dependencies` groups to `minor` + `patch` only.
- Major bumps will now land as **individual PRs** instead of being absorbed into the weekly group.

## Why
The current groups bundle every bump regardless of semver. The most recent run produced:
- #122 (dev-deps): 8 bumps including **TypeScript 5→6**, **Vitest 3→4**, **Prisma 6→7**, **commander 13→14**, **@clack/prompts 0→1**
- #123 (prod-deps): 3 bumps including **Next 15→16**, **Zod 3→4**, **@medv/finder 3→4**

Both PRs are unreviewable in practice, hard to roll back, and broke CI in the same step (Dependabot can't regenerate `bun.lock`, so any package bump pre-fails on `bun install --frozen-lockfile`). After this change:
- Minor/patch groups stay small, low-risk, and easy to merge in bulk.
- Each major is evaluated, tested, and shipped on its own timeline.

## Follow-up
- Close #122 and #123 — Dependabot will recreate them under the new rules at the next weekly run.

## Test plan
- [ ] Verify next Dependabot run produces separate PRs for any pending major bumps.
- [ ] Verify minor/patch groups still get aggregated.