### PR TITLE
feat: tech-lead review quick wins — a11y keyboard flow, store persistence contract, CSV formula guard (#99, #103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,12 @@ initSiteping({
   accentColor: '#0066ff',         // Widget accent color
   theme: 'light',                 // 'light' | 'dark' | 'auto'
   locale: 'en',                   // 'en' | 'fr' (default: 'en')
-  forceShow: false,               // Show in production? Default: false
+  forceShow: false,               // Always render — bypasses BOTH the
+                                  // production guard and the mobile-viewport
+                                  // guard. Default: false
+  minViewportWidth: 768,          // Minimum viewport width (px) to render;
+                                  // below it onSkip('mobile') fires. Set 0 to
+                                  // allow mobile viewports. Default: 768
   debug: false,                   // Enable debug logging
   showAnnotationsToggle: true,    // Show the "toggle markers visibility" item
                                   // in the FAB radial menu. Default: true. Set
@@ -589,8 +594,8 @@ bun run check
 
 The widget is **dev-only by default**. It auto-hides when `NODE_ENV=production` or `import.meta.env.MODE === 'production'`.
 
-- **Fix:** Pass `forceShow: true` in the config to show it in production.
-- The widget also hides on viewports narrower than **768px** (mobile). This is by design — annotation drawing requires a pointer device.
+- **Fix:** Pass `forceShow: true` in the config to show it in production. Note that `forceShow` also bypasses the mobile-viewport guard below.
+- The widget also hides on viewports narrower than **768px** (mobile). This is by design — annotation drawing works best with a pointer device. Tune the threshold with `minViewportWidth` (set `0` to allow mobile viewports), or bypass it entirely with `forceShow: true`.
 
 ### Prisma errors after setup
 

--- a/packages/adapter-localstorage/README.md
+++ b/packages/adapter-localstorage/README.md
@@ -51,7 +51,7 @@ Remove all data from localStorage for this store key.
 
 ## Edge Cases
 
-- **localStorage full** — writes are silently dropped (best-effort persistence)
+- **localStorage full** — `createFeedback` drops the screenshot (the heaviest field) and retries; if the write still fails — or a `updateFeedback` / `deleteFeedback` / `deleteAllFeedbacks` write fails — a `StorePersistenceError` is thrown so callers know the mutation was **not** persisted (detect it with `isStorePersistence`)
 - **Corrupted data** — returns empty array, does not throw
 - **Multiple stores** — use different `key` values for isolation
 

--- a/packages/adapter-localstorage/__tests__/localstorage-store.test.ts
+++ b/packages/adapter-localstorage/__tests__/localstorage-store.test.ts
@@ -40,6 +40,23 @@ describe("LocalStorageStore specific", () => {
     annotations: [],
   };
 
+  /**
+   * Run `fn` with `Storage.prototype.setItem` stubbed to throw a spec-shaped
+   * QuotaExceededError (the name goes in the SECOND constructor slot), and
+   * restore the original even when an assertion inside `fn` fails.
+   */
+  async function withQuotaExceeded<T>(fn: () => Promise<T>): Promise<T> {
+    const original = Storage.prototype.setItem;
+    Storage.prototype.setItem = () => {
+      throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    };
+    try {
+      return await fn();
+    } finally {
+      Storage.prototype.setItem = original;
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Persistence
   // -----------------------------------------------------------------------
@@ -120,41 +137,71 @@ describe("LocalStorageStore specific", () => {
       expect(feedbacks).toHaveLength(0);
     });
 
-    it("handles localStorage full on save (silent fail)", async () => {
+    it("createFeedback throws StorePersistenceError when the write fails and there is no screenshot to drop", async () => {
+      await withQuotaExceeded(async () => {
+        await expect(store.createFeedback(input)).rejects.toBeInstanceOf(StorePersistenceError);
+      });
+    });
+
+    it("createFeedback drops the screenshot and retries when the first write fails (quota)", async () => {
       const original = Storage.prototype.setItem;
-      Storage.prototype.setItem = () => {
-        throw new DOMException("QuotaExceededError");
+      let calls = 0;
+      Storage.prototype.setItem = function (this: Storage, key: string, value: string) {
+        calls += 1;
+        if (calls === 1) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+        original.call(this, key, value);
       };
-      await expect(store.createFeedback(input)).resolves.toBeDefined();
-      Storage.prototype.setItem = original;
+      try {
+        const record = await store.createFeedback({ ...input, screenshotDataUrl: "data:image/jpeg;base64,xxxx" });
+        expect(record.screenshotUrl).toBeNull();
+        const { feedbacks } = await store.getFeedbacks({ projectName: "test-project" });
+        expect(feedbacks).toHaveLength(1);
+      } finally {
+        Storage.prototype.setItem = original;
+      }
+    });
+
+    it("createFeedback throws StorePersistenceError when even the screenshot-less retry fails", async () => {
+      await withQuotaExceeded(async () => {
+        await expect(
+          store.createFeedback({ ...input, screenshotDataUrl: "data:image/jpeg;base64,xxxx" }),
+        ).rejects.toBeInstanceOf(StorePersistenceError);
+      });
     });
 
     it("updateFeedback throws StorePersistenceError when the write fails (quota)", async () => {
       const fb = await store.createFeedback(input);
-      const original = Storage.prototype.setItem;
-      Storage.prototype.setItem = () => {
-        throw new DOMException("QuotaExceededError");
-      };
-      try {
+      await withQuotaExceeded(async () => {
         await expect(
           store.updateFeedback(fb.id, { status: "resolved", resolvedAt: new Date() }),
         ).rejects.toBeInstanceOf(StorePersistenceError);
-      } finally {
-        Storage.prototype.setItem = original;
-      }
+      });
     });
 
     it("deleteFeedback throws StorePersistenceError when the write fails (quota)", async () => {
       const fb = await store.createFeedback(input);
-      const original = Storage.prototype.setItem;
-      Storage.prototype.setItem = () => {
-        throw new DOMException("QuotaExceededError");
-      };
-      try {
+      await withQuotaExceeded(async () => {
         await expect(store.deleteFeedback(fb.id)).rejects.toBeInstanceOf(StorePersistenceError);
-      } finally {
-        Storage.prototype.setItem = original;
-      }
+      });
+    });
+
+    it("deleteAllFeedbacks throws StorePersistenceError when the write fails (quota)", async () => {
+      await store.createFeedback(input);
+      await withQuotaExceeded(async () => {
+        await expect(store.deleteAllFeedbacks("test-project")).rejects.toBeInstanceOf(StorePersistenceError);
+      });
+    });
+
+    it("preserves the underlying exception as the StorePersistenceError cause", async () => {
+      const fb = await store.createFeedback(input);
+      const error = await withQuotaExceeded(() =>
+        store.deleteFeedback(fb.id).then(
+          () => null,
+          (e: unknown) => e,
+        ),
+      );
+      expect(error).toBeInstanceOf(StorePersistenceError);
+      expect((error as StorePersistenceError).cause).toBeInstanceOf(DOMException);
     });
 
     it("clear() removes all data for this store key", async () => {

--- a/packages/adapter-localstorage/__tests__/localstorage-store.test.ts
+++ b/packages/adapter-localstorage/__tests__/localstorage-store.test.ts
@@ -2,7 +2,7 @@
 
 import { testSitepingStore } from "@siteping/core/testing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { LocalStorageStore } from "../src/index.js";
+import { LocalStorageStore, StorePersistenceError } from "../src/index.js";
 
 // Run the full SitepingStore conformance suite
 testSitepingStore(() => {
@@ -127,6 +127,34 @@ describe("LocalStorageStore specific", () => {
       };
       await expect(store.createFeedback(input)).resolves.toBeDefined();
       Storage.prototype.setItem = original;
+    });
+
+    it("updateFeedback throws StorePersistenceError when the write fails (quota)", async () => {
+      const fb = await store.createFeedback(input);
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new DOMException("QuotaExceededError");
+      };
+      try {
+        await expect(
+          store.updateFeedback(fb.id, { status: "resolved", resolvedAt: new Date() }),
+        ).rejects.toBeInstanceOf(StorePersistenceError);
+      } finally {
+        Storage.prototype.setItem = original;
+      }
+    });
+
+    it("deleteFeedback throws StorePersistenceError when the write fails (quota)", async () => {
+      const fb = await store.createFeedback(input);
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = () => {
+        throw new DOMException("QuotaExceededError");
+      };
+      try {
+        await expect(store.deleteFeedback(fb.id)).rejects.toBeInstanceOf(StorePersistenceError);
+      } finally {
+        Storage.prototype.setItem = original;
+      }
     });
 
     it("clear() removes all data for this store key", async () => {

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@siteping/core";
 
 export type { SitepingStore } from "@siteping/core";
-export { StoreDuplicateError, StoreNotFoundError, StorePersistenceError } from "@siteping/core";
+export { isStorePersistence, StoreDuplicateError, StoreNotFoundError, StorePersistenceError } from "@siteping/core";
 
 const DEFAULT_KEY = "siteping_feedbacks";
 

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -8,10 +8,11 @@ import {
   type FeedbackUpdateInput,
   type SitepingStore,
   StoreNotFoundError,
+  StorePersistenceError,
 } from "@siteping/core";
 
 export type { SitepingStore } from "@siteping/core";
-export { StoreDuplicateError, StoreNotFoundError } from "@siteping/core";
+export { StoreDuplicateError, StoreNotFoundError, StorePersistenceError } from "@siteping/core";
 
 const DEFAULT_KEY = "siteping_feedbacks";
 
@@ -173,7 +174,10 @@ export class LocalStorageStore implements SitepingStore {
     fb.status = data.status;
     fb.resolvedAt = data.resolvedAt;
     fb.updatedAt = new Date();
-    this.save(feedbacks);
+    // save() returns false when localStorage is full. Surface it instead of
+    // returning a record that claims success — otherwise the mutation is
+    // silently lost (the in-memory `fb` is returned but never persisted).
+    if (!this.save(feedbacks)) throw new StorePersistenceError();
     return fb;
   }
 
@@ -183,7 +187,8 @@ export class LocalStorageStore implements SitepingStore {
     if (idx === -1) throw new StoreNotFoundError();
 
     feedbacks.splice(idx, 1);
-    this.save(feedbacks);
+    // Surface persistence failure rather than reporting a phantom delete.
+    if (!this.save(feedbacks)) throw new StorePersistenceError();
   }
 
   async deleteAllFeedbacks(projectName: string): Promise<void> {

--- a/packages/adapter-localstorage/src/index.ts
+++ b/packages/adapter-localstorage/src/index.ts
@@ -62,14 +62,17 @@ export class LocalStorageStore implements SitepingStore {
     }
   }
 
-  private save(feedbacks: FeedbackRecord[]): boolean {
+  /**
+   * Persist the full feedback array, or throw `StorePersistenceError` (with
+   * the underlying exception as `cause` — quota, storage disabled, …) when the
+   * write fails. Centralized here so no mutating method can accidentally
+   * report a phantom success on a lost write.
+   */
+  private persist(feedbacks: FeedbackRecord[]): void {
     try {
       localStorage.setItem(this.key, JSON.stringify(feedbacks));
-      return true;
-    } catch {
-      // localStorage full — caller decides how to recover (e.g. drop the
-      // newest screenshot and retry).
-      return false;
+    } catch (cause) {
+      throw new StorePersistenceError(undefined, { cause });
     }
   }
 
@@ -146,14 +149,17 @@ export class LocalStorageStore implements SitepingStore {
     };
 
     feedbacks.unshift(record);
-    if (!this.save(feedbacks) && record.screenshotUrl) {
+    try {
+      this.persist(feedbacks);
+    } catch (err) {
       // Quota exceeded — usually the inline screenshot pushed us past the
       // ~5 MB cap. Retry without the screenshot so the user's text feedback
       // is preserved (the screenshot is by far the heaviest field). If even
-      // that fails, fall through to legacy silent-fail behaviour: the
-      // record stays in memory for this call but isn't persisted.
+      // that fails, let the error propagate — returning the record would
+      // claim a success that was never persisted.
+      if (!record.screenshotUrl) throw err;
       record.screenshotUrl = null;
-      this.save(feedbacks);
+      this.persist(feedbacks);
     }
     return record;
   }
@@ -174,10 +180,7 @@ export class LocalStorageStore implements SitepingStore {
     fb.status = data.status;
     fb.resolvedAt = data.resolvedAt;
     fb.updatedAt = new Date();
-    // save() returns false when localStorage is full. Surface it instead of
-    // returning a record that claims success — otherwise the mutation is
-    // silently lost (the in-memory `fb` is returned but never persisted).
-    if (!this.save(feedbacks)) throw new StorePersistenceError();
+    this.persist(feedbacks);
     return fb;
   }
 
@@ -187,13 +190,12 @@ export class LocalStorageStore implements SitepingStore {
     if (idx === -1) throw new StoreNotFoundError();
 
     feedbacks.splice(idx, 1);
-    // Surface persistence failure rather than reporting a phantom delete.
-    if (!this.save(feedbacks)) throw new StorePersistenceError();
+    this.persist(feedbacks);
   }
 
   async deleteAllFeedbacks(projectName: string): Promise<void> {
     const feedbacks = this.load().filter((f) => f.projectName !== projectName);
-    this.save(feedbacks);
+    this.persist(feedbacks);
   }
 
   /** Remove all data from localStorage for this store key. */

--- a/packages/adapter-memory/src/index.ts
+++ b/packages/adapter-memory/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@siteping/core";
 
 export type { SitepingStore } from "@siteping/core";
-export { StoreDuplicateError, StoreNotFoundError } from "@siteping/core";
+export { isStorePersistence, StoreDuplicateError, StoreNotFoundError, StorePersistenceError } from "@siteping/core";
 
 /**
  * In-memory `SitepingStore` implementation.

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -1,6 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSitepingHandler } from "../src/index.js";
+import { createSitepingHandler, type SitepingPrismaClient } from "../src/index.js";
 import { validAnnotation, validPayloadNoAnnotations } from "./fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Type-level regression for #99
+// ---------------------------------------------------------------------------
+
+describe("PrismaModelDelegate structural compatibility (#99)", () => {
+  it("accepts a delegate whose methods take narrower arg types than `unknown`", () => {
+    // Mirrors a real Prisma-generated client: each method declares a SPECIFIC
+    // args type (narrower than `unknown`). With function-property syntax these
+    // would be checked contravariantly and FAIL to assign under
+    // strictFunctionTypes; method syntax is bivariant, so this compiles. If
+    // PrismaModelDelegate ever regresses to arrow-property syntax, `bun run
+    // check` fails here.
+    interface GeneratedDelegate {
+      create(args: { data: unknown; include?: unknown }): Promise<{ id: string }>;
+      findMany(args: { where?: unknown; include?: unknown }): Promise<{ id: string }[]>;
+      findUnique(args: { where: unknown }): Promise<{ id: string } | null>;
+      update(args: { where: unknown; data: unknown }): Promise<{ id: string }>;
+      delete(args: { where: unknown }): Promise<{ id: string }>;
+      deleteMany(args: { where?: unknown }): Promise<{ count: number }>;
+      count(args: { where?: unknown }): Promise<number>;
+    }
+    const delegate = {} as GeneratedDelegate;
+    const client: SitepingPrismaClient = { sitepingFeedback: delegate };
+    expect(client.sitepingFeedback).toBe(delegate);
+  });
+});
 
 function mockPrisma() {
   return {

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -1,33 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSitepingHandler, type SitepingPrismaClient } from "../src/index.js";
+import { createSitepingHandler } from "../src/index.js";
 import { validAnnotation, validPayloadNoAnnotations } from "./fixtures.js";
 
-// ---------------------------------------------------------------------------
-// Type-level regression for #99
-// ---------------------------------------------------------------------------
-
-describe("PrismaModelDelegate structural compatibility (#99)", () => {
-  it("accepts a delegate whose methods take narrower arg types than `unknown`", () => {
-    // Mirrors a real Prisma-generated client: each method declares a SPECIFIC
-    // args type (narrower than `unknown`). With function-property syntax these
-    // would be checked contravariantly and FAIL to assign under
-    // strictFunctionTypes; method syntax is bivariant, so this compiles. If
-    // PrismaModelDelegate ever regresses to arrow-property syntax, `bun run
-    // check` fails here.
-    interface GeneratedDelegate {
-      create(args: { data: unknown; include?: unknown }): Promise<{ id: string }>;
-      findMany(args: { where?: unknown; include?: unknown }): Promise<{ id: string }[]>;
-      findUnique(args: { where: unknown }): Promise<{ id: string } | null>;
-      update(args: { where: unknown; data: unknown }): Promise<{ id: string }>;
-      delete(args: { where: unknown }): Promise<{ id: string }>;
-      deleteMany(args: { where?: unknown }): Promise<{ count: number }>;
-      count(args: { where?: unknown }): Promise<number>;
-    }
-    const delegate = {} as GeneratedDelegate;
-    const client: SitepingPrismaClient = { sitepingFeedback: delegate };
-    expect(client.sitepingFeedback).toBe(delegate);
-  });
-});
+// NOTE: the type-level regression guard for #99 (delegate bivariance) lives in
+// src/index.ts next to PrismaModelDelegate — `tsc --noEmit` only sees src/, so
+// a test-file assertion can never fail the check task.
 
 function mockPrisma() {
   return {

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -76,6 +76,29 @@ export interface PrismaModelDelegate {
 }
 
 /**
+ * Compile-time regression guard for #99 — intentionally in `src/` because the
+ * package's `check` script (`tsc --noEmit`) only type-checks `src/`, and
+ * vitest transpiles tests without type-checking.
+ *
+ * `GeneratedDelegateProbe` mirrors a real generated client: every method
+ * declares args NARROWER than `unknown`. With method syntax the conditional
+ * below resolves to `true`; if `PrismaModelDelegate` ever regresses to
+ * function-property syntax (contravariant under `strictFunctionTypes`), it
+ * resolves to `false` and the `AssertTrue` constraint fails the build.
+ */
+type AssertTrue<T extends true> = T;
+interface GeneratedDelegateProbe {
+  create(args: { data: unknown; include?: unknown }): Promise<{ id: string }>;
+  findMany(args: { where?: unknown; include?: unknown }): Promise<{ id: string }[]>;
+  findUnique(args: { where: unknown }): Promise<{ id: string } | null>;
+  update(args: { where: unknown; data: unknown }): Promise<{ id: string }>;
+  delete(args: { where: unknown }): Promise<{ id: string }>;
+  deleteMany(args: { where?: unknown }): Promise<{ count: number }>;
+  count(args: { where?: unknown }): Promise<number>;
+}
+type _AssertDelegateBivariance = AssertTrue<GeneratedDelegateProbe extends PrismaModelDelegate ? true : false>;
+
+/**
  * Minimal Prisma client shape expected by this adapter.
  * Consumers pass their own `PrismaClient` instance at runtime — this interface
  * defines the subset of methods the adapter actually uses, so it can be

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -50,15 +50,23 @@ export { dispatchWebhook, dispatchWebhooks } from "./webhooks.js";
  * Arguments are kept `unknown` so any Prisma version's generated client
  * satisfies the constraint; the adapter assembles type-safe payloads
  * internally before forwarding them.
+ *
+ * Members use **method syntax** (`create(args)`) rather than function-property
+ * syntax (`create: (args) => ...`) on purpose: under `strictFunctionTypes`,
+ * function-property parameters are checked *contravariantly*, so a real
+ * generated delegate — whose `create(args: SpecificArgs)` takes a type narrower
+ * than `unknown` — would fail to assign to `PrismaModelDelegate`. Method
+ * signatures are checked *bivariantly* on parameters, which is exactly what we
+ * want for structurally matching a third-party generated client (#99).
  */
 export interface PrismaModelDelegate {
-  create: (args: unknown) => Promise<unknown>;
-  findMany: (args: unknown) => Promise<unknown[]>;
-  findUnique: (args: unknown) => Promise<unknown>;
-  update: (args: unknown) => Promise<unknown>;
-  delete: (args: unknown) => Promise<unknown>;
-  deleteMany: (args: unknown) => Promise<unknown>;
-  count: (args: unknown) => Promise<number>;
+  create(args: unknown): Promise<unknown>;
+  findMany(args: unknown): Promise<unknown[]>;
+  findUnique(args: unknown): Promise<unknown>;
+  update(args: unknown): Promise<unknown>;
+  delete(args: unknown): Promise<unknown>;
+  deleteMany(args: unknown): Promise<unknown>;
+  count(args: unknown): Promise<number>;
 }
 
 /**

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -24,7 +24,13 @@ import {
 import { dispatchWebhooks, type WebhookConfig } from "./webhooks.js";
 
 export type { ScreenshotStorage, SitepingStore } from "@siteping/core";
-export { flattenAnnotation, StoreDuplicateError, StoreNotFoundError } from "@siteping/core";
+export {
+  flattenAnnotation,
+  isStorePersistence,
+  StoreDuplicateError,
+  StoreNotFoundError,
+  StorePersistenceError,
+} from "@siteping/core";
 export type {
   FeedbackCreateInput as FeedbackCreateSchemaInput,
   FeedbackDeleteInput,

--- a/packages/core/__tests__/store-errors.test.ts
+++ b/packages/core/__tests__/store-errors.test.ts
@@ -4,8 +4,10 @@ import {
   flattenAnnotation,
   isStoreDuplicate,
   isStoreNotFound,
+  isStorePersistence,
   StoreDuplicateError,
   StoreNotFoundError,
+  StorePersistenceError,
 } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -143,6 +145,71 @@ describe("isStoreDuplicate", () => {
   it("returns false for null/undefined", () => {
     expect(isStoreDuplicate(null)).toBe(false);
     expect(isStoreDuplicate(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StorePersistenceError
+// ---------------------------------------------------------------------------
+
+describe("StorePersistenceError", () => {
+  it("has default message", () => {
+    const err = new StorePersistenceError();
+    expect(err.message).toBe("Failed to persist store mutation");
+  });
+
+  it("accepts a custom message", () => {
+    const err = new StorePersistenceError("quota exceeded");
+    expect(err.message).toBe("quota exceeded");
+  });
+
+  it("has code STORE_PERSISTENCE", () => {
+    const err = new StorePersistenceError();
+    expect(err.code).toBe("STORE_PERSISTENCE");
+  });
+
+  it("has name StorePersistenceError", () => {
+    const err = new StorePersistenceError();
+    expect(err.name).toBe("StorePersistenceError");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new StorePersistenceError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(StorePersistenceError);
+  });
+
+  it("preserves the underlying exception as cause", () => {
+    const cause = new Error("setItem failed");
+    const err = new StorePersistenceError(undefined, { cause });
+    expect(err.cause).toBe(cause);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isStorePersistence
+// ---------------------------------------------------------------------------
+
+describe("isStorePersistence", () => {
+  it("returns true for StorePersistenceError", () => {
+    expect(isStorePersistence(new StorePersistenceError())).toBe(true);
+  });
+
+  it("returns true for a code-only match (cross-bundle copies of core)", () => {
+    expect(isStorePersistence({ code: "STORE_PERSISTENCE" })).toBe(true);
+    expect(isStorePersistence(Object.assign(new Error("full"), { code: "STORE_PERSISTENCE" }))).toBe(true);
+  });
+
+  it("returns false for the sibling store errors", () => {
+    expect(isStorePersistence(new StoreNotFoundError())).toBe(false);
+    expect(isStorePersistence(new StoreDuplicateError())).toBe(false);
+  });
+
+  it("returns false for plain Error and primitives", () => {
+    expect(isStorePersistence(new Error("oops"))).toBe(false);
+    expect(isStorePersistence(null)).toBe(false);
+    expect(isStorePersistence(undefined)).toBe(false);
+    expect(isStorePersistence("STORE_PERSISTENCE")).toBe(false);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export {
   flattenAnnotation,
   isStoreDuplicate,
   isStoreNotFound,
+  isStorePersistence,
   StoreDuplicateError,
   StoreNotFoundError,
   StorePersistenceError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,4 +74,5 @@ export {
   isStoreNotFound,
   StoreDuplicateError,
   StoreNotFoundError,
+  StorePersistenceError,
 } from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -70,8 +70,21 @@ export interface SitepingConfig {
   showAnnotationsToggle?: boolean | undefined;
   /** Accent color for the widget UI — defaults to '#0066ff' */
   accentColor?: string;
-  /** Show the widget even in production — defaults to false */
+  /**
+   * Render the widget even when it would normally be skipped — this bypasses
+   * BOTH the production-environment guard AND the mobile-viewport guard.
+   * Defaults to false. Use it for dedicated review tools, staging environments,
+   * or responsive testing where you always want the widget present.
+   */
   forceShow?: boolean;
+  /**
+   * Minimum viewport width (px) at or above which the widget renders. Below it,
+   * the widget is skipped and `onSkip("mobile")` fires. Defaults to `768`.
+   *
+   * Set lower (e.g. `0`) to allow narrow/mobile viewports, or use `forceShow`
+   * to bypass the viewport check entirely.
+   */
+  minViewportWidth?: number | undefined;
   /** Enable debug logging of lifecycle events — defaults to false */
   debug?: boolean;
   /** Color theme — defaults to 'light' */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -517,6 +517,17 @@ export function isStoreDuplicate(error: unknown): error is StoreDuplicateError |
   return hasErrorCode(error, "P2002");
 }
 
+/**
+ * Type guard for `StorePersistenceError`. Matches on the stable `code` field
+ * in addition to `instanceof`: every consumer package bundles its own copy of
+ * core (tsup `noExternal`), so an instance thrown by one package fails an
+ * `instanceof` check against another package's class identity.
+ */
+export function isStorePersistence(error: unknown): error is StorePersistenceError | CodedError<"STORE_PERSISTENCE"> {
+  if (error instanceof StorePersistenceError) return true;
+  return hasErrorCode(error, "STORE_PERSISTENCE");
+}
+
 // ---------------------------------------------------------------------------
 // Store helpers — shared conversion logic for adapters
 // ---------------------------------------------------------------------------
@@ -570,20 +581,23 @@ export interface FeedbackPage {
  * - **`createFeedback`**: either return the existing record on duplicate
  *   `clientId` (idempotent) or throw `StoreDuplicateError`. The handler
  *   handles both patterns.
+ * - **All mutations**: when a write is accepted but cannot be persisted
+ *   (e.g. storage quota), throw `StorePersistenceError` instead of reporting
+ *   a phantom success. Detect it with `isStorePersistence`.
  * - Other methods should not throw on empty results — return empty arrays or `null`.
  */
 export interface SitepingStore {
-  /** Create a feedback with its annotations. Idempotent on `clientId` — return existing record on duplicate, or throw `StoreDuplicateError`. */
+  /** Create a feedback with its annotations. Idempotent on `clientId` — return existing record on duplicate, or throw `StoreDuplicateError`. Throws `StorePersistenceError` when the write cannot be persisted. */
   createFeedback(data: FeedbackCreateInput): Promise<FeedbackRecord>;
   /** Paginated query with optional filters. Returns empty array (not error) when no results. */
   getFeedbacks(query: FeedbackQuery): Promise<FeedbackPage>;
   /** Lookup by client-generated UUID. Returns `null` (not error) when not found. */
   findByClientId(clientId: string): Promise<FeedbackRecord | null>;
-  /** Update status/resolvedAt. Throws `StoreNotFoundError` if `id` does not exist. */
+  /** Update status/resolvedAt. Throws `StoreNotFoundError` if `id` does not exist, `StorePersistenceError` when the write cannot be persisted. */
   updateFeedback(id: string, data: FeedbackUpdateInput): Promise<FeedbackRecord>;
-  /** Delete a single record. Throws `StoreNotFoundError` if `id` does not exist. */
+  /** Delete a single record. Throws `StoreNotFoundError` if `id` does not exist, `StorePersistenceError` when the write cannot be persisted. */
   deleteFeedback(id: string): Promise<void>;
-  /** Bulk delete all feedbacks for a project. No-op (not error) if none exist. */
+  /** Bulk delete all feedbacks for a project. No-op (not error) if none exist. Throws `StorePersistenceError` when the write cannot be persisted. */
   deleteAllFeedbacks(projectName: string): Promise<void>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -482,6 +482,20 @@ export class StoreDuplicateError extends Error {
   }
 }
 
+/**
+ * Thrown when a store accepts a mutation but cannot persist it — e.g.
+ * `localStorage` is full (QuotaExceededError). Adapters MUST throw this rather
+ * than swallow the failure, so callers learn the write was lost instead of
+ * seeing a phantom success.
+ */
+export class StorePersistenceError extends Error {
+  readonly code = "STORE_PERSISTENCE" as const;
+  constructor(message = "Failed to persist store mutation") {
+    super(message);
+    this.name = "StorePersistenceError";
+  }
+}
+
 /** Shape of any ORM error that carries a Prisma-style `code` field. */
 type CodedError<C extends string = string> = { code: C };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -490,8 +490,8 @@ export class StoreDuplicateError extends Error {
  */
 export class StorePersistenceError extends Error {
   readonly code = "STORE_PERSISTENCE" as const;
-  constructor(message = "Failed to persist store mutation") {
-    super(message);
+  constructor(message = "Failed to persist store mutation", options?: ErrorOptions) {
+    super(message, options);
     this.name = "StorePersistenceError";
   }
 }

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -73,7 +73,8 @@ All configuration options for `initSiteping()`:
 | `accentColor` | `string` | `'#0066ff'` | Widget accent color — hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`) |
 | `theme` | `'light' \| 'dark' \| 'auto'` | `'light'` | Widget color theme |
 | `locale` | `'en' \| 'fr' \| 'de' \| 'es' \| 'it' \| 'pt' \| 'ru'` | `'en'` | Widget UI language. Unknown locales fall back to English |
-| `forceShow` | `boolean` | `false` | Show the widget in production (hidden by default) |
+| `forceShow` | `boolean` | `false` | Render the widget even when it would normally be skipped — bypasses **both** the production guard and the mobile-viewport guard |
+| `minViewportWidth` | `number` | `768` | Minimum viewport width (px) for the widget to render; below it `onSkip('mobile')` fires. Set `0` to allow mobile viewports |
 | `debug` | `boolean` | `false` | Enable debug logging to console |
 | `identity` | `{ name: string; email: string }` | — | Pre-fill author identity from the host (SSO). When set, the widget skips the identity modal |
 | `deepLink` | `boolean \| { param?: string }` | `false` | On initial load, focus the annotation referenced by `?siteping=<id>` (or a custom query key). SPA navigations are ignored — use `focusFeedback()` for route-change focus |

--- a/packages/widget/__tests__/helpers.ts
+++ b/packages/widget/__tests__/helpers.ts
@@ -35,6 +35,20 @@ export function createShadowRoot(): ShadowRoot {
 }
 
 /**
+ * Run `fn` with `window.innerWidth` stubbed to `width`, restoring the original
+ * value afterwards — even when an assertion inside `fn` throws.
+ */
+export function withViewportWidth<T>(width: number, fn: () => T): T {
+  const original = window.innerWidth;
+  Object.defineProperty(window, "innerWidth", { value: width, writable: true, configurable: true });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(window, "innerWidth", { value: original, writable: true, configurable: true });
+  }
+}
+
+/**
  * Stub window.matchMedia — jsdom does not implement it.
  * Duplicated in: launcher.test.ts, popup.test.ts
  */

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -99,16 +99,17 @@ function createAnnotator() {
 }
 
 /**
- * Find the annotator overlay — the div appended to body with aria-hidden="true"
- * and tabindex="0" (the overlay, not an SVG or other element).
+ * Find the annotator overlay — the focusable (tabindex="0") screenshot-ignored
+ * div appended to body (the toolbar carries data-siteping-ignore too, but no
+ * tabindex).
  */
 function findOverlay(): HTMLElement | null {
-  return document.body.querySelector<HTMLElement>('div[aria-hidden="true"][tabindex="0"]');
+  return document.body.querySelector<HTMLElement>('div[data-siteping-ignore][tabindex="0"]');
 }
 
 /** Count how many annotator overlays exist */
 function countOverlays(): number {
-  return document.body.querySelectorAll('div[aria-hidden="true"][tabindex="0"]').length;
+  return document.body.querySelectorAll('div[data-siteping-ignore][tabindex="0"]').length;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,7 +132,7 @@ describe("Annotator", () => {
     annotator.destroy();
     // Remove any leftover overlay/toolbar DOM from async handlers that may not
     // have completed before the test ended (e.g. finishDrawing's await)
-    for (const el of document.body.querySelectorAll('div[aria-hidden="true"]')) {
+    for (const el of document.body.querySelectorAll('div[data-siteping-ignore][tabindex="0"]')) {
       el.remove();
     }
     for (const btn of document.body.querySelectorAll("button")) {
@@ -146,12 +147,17 @@ describe("Annotator", () => {
   // -------------------------------------------------------------------------
 
   describe("activate", () => {
-    it("creates an overlay on annotation:start", () => {
+    it("creates an overlay exposed to assistive tech on annotation:start", () => {
       bus.emit("annotation:start");
 
       const overlay = findOverlay();
       expect(overlay).not.toBeNull();
-      expect(overlay!.getAttribute("aria-hidden")).toBe("true");
+      // The overlay receives focus, so it must NOT be aria-hidden — a focused
+      // aria-hidden element is invisible to screen readers (axe
+      // "aria-hidden-focus"). It carries a role and an accessible name instead.
+      expect(overlay!.hasAttribute("aria-hidden")).toBe(false);
+      expect(overlay!.getAttribute("role")).toBe("application");
+      expect(overlay!.getAttribute("aria-label")).toBe(t("annotator.instruction"));
     });
 
     it("focuses the overlay so the keyboard (Enter) annotation path receives keydown", () => {
@@ -163,6 +169,26 @@ describe("Annotator", () => {
       // this fix, activeElement stayed on <body> and the Enter path was dead
       // (WCAG 2.1.1 Level A). The overlay carries tabindex=0.
       expect(document.activeElement).toBe(overlay);
+    });
+
+    it("restores focus to the pre-activation element on deactivate (WCAG 2.4.3)", () => {
+      const target = document.createElement("button");
+      document.body.appendChild(target);
+      target.focus();
+
+      try {
+        bus.emit("annotation:start");
+        expect(document.activeElement).toBe(findOverlay());
+
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+        // Removing the focused overlay would strand focus on <body> without
+        // the explicit restore in deactivate().
+        expect(findOverlay()).toBeNull();
+        expect(document.activeElement).toBe(target);
+      } finally {
+        target.remove();
+      }
     });
 
     it("creates a toolbar element (button with cancel text) on activation", () => {

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -154,6 +154,17 @@ describe("Annotator", () => {
       expect(overlay!.getAttribute("aria-hidden")).toBe("true");
     });
 
+    it("focuses the overlay so the keyboard (Enter) annotation path receives keydown", () => {
+      bus.emit("annotation:start");
+
+      const overlay = findOverlay();
+      expect(overlay).not.toBeNull();
+      // onOverlayKeyDown only fires when the overlay itself is focused. Before
+      // this fix, activeElement stayed on <body> and the Enter path was dead
+      // (WCAG 2.1.1 Level A). The overlay carries tabindex=0.
+      expect(document.activeElement).toBe(overlay);
+    });
+
     it("creates a toolbar element (button with cancel text) on activation", () => {
       bus.emit("annotation:start");
 

--- a/packages/widget/__tests__/widget/export-utils.test.ts
+++ b/packages/widget/__tests__/widget/export-utils.test.ts
@@ -67,6 +67,28 @@ describe("feedback export conversion", () => {
     expect(feedbacksToCsv([])).toBe("id,type,status,message,url,authorName,authorEmail,createdAt,resolvedAt,viewport");
   });
 
+  it("neutralizes spreadsheet formula injection in user-controlled fields", () => {
+    const csv = feedbacksToCsv([
+      makeFeedback({
+        id: "fb-inj",
+        message: '=HYPERLINK("http://evil","click")',
+        url: "@SUM(A1:A9)",
+        authorName: "+1-555-0100",
+        authorEmail: "-2+3",
+      }),
+    ]);
+    const dataRow = csv.split("\n")[1]!;
+    // Each field starting with = + - @ is prefixed with a single quote so the
+    // spreadsheet treats it as text instead of evaluating it as a formula.
+    expect(dataRow).toContain("'=HYPERLINK");
+    expect(dataRow).toContain("'@SUM(A1:A9)");
+    expect(dataRow).toContain("'+1-555-0100");
+    expect(dataRow).toContain("'-2+3");
+    // Benign values (not starting with a formula trigger) are untouched.
+    expect(dataRow).toContain("fb-inj");
+    expect(dataRow).not.toContain("'fb-inj");
+  });
+
   it("serializes formatted JSON without dropping nested annotation data", () => {
     const json = feedbacksToJson([
       makeFeedback({

--- a/packages/widget/__tests__/widget/fab.test.ts
+++ b/packages/widget/__tests__/widget/fab.test.ts
@@ -370,6 +370,39 @@ describe("Fab", () => {
       expect(listener).toHaveBeenCalledOnce();
     });
 
+    it("re-focuses the FAB when an annotation session it launched ends", () => {
+      const fabBtn = shadow.querySelector<HTMLButtonElement>(".sp-fab")!;
+      fabBtn.click();
+      shadow.querySelector<HTMLButtonElement>('[data-item-id="annotate"]')!.click();
+
+      // Simulate the annotator stealing focus to its body-level overlay, then
+      // ending the session (Escape / cancel / submit).
+      const decoy = document.createElement("div");
+      decoy.setAttribute("tabindex", "0");
+      document.body.appendChild(decoy);
+      decoy.focus();
+      try {
+        bus.emit("annotation:end");
+        expect(shadow.activeElement).toBe(fabBtn);
+      } finally {
+        decoy.remove();
+      }
+    });
+
+    it("does not re-focus the FAB for annotation sessions it did not launch", () => {
+      const decoy = document.createElement("div");
+      decoy.setAttribute("tabindex", "0");
+      document.body.appendChild(decoy);
+      decoy.focus();
+      try {
+        bus.emit("annotation:end");
+        expect(shadow.activeElement).toBeNull();
+        expect(document.activeElement).toBe(decoy);
+      } finally {
+        decoy.remove();
+      }
+    });
+
     it("clicking 'toggle-annotations' emits annotations:toggle", () => {
       const listener = vi.fn();
       bus.on("annotations:toggle", listener);

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -2,6 +2,7 @@
 
 import type { SitepingConfig } from "@siteping/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withViewportWidth } from "../helpers.js";
 
 // jsdom does not implement window.matchMedia — provide a stub
 Object.defineProperty(window, "matchMedia", {
@@ -183,101 +184,80 @@ describe("launch", () => {
 
   describe("mobile guard", () => {
     // defaultConfig() sets forceShow:true, which now (intentionally, #103)
-    // bypasses the mobile guard too — so the skip tests opt out of it.
+    // bypasses the mobile guard too — so every test that exercises the
+    // threshold opts out of it. destroy() runs in finally so a failing
+    // assertion can't leak the launcher's module-level singleton.
     it("returns a no-op instance when viewport is narrow (< 768px)", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
-
-      try {
+      withViewportWidth(600, () => {
         const instance = launch(defaultConfig({ forceShow: false }));
-
-        const widget = document.querySelector("siteping-widget");
-        expect(widget).toBeNull();
-
-        // Shouldn't throw
-        instance.destroy();
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+        try {
+          expect(document.querySelector("siteping-widget")).toBeNull();
+        } finally {
+          instance.destroy();
+        }
+      });
     });
 
     it("calls onSkip with 'mobile' reason on narrow viewport", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 500, writable: true, configurable: true });
-
-      try {
+      withViewportWidth(500, () => {
         const onSkip = vi.fn();
-        launch(defaultConfig({ forceShow: false, onSkip }));
-
-        expect(onSkip).toHaveBeenCalledWith("mobile");
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+        const instance = launch(defaultConfig({ forceShow: false, onSkip }));
+        try {
+          expect(onSkip).toHaveBeenCalledWith("mobile");
+        } finally {
+          instance.destroy();
+        }
+      });
     });
 
     it("initializes normally when viewport is >= 768px", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 1024, writable: true, configurable: true });
-
-      try {
-        const instance = launch(defaultConfig());
-
-        const widget = document.querySelector("siteping-widget");
-        expect(widget).not.toBeNull();
-
-        instance.destroy();
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+      withViewportWidth(1024, () => {
+        // forceShow:false so this actually exercises the default threshold —
+        // with the bypass active the test would pass at any width.
+        const instance = launch(defaultConfig({ forceShow: false }));
+        try {
+          expect(document.querySelector("siteping-widget")).not.toBeNull();
+        } finally {
+          instance.destroy();
+        }
+      });
     });
 
     it("forceShow bypasses the mobile guard (#103)", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
-
-      try {
+      withViewportWidth(600, () => {
         const onSkip = vi.fn();
         const instance = launch(defaultConfig({ forceShow: true, onSkip }));
-
-        expect(document.querySelector("siteping-widget")).not.toBeNull();
-        expect(onSkip).not.toHaveBeenCalled();
-
-        instance.destroy();
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+        try {
+          expect(document.querySelector("siteping-widget")).not.toBeNull();
+          expect(onSkip).not.toHaveBeenCalled();
+        } finally {
+          instance.destroy();
+        }
+      });
     });
 
     it("minViewportWidth lowers the threshold so a narrow viewport renders (#103)", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
-
-      try {
+      withViewportWidth(600, () => {
         const instance = launch(defaultConfig({ forceShow: false, minViewportWidth: 0 }));
-
-        expect(document.querySelector("siteping-widget")).not.toBeNull();
-
-        instance.destroy();
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+        try {
+          expect(document.querySelector("siteping-widget")).not.toBeNull();
+        } finally {
+          instance.destroy();
+        }
+      });
     });
 
     it("minViewportWidth can raise the threshold (skips a mid-width viewport)", () => {
-      const origWidth = window.innerWidth;
-      Object.defineProperty(window, "innerWidth", { value: 1000, writable: true, configurable: true });
-
-      try {
+      withViewportWidth(1000, () => {
         const onSkip = vi.fn();
         const instance = launch(defaultConfig({ forceShow: false, minViewportWidth: 1200, onSkip }));
-
-        expect(document.querySelector("siteping-widget")).toBeNull();
-        expect(onSkip).toHaveBeenCalledWith("mobile");
-
-        instance.destroy();
-      } finally {
-        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
-      }
+        try {
+          expect(document.querySelector("siteping-widget")).toBeNull();
+          expect(onSkip).toHaveBeenCalledWith("mobile");
+        } finally {
+          instance.destroy();
+        }
+      });
     });
   });
 

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -182,12 +182,14 @@ describe("launch", () => {
   // -------------------------------------------------------------------------
 
   describe("mobile guard", () => {
+    // defaultConfig() sets forceShow:true, which now (intentionally, #103)
+    // bypasses the mobile guard too — so the skip tests opt out of it.
     it("returns a no-op instance when viewport is narrow (< 768px)", () => {
       const origWidth = window.innerWidth;
       Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
 
       try {
-        const instance = launch(defaultConfig());
+        const instance = launch(defaultConfig({ forceShow: false }));
 
         const widget = document.querySelector("siteping-widget");
         expect(widget).toBeNull();
@@ -205,7 +207,7 @@ describe("launch", () => {
 
       try {
         const onSkip = vi.fn();
-        launch(defaultConfig({ onSkip }));
+        launch(defaultConfig({ forceShow: false, onSkip }));
 
         expect(onSkip).toHaveBeenCalledWith("mobile");
       } finally {
@@ -222,6 +224,55 @@ describe("launch", () => {
 
         const widget = document.querySelector("siteping-widget");
         expect(widget).not.toBeNull();
+
+        instance.destroy();
+      } finally {
+        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
+      }
+    });
+
+    it("forceShow bypasses the mobile guard (#103)", () => {
+      const origWidth = window.innerWidth;
+      Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
+
+      try {
+        const onSkip = vi.fn();
+        const instance = launch(defaultConfig({ forceShow: true, onSkip }));
+
+        expect(document.querySelector("siteping-widget")).not.toBeNull();
+        expect(onSkip).not.toHaveBeenCalled();
+
+        instance.destroy();
+      } finally {
+        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
+      }
+    });
+
+    it("minViewportWidth lowers the threshold so a narrow viewport renders (#103)", () => {
+      const origWidth = window.innerWidth;
+      Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
+
+      try {
+        const instance = launch(defaultConfig({ forceShow: false, minViewportWidth: 0 }));
+
+        expect(document.querySelector("siteping-widget")).not.toBeNull();
+
+        instance.destroy();
+      } finally {
+        Object.defineProperty(window, "innerWidth", { value: origWidth, writable: true, configurable: true });
+      }
+    });
+
+    it("minViewportWidth can raise the threshold (skips a mid-width viewport)", () => {
+      const origWidth = window.innerWidth;
+      Object.defineProperty(window, "innerWidth", { value: 1000, writable: true, configurable: true });
+
+      try {
+        const onSkip = vi.fn();
+        const instance = launch(defaultConfig({ forceShow: false, minViewportWidth: 1200, onSkip }));
+
+        expect(document.querySelector("siteping-widget")).toBeNull();
+        expect(onSkip).toHaveBeenCalledWith("mobile");
 
         instance.destroy();
       } finally {

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -259,6 +259,22 @@ describe("launch", () => {
         }
       });
     });
+
+    it("falls back to the 768px default when minViewportWidth is not a finite number", () => {
+      withViewportWidth(600, () => {
+        // NaN (e.g. Number('768px') from an untyped script-tag consumer) is not
+        // nullish, and `innerWidth < NaN` is always false — without validation
+        // it would silently disable the guard.
+        const onSkip = vi.fn();
+        const instance = launch(defaultConfig({ forceShow: false, minViewportWidth: Number.NaN, onSkip }));
+        try {
+          expect(document.querySelector("siteping-widget")).toBeNull();
+          expect(onSkip).toHaveBeenCalledWith("mobile");
+        } finally {
+          instance.destroy();
+        }
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/widget/__tests__/widget/panel.test.ts
+++ b/packages/widget/__tests__/widget/panel.test.ts
@@ -1202,6 +1202,43 @@ describe("Panel", () => {
       });
     });
 
+    it("detail onResolve emits feedback:error and keeps the detail view open on failure", async () => {
+      const fb = makeFeedback({ id: "fb-1", status: "open", annotations: [annotation] });
+      apiClient.getFeedbacks.mockResolvedValue({ feedbacks: [fb], total: 1 });
+      apiClient.resolveFeedback.mockRejectedValue(new Error("persist failed"));
+
+      const errorListener = vi.fn();
+      bus.on("feedback:error", errorListener);
+
+      await panel.open();
+      shadow.querySelector<HTMLElement>('[data-feedback-id="fb-1"]')!.click();
+      shadow.querySelector<HTMLButtonElement>(".sp-detail-btn-resolve")!.click();
+
+      await vi.waitFor(() => {
+        expect(errorListener).toHaveBeenCalledWith(expect.any(Error));
+      });
+      // The list path notified the host; the detail view stays open for retry.
+      const detail = shadow.querySelector<HTMLElement>(".sp-detail")!;
+      expect(detail.classList.contains("sp-detail--visible")).toBe(true);
+    });
+
+    it("detail onDelete emits feedback:error on failure", async () => {
+      const fb = makeFeedback({ id: "fb-1", annotations: [annotation] });
+      apiClient.getFeedbacks.mockResolvedValue({ feedbacks: [fb], total: 1 });
+      apiClient.deleteFeedback.mockRejectedValue(new Error("persist failed"));
+
+      const errorListener = vi.fn();
+      bus.on("feedback:error", errorListener);
+
+      await panel.open();
+      shadow.querySelector<HTMLElement>('[data-feedback-id="fb-1"]')!.click();
+      shadow.querySelector<HTMLButtonElement>(".sp-detail-btn-delete")!.click();
+
+      await vi.waitFor(() => {
+        expect(errorListener).toHaveBeenCalledWith(expect.any(Error));
+      });
+    });
+
     it("detail onGoToAnnotation scrolls and pins the highlight", async () => {
       const fb = makeFeedback({ id: "fb-1", annotations: [annotation] });
       apiClient.getFeedbacks.mockResolvedValue({ feedbacks: [fb], total: 1 });

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -115,7 +115,13 @@ export class Annotator {
         cursor:crosshair;
       `,
     });
-    this.overlay.setAttribute("aria-hidden", "true");
+    // The overlay is an interactive surface (draw with the pointer, Enter to
+    // annotate the previously focused element, Escape to cancel) and receives
+    // programmatic focus below — so it must be exposed to assistive tech, NOT
+    // aria-hidden: focusing an aria-hidden element parks screen-reader users
+    // on a node that announces nothing (axe "aria-hidden-focus", serious).
+    this.overlay.setAttribute("role", "application");
+    this.overlay.setAttribute("aria-label", this.t("annotator.instruction"));
     this.overlay.setAttribute("data-siteping-ignore", "true");
 
     // Toolbar — glassmorphism bar
@@ -209,8 +215,8 @@ export class Annotator {
     // annotate the element that was focused before activation) actually
     // receives keydown — onOverlayKeyDown only fires when the overlay itself
     // is focused. The overlay has tabindex=0, and preActiveFocusElement was
-    // captured above (line ~97) before the overlay existed, so focusing here
-    // doesn't clobber the keyboard target. (WCAG 2.1.1 Level A)
+    // captured at the top of activate(), before the overlay existed, so
+    // focusing here doesn't clobber the keyboard target. (WCAG 2.1.1 Level A)
     this.overlay.focus({ preventScroll: true });
   }
 
@@ -218,6 +224,7 @@ export class Annotator {
     if (!this.isActive) return;
     this.isActive = false;
     this.isDrawing = false;
+    const previouslyFocused = this.preActiveFocusElement;
     this.preActiveFocusElement = null;
 
     // Cancel any pending rAF to prevent stale callbacks
@@ -236,6 +243,14 @@ export class Annotator {
     this.overlay = null;
     this.toolbar = null;
     this.drawingRect = null;
+
+    // Removing the focused overlay drops focus to <body> — hand it back to the
+    // element that had it before activation (WCAG 2.4.3 focus order). When
+    // activation came from the FAB menu this element is the shadow host and
+    // focus() is a no-op; the Fab restores itself on annotation:end instead.
+    if (previouslyFocused instanceof HTMLElement && previouslyFocused.isConnected) {
+      previouslyFocused.focus({ preventScroll: true });
+    }
 
     this.bus.emit("annotation:end");
   }

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -204,6 +204,14 @@ export class Annotator {
 
     document.body.appendChild(this.overlay);
     document.body.appendChild(this.toolbar);
+
+    // Move focus to the overlay so the keyboard-annotation path (Enter →
+    // annotate the element that was focused before activation) actually
+    // receives keydown — onOverlayKeyDown only fires when the overlay itself
+    // is focused. The overlay has tabindex=0, and preActiveFocusElement was
+    // captured above (line ~97) before the overlay existed, so focusing here
+    // doesn't clobber the keyboard target. (WCAG 2.1.1 Level A)
+    this.overlay.focus({ preventScroll: true });
   }
 
   private deactivate(): void {

--- a/packages/widget/src/export-utils.ts
+++ b/packages/widget/src/export-utils.ts
@@ -154,12 +154,25 @@ const CSV_COLUMNS = [
   "viewport",
 ] as const;
 
-/** Escape a value for CSV: wrap in double-quotes if it contains commas, newlines, or quotes. */
+/**
+ * Escape a value for CSV. Two concerns, applied in order:
+ *
+ * 1. **Formula injection** — spreadsheet apps (Excel, Google Sheets,
+ *    LibreOffice) treat a cell starting with `=`, `+`, `-`, `@`, or a leading
+ *    TAB/CR as a formula. Columns like `message`, `authorName`, and `url` are
+ *    arbitrary end-user input, so a payload such as `=HYPERLINK("http://evil",
+ *    A1)` or `=cmd|'/c calc'!A1` would execute when a reviewer opens the export.
+ *    We neutralize it by prefixing a single quote (the OWASP-recommended guard),
+ *    which forces the cell to be treated as text.
+ * 2. **RFC-4180 quoting** — wrap in double-quotes (doubling inner quotes) if the
+ *    guarded value contains commas, quotes, or newlines.
+ */
 function escapeCsvField(value: string): string {
-  if (value.includes('"') || value.includes(",") || value.includes("\n") || value.includes("\r")) {
-    return `"${value.replace(/"/g, '""')}"`;
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  if (guarded.includes('"') || guarded.includes(",") || guarded.includes("\n") || guarded.includes("\r")) {
+    return `"${guarded.replace(/"/g, '""')}"`;
   }
-  return value;
+  return guarded;
 }
 
 /** Convert feedbacks to CSV string */

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -272,9 +272,17 @@ export class Fab {
       case "chat":
         this.bus.emit("panel:toggle", true);
         break;
-      case "annotate":
+      case "annotate": {
+        // close() above re-focused the FAB, so the annotator can only capture
+        // the shadow host as its pre-activation element — restoring focus is
+        // on us: put keyboard users back on the FAB when the session ends.
+        const unsubscribe = this.bus.on("annotation:end", () => {
+          unsubscribe();
+          this.fab.focus();
+        });
         this.bus.emit("annotation:start");
         break;
+      }
       case "toggle-annotations": {
         this.annotationsVisible = !this.annotationsVisible;
         this.bus.emit("annotations:toggle", this.annotationsVisible);

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -127,10 +127,15 @@ export function launch(config: SitepingConfig): SitepingInstance {
     }
   }
 
-  // Guard: desktop only (< MOBILE_BREAKPOINT = hidden)
-  if (window.innerWidth < MOBILE_BREAKPOINT) {
+  // Guard: desktop only (viewport below the threshold = hidden). forceShow
+  // bypasses this just like the production guard above; minViewportWidth lets
+  // hosts tune (or disable, with 0) the threshold. See issue #103.
+  const minViewportWidth = config.minViewportWidth ?? MOBILE_BREAKPOINT;
+  if (!config.forceShow && window.innerWidth < minViewportWidth) {
     const reason = "mobile";
-    console.info(`[siteping] Widget not loaded: viewport width < ${MOBILE_BREAKPOINT}px (mobile not supported).`);
+    console.info(
+      `[siteping] Widget not loaded: viewport width < ${minViewportWidth}px (mobile not supported). Use forceShow: true or lower minViewportWidth to override.`,
+    );
     config.onSkip?.(reason);
     return skippedInstance();
   }

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -129,8 +129,13 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   // Guard: desktop only (viewport below the threshold = hidden). forceShow
   // bypasses this just like the production guard above; minViewportWidth lets
-  // hosts tune (or disable, with 0) the threshold. See issue #103.
-  const minViewportWidth = config.minViewportWidth ?? MOBILE_BREAKPOINT;
+  // hosts tune (or disable, with 0) the threshold. Non-finite values (NaN from
+  // an untyped script-tag consumer, Infinity) would silently break the `<`
+  // comparison — fail back to the default instead. See issue #103.
+  const minViewportWidth =
+    typeof config.minViewportWidth === "number" && Number.isFinite(config.minViewportWidth)
+      ? config.minViewportWidth
+      : MOBILE_BREAKPOINT;
   if (!config.forceShow && window.innerWidth < minViewportWidth) {
     const reason = "mobile";
     console.info(

--- a/packages/widget/src/panel.ts
+++ b/packages/widget/src/panel.ts
@@ -189,16 +189,29 @@ export class Panel {
       {
         onBack: () => this.detail.hide(),
         onResolve: async (fb) => {
-          const newResolved = fb.status !== "resolved";
-          await this.client.resolveFeedback(fb.id, newResolved);
-          await this.loadFeedbacks();
-          this.detail.hide();
+          try {
+            const newResolved = fb.status !== "resolved";
+            await this.client.resolveFeedback(fb.id, newResolved);
+            await this.loadFeedbacks();
+            this.detail.hide();
+          } catch (error) {
+            // Surface the failure to the host (config.onError) like the list
+            // and bulk paths do, then rethrow so DetailView restores its
+            // buttons and stays open.
+            this.bus.emit("feedback:error", error instanceof Error ? error : new Error(String(error)));
+            throw error;
+          }
         },
         onDelete: async (fb) => {
-          await this.client.deleteFeedback(fb.id);
-          this.bus.emit("feedback:deleted", fb.id);
-          await this.loadFeedbacks();
-          this.detail.hide();
+          try {
+            await this.client.deleteFeedback(fb.id);
+            this.bus.emit("feedback:deleted", fb.id);
+            await this.loadFeedbacks();
+            this.detail.hide();
+          } catch (error) {
+            this.bus.emit("feedback:error", error instanceof Error ? error : new Error(String(error)));
+            throw error;
+          }
         },
         onGoToAnnotation: (fb) => {
           if (fb.annotations.length > 0) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,13 @@ export default defineConfig({
   test: {
     include: ["packages/**/__tests__/**/*.test.{ts,tsx}"],
     setupFiles: ["packages/widget/__tests__/setup-i18n.ts"],
+    // Cap forks so a local run leaves CPU headroom for the editor — on WSL2
+    // vscode-server shares the VM and a full-core run freezes it. Don't go
+    // lower: jsdom DOMs are retained in the heap, and a fork reused across
+    // more files balloons to ~15 GB at maxForks=2. No-op in CI (≤4 cores).
+    poolOptions: {
+      forks: { maxForks: 4 },
+    },
     coverage: {
       provider: "istanbul",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
## What this branch delivers

The six original quick-win commits from the tech-lead review:

- **widget** — the annotation overlay now receives focus so the keyboard (Enter) path gets keydown (WCAG 2.1.1); CSV export neutralizes spreadsheet formula injection (OWASP single-quote guard); `forceShow` bypasses the mobile guard and the new `minViewportWidth` tunes it (closes #103)
- **adapter-localstorage** — `updateFeedback`/`deleteFeedback` throw `StorePersistenceError` instead of reporting phantom success
- **adapter-prisma** — `PrismaModelDelegate` uses method syntax so real generated delegates (narrower-than-`unknown` args) stay assignable (closes #99)
- **tooling** — vitest capped at 4 forks locally

## Adversarial review pass (8 follow-up commits)

Before opening this PR the diff went through a multi-agent review (9 finder angles → 1-vote verification per candidate → gap sweep). Confirmed findings, all fixed here:

| Finding | Fix |
|---|---|
| `createFeedback` / `deleteAllFeedbacks` still swallowed failed writes — violating the very contract this branch introduces | single throwing `persist()` chokepoint, screenshot-drop retry preserved, error `cause` kept |
| The #99 "type-level regression test" could never fail (tsconfig only includes `src/`; vitest doesn't type-check; tautological expect) | zero-runtime probe next to the interface — empirically verified: property syntax ⇒ TS2344 |
| New `focus()` landed on an `aria-hidden="true"` overlay (axe `aria-hidden-focus`, serious) | overlay exposed with `role="application"` + existing i18n label |
| `deactivate()` removed the focused overlay without restoring focus (WCAG 2.4.3 regression on Escape/cancel/submit) | focus handed back to the pre-activation element; FAB re-focuses itself for sessions it launched |
| Detail-view resolve/delete failures dead-ended in a bare catch while the list path emits `feedback:error` | detail handlers emit + rethrow |
| `minViewportWidth: NaN` silently disabled the mobile guard (`innerWidth < NaN` is always false) | finite-number validation with fallback to 768 |
| `StorePersistenceError` had no cross-bundle-safe guard, stale interface docs, and wasn't importable from the server adapters | `isStorePersistence` (code-field match), error-contract docblocks, re-exports from all adapters |
| Tests: spec-invalid `new DOMException("QuotaExceededError")` (name in the message slot), stub restore without `finally`, 6× copy-pasted viewport scaffold, wide-viewport test passing via the `forceShow` bypass | `withQuotaExceeded` / `withViewportWidth` helpers, `destroy()` in `finally`, threshold actually exercised |
| READMEs still described `forceShow` as production-only and never mentioned `minViewportWidth`; adapter README claimed writes are "silently dropped" | docs updated |

Verified-but-deferred findings are filed as #162 (FAB keyboard capture + affordance), #163 (popup re-entry wipes drafts), #164 (read-path durability + conformance-suite coverage).

## Notes for reviewers

- **CSV apostrophe prefix mutates data starting with `= + - @` (e.g. `+33…` phone numbers).** Intentional OWASP tradeoff, asserted by tests; the JSON export remains the lossless programmatic path. No opt-out on purpose.
- **`forceShow` semantics change ships as a patch** (pre-major `bump-patch-for-minor-pre-major`): existing `forceShow: true` integrations will start rendering on mobile. Intentional per #103; now documented in both READMEs.
- Local env note: the demo Next build and the size-limit plugin fail to resolve under the local bun canary; both are environment-only — measured gzip sizes directly: ESM 25.8 KB / 54 KB limit, IIFE 104.3 KB / 110 KB limit.

## Verification

- `turbo build` (packages) ✓ — `bun run check` 10/10 ✓ — `bun run lint` ✓
- Full suite under real Node: **1485/1485** ✓
- #99 guard empirically validated (revert ⇒ `tsc` fails, restore ⇒ passes)