### PR TITLE
fix(cli): avoid leading newline in prisma sync

### DIFF
--- a/packages/cli/__tests__/generators/prisma.test.ts
+++ b/packages/cli/__tests__/generators/prisma.test.ts
@@ -139,6 +139,16 @@ describe("syncPrismaModels", () => {
     expect(output).toContain("generator client");
   });
 
+  it("does not prepend a blank line to the schema", () => {
+    writeFileSync(schemaPath, MINIMAL_SCHEMA);
+
+    syncPrismaModels(schemaPath);
+
+    const output = readFileSync(schemaPath, "utf-8");
+    expect(output.startsWith("\n")).toBe(false);
+    expect(output[0]).toBe("d");
+  });
+
   // -----------------------------------------------------------------------
   // Adding models alongside existing models
   // -----------------------------------------------------------------------

--- a/packages/cli/__tests__/generators/prisma.test.ts
+++ b/packages/cli/__tests__/generators/prisma.test.ts
@@ -145,8 +145,7 @@ describe("syncPrismaModels", () => {
     syncPrismaModels(schemaPath);
 
     const output = readFileSync(schemaPath, "utf-8");
-    expect(output.startsWith("\n")).toBe(false);
-    expect(output[0]).toBe("d");
+    expect(output).toMatch(/^datasource db/);
   });
 
   // -----------------------------------------------------------------------

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -131,7 +131,9 @@ export function syncPrismaModels(schemaPath: string = DEFAULT_SCHEMA_PATH): Sync
   }
 
   if (addedModels.length > 0 || changes.length > 0) {
-    const output = printSchema(schema).replace(/^\n+/, "");
+    // prisma-ast's printSchema() unconditionally prepends a newline, and prints
+    // blank lines as os.EOL ("\r\n" on Windows) -- strip both forms (#98)
+    const output = printSchema(schema).replace(/^(\r?\n)+/, "");
     try {
       writeFileSync(schemaPath, output, "utf-8");
     } catch (error) {

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -131,7 +131,7 @@ export function syncPrismaModels(schemaPath: string = DEFAULT_SCHEMA_PATH): Sync
   }
 
   if (addedModels.length > 0 || changes.length > 0) {
-    const output = printSchema(schema);
+    const output = printSchema(schema).replace(/^\n+/, "");
     try {
       writeFileSync(schemaPath, output, "utf-8");
     } catch (error) {


### PR DESCRIPTION
## Summary
- strip leading newlines from the generated Prisma schema before writing it back
- add a regression test that ensures sync does not prepend a blank line

## Context
Fixes #98.

## Testing
- bun run test:run packages/cli/__tests__/generators/prisma.test.ts
- bun run test:run packages/cli/__tests__/commands/sync.test.ts