### PR TITLE
chore(deps-dev): pin jsdom to exact 29.1.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@prisma/client": "^7.8.0",
         "@types/node": "^25.9.1",
         "@vitest/coverage-istanbul": "^3.0.0",
-        "jsdom": "^29.1.1",
+        "jsdom": "29.1.1",
         "tsup": "^8.5.0",
         "turbo": "^2.9.14",
         "typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@prisma/client": "^7.8.0",
     "@types/node": "^25.9.1",
     "@vitest/coverage-istanbul": "^3.0.0",
-    "jsdom": "^29.1.1",
+    "jsdom": "29.1.1",
     "tsup": "^8.5.0",
     "turbo": "^2.9.14",
     "typescript": "^5.7.0",


### PR DESCRIPTION
## Summary

Pin `jsdom` to an exact version (`29.1.1`) instead of the caret range `^29.1.1`.

`jsdom`'s CSS parser is version-sensitive. While triaging #157 I hit 4 failing tests in `packages/widget/__tests__/widget/screenshot.test.ts` (the `ignoreElements` predicate suite) on a local install that had drifted to `jsdom@29.0.1`. That version throws `SyntaxError: Error parsing CSS component value, unexpected EOF` when the widget's shadow-DOM stylesheet is parsed; `captureScreenshot`'s graceful-degrade `catch` swallows it and returns `null`, so `html2canvas` is never invoked and the predicate assertions fail. `29.1.1` parses it cleanly.

CI already pins the resolved version through `bun.lock` (`--frozen-lockfile`), so **`main` is not affected** — but the caret range allows the same silent drift on contributor machines and on any future lockfile regeneration. Pinning removes that foot-gun. This matches `@biomejs/biome`, which is already exact-pinned for the same reason (its version affects output). Dependabot continues to propose upgrades as reviewable PRs.

## Changes

- [x] `package.json`: `"jsdom": "^29.1.1"` → `"jsdom": "29.1.1"`
- [x] `bun.lock`: same specifier update (resolved `jsdom@29.1.1` entry + integrity hash unchanged)

## Test plan

- [x] `bun install --frozen-lockfile` passes locally (exit 0, "no changes") — the lockfile satisfies the CI install gate.
- Resolved `jsdom` version is unchanged (`29.1.1` before and after), so no runtime/test behavior changes; this only tightens the allowed range.

## Checklist

- [x] Tests pass — no behavior change; resolved version identical. CI runs the full suite with the pinned version.
- [x] Types pass (`bun run check`) — n/a, dev-dependency range only
- [x] No dead code or unused imports
- [x] Commit messages follow Conventional Commits (`type(scope): description`)

---

### ⚠️ Out of scope — pre-existing lockfile drift (not touched here)

While regenerating the lockfile I noticed `bun.lock` records `@siteping/widget@0.9.12` and `@siteping/cli@0.4.6`, but their `package.json` files on `main` are already at `0.9.13` / `0.4.7` (from release `#143`). `--frozen-lockfile` tolerates this workspace self-version drift (CI is green), so it's benign — but the release flow apparently bumps versions without regenerating `bun.lock`. **I deliberately left this untouched** to keep this PR to the jsdom pin only. Worth a separate look at whether the release job should run `bun install` after the version bump.
