### PR TITLE
fix(ci): rename first-interaction inputs after v3 bump

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Greet first-time contributors
         uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 Welcome to **SitePing**, and thanks for opening your first issue!
 
             A few quick things that help us help you faster:
@@ -32,7 +32,7 @@ jobs:
             - If it's a feature, describe the **use case** before the implementation — it helps us pick the right shape for the API.
 
             We try to triage within a few days. In the meantime, browse [`good first issue`](https://github.com/NeosiaNexus/SitePing/labels/good%20first%20issue) if you'd like to ship a fix yourself. 🚀
-          pr-message: |
+          pr_message: |
             🎉 **Welcome, new contributor!** Thanks for your first pull request to SitePing — this is genuinely exciting.
 
             A few things to know:


### PR DESCRIPTION
## Summary
- Rename `repo-token` → `repo_token`, `issue-message` → `issue_message`, `pr-message` → `pr_message` in `welcome.yml`.

## Why
`actions/first-interaction@v3` (landed via #117) switched its input names from kebab-case to snake_case. The bump wasn't accompanied by a workflow update, so the welcome workflow now crashes on every new issue/PR with:

```
##[warning]Unexpected input(s) 'repo-token', 'issue-message', 'pr-message', valid inputs are ['issue_message', 'pr_message', 'repo_token']
Error: Input required and not supplied: issue_message
```

Observed live on PR #131 (the welcome check failed there).

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, verify the welcome workflow succeeds on the next new issue/PR.