### PR TITLE
fix(widget): re-fetch feedbacks on SPA navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ When the recipient clicks the link, the widget opens on the original page with t
 deepLink: { param: 'fb' }   // → ?fb=<feedbackId>
 ```
 
-**Only the initial page load triggers focus.** SPA navigations and `history.pushState` updates are ignored on purpose — re-scrolling during normal browsing would be surprising. Hosts that need to drive focus after a route change can call the imperative counterpart instead:
+**Only the initial page load triggers focus.** SPA navigations and `history.pushState` updates never trigger an automatic *re-scroll* — re-scrolling during normal browsing would be surprising. (The feedback **data** does follow route changes automatically: the widget re-fetches the new page's feedbacks on SPA navigation by default — see `watchNavigation`. It's only the deep-link *focus/scroll* that stays initial-load only.) Hosts that need to drive focus after a route change can call the imperative counterpart instead:
 
 ```ts
 const widget = initSiteping({ endpoint: '/api/siteping', projectName: 'my-app' })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -175,6 +175,28 @@ export interface SitepingConfig {
    */
   deepLink?: boolean | SitepingDeepLinkOptions | undefined;
   /**
+   * Automatically re-fetch feedbacks when the page changes during client-side
+   * (SPA) navigation. Enabled by default.
+   *
+   * The widget is normally mounted once (singleton) inside a persistent layout
+   * — e.g. a Next.js App Router `layout.tsx`, which does NOT remount on
+   * client-side navigation. Without this, init runs a single time and both the
+   * panel list and the page markers stay frozen on the page where the widget
+   * first mounted. With it on, the widget patches the History API
+   * (`pushState`/`replaceState`, which SPA routers call instead of triggering
+   * `popstate`) and listens for `popstate`/`hashchange`, then re-fetches when
+   * the scope key (`getPageScope().url` + template) actually changes.
+   *
+   * This re-fetches data only — it deliberately does NOT re-focus or re-scroll
+   * to an annotation (deep-link focus stays initial-load only; see `deepLink`),
+   * so normal browsing is never interrupted by a surprise scroll.
+   *
+   * - `true` (default) — watch navigation and re-fetch on route change.
+   * - `false` — never touch the History API; hosts drive updates manually via
+   *   `instance.refresh()`.
+   */
+  watchNavigation?: boolean | undefined;
+  /**
    * Pre-fill author identity from the host application — typically the
    * currently signed-in user. When set, the widget uses these values
    * directly and never shows the identity modal, even on first feedback.

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -78,6 +78,7 @@ All configuration options for `initSiteping()`:
 | `debug` | `boolean` | `false` | Enable debug logging to console |
 | `identity` | `{ name: string; email: string }` | — | Pre-fill author identity from the host (SSO). When set, the widget skips the identity modal |
 | `deepLink` | `boolean \| { param?: string }` | `false` | On initial load, focus the annotation referenced by `?siteping=<id>` (or a custom query key). SPA navigations are ignored — use `focusFeedback()` for route-change focus |
+| `watchNavigation` | `boolean` | `true` | Auto re-fetch feedbacks on client-side (SPA) navigation. The widget patches the History API + listens for `popstate`/`hashchange`, so the panel list and markers follow route changes even when the widget is mounted once in a persistent layout (e.g. Next.js App Router). Re-fetches data only — it never re-scrolls. Set `false` to opt out and drive updates via `refresh()` |
 
 > **Custom translations** — Use `registerLocale(code, translations)` to add your own locale at runtime.
 

--- a/packages/widget/__tests__/widget/launcher-spa-navigation.test.ts
+++ b/packages/widget/__tests__/widget/launcher-spa-navigation.test.ts
@@ -1,0 +1,323 @@
+// @vitest-environment jsdom
+
+import type { PageScope, SitepingConfig } from "@siteping/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mockMatchMedia } from "../helpers.js";
+
+// jsdom does not implement window.matchMedia — provide a stub
+mockMatchMedia(false);
+
+// ---------------------------------------------------------------------------
+// Mock modules before importing launcher
+// ---------------------------------------------------------------------------
+
+const mockGetFeedbacks = vi.fn().mockResolvedValue({ feedbacks: [], total: 0 });
+
+vi.mock(new URL("../../src/api-client.js", import.meta.url).pathname, () => ({
+  ApiClient: vi.fn().mockImplementation(() => ({
+    sendFeedback: vi.fn(),
+    getFeedbacks: mockGetFeedbacks,
+    resolveFeedback: vi.fn(),
+    deleteFeedback: vi.fn(),
+    deleteAllFeedbacks: vi.fn(),
+  })),
+  flushRetryQueue: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock(new URL("../../src/annotator.js", import.meta.url).pathname, () => ({
+  Annotator: vi.fn().mockImplementation(() => ({
+    destroy: vi.fn(),
+    refreshLabels: vi.fn(),
+  })),
+}));
+
+const mockMarkersRender = vi.fn();
+vi.mock(new URL("../../src/markers.js", import.meta.url).pathname, () => ({
+  MarkerManager: vi.fn().mockImplementation(() => ({
+    render: mockMarkersRender,
+    highlight: vi.fn(),
+    pinHighlight: vi.fn(),
+    addFeedback: vi.fn(),
+    focusFeedback: vi.fn().mockReturnValue(false),
+    destroy: vi.fn(),
+    count: 0,
+  })),
+}));
+
+vi.mock(new URL("../../src/tooltip.js", import.meta.url).pathname, () => ({
+  Tooltip: vi.fn().mockImplementation(() => ({
+    tooltipId: "sp-tooltip",
+    show: vi.fn(),
+    scheduleHide: vi.fn(),
+    contains: vi.fn(),
+    destroy: vi.fn(),
+  })),
+}));
+
+vi.mock(new URL("../../src/styles/base.js", import.meta.url).pathname, () => ({
+  buildStyles: vi.fn().mockReturnValue("/* styles */"),
+}));
+
+vi.mock(new URL("../../src/identity.js", import.meta.url).pathname, () => ({
+  getIdentity: vi.fn().mockReturnValue({ name: "Test User", email: "test@example.com" }),
+  saveIdentity: vi.fn(),
+}));
+
+// Mock the lazily-imported Panel so the open/closed branch of the navigation
+// watcher is fully deterministic (the real Panel only fetches on open(), but
+// the stub lets us flip `isCurrentlyOpen` at will and assert delegation).
+const mockPanelOpen = vi.fn();
+const mockPanelRefresh = vi.fn().mockResolvedValue(undefined);
+let panelIsOpen = false;
+
+vi.mock(new URL("../../src/panel.js", import.meta.url).pathname, () => ({
+  Panel: vi.fn().mockImplementation(() => ({
+    open: mockPanelOpen,
+    close: vi.fn(),
+    refresh: mockPanelRefresh,
+    destroy: vi.fn(),
+    get isCurrentlyOpen() {
+      return panelIsOpen;
+    },
+  })),
+}));
+
+import { launch } from "../../src/launcher.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function defaultConfig(overrides: Partial<SitepingConfig> = {}): SitepingConfig {
+  return {
+    endpoint: "/api/siteping",
+    projectName: "test-project",
+    forceShow: true,
+    ...overrides,
+  };
+}
+
+/** Wait until the initial markers load has fired once, then clear the spy so
+ *  subsequent assertions only count navigation-triggered fetches. */
+async function settleInitialLoad(): Promise<void> {
+  await vi.waitFor(() => {
+    expect(mockGetFeedbacks).toHaveBeenCalled();
+  });
+  mockGetFeedbacks.mockClear();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("launcher — SPA navigation watcher", () => {
+  // A controllable scope so tests never depend on jsdom's history/location
+  // quirks: the watcher reads getScope() → config.getPageScope() → this value.
+  let currentScope: PageScope = { url: "/page-1", urlPattern: null };
+
+  afterEach(() => {
+    for (const el of document.querySelectorAll("siteping-widget")) el.remove();
+    for (const el of document.querySelectorAll('[role="status"]')) el.remove();
+    vi.clearAllMocks();
+    mockGetFeedbacks.mockResolvedValue({ feedbacks: [], total: 0 });
+    mockPanelRefresh.mockResolvedValue(undefined);
+    panelIsOpen = false;
+    currentScope = { url: "/page-1", urlPattern: null };
+  });
+
+  it("re-fetches feedbacks for the new scope when pushState changes the route", async () => {
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    // Simulate a Next.js App Router client-side navigation: the host's route
+    // state advances, and Next calls history.pushState under the hood.
+    currentScope = { url: "/page-2", urlPattern: null };
+    window.history.pushState(null, "", "/page-2");
+
+    await vi.waitFor(() => {
+      expect(mockGetFeedbacks).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGetFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/page-2" }));
+
+    instance.destroy();
+  });
+
+  it("re-fetches on replaceState route changes", async () => {
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    currentScope = { url: "/page-3", urlPattern: null };
+    window.history.replaceState(null, "", "/page-3");
+
+    await vi.waitFor(() => {
+      expect(mockGetFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/page-3" }));
+    });
+
+    instance.destroy();
+  });
+
+  it("re-fetches on popstate (browser back/forward)", async () => {
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    currentScope = { url: "/page-4", urlPattern: null };
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await vi.waitFor(() => {
+      expect(mockGetFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/page-4" }));
+    });
+
+    instance.destroy();
+  });
+
+  it("does NOT re-fetch when the scope is unchanged (e.g. query-only navigation)", async () => {
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    // pushState fires, but the scope key (url + template) is identical.
+    window.history.pushState(null, "", "/page-1?tab=2");
+
+    // Give the watcher a chance to (wrongly) fire.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mockGetFeedbacks).not.toHaveBeenCalled();
+
+    instance.destroy();
+  });
+
+  it("delegates to the open panel's refresh() instead of fetching markers itself", async () => {
+    // This is the exact symptom reported: the panel list stays frozen across
+    // SPA navigation because nothing re-runs loadFeedbacks() while it's open.
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    // Open the panel so panelInstance exists and reports as open.
+    instance.open();
+    await vi.waitFor(() => {
+      expect(mockPanelOpen).toHaveBeenCalled();
+    });
+    panelIsOpen = true;
+    mockGetFeedbacks.mockClear();
+    mockPanelRefresh.mockClear();
+
+    currentScope = { url: "/page-5", urlPattern: null };
+    window.history.pushState(null, "", "/page-5");
+
+    await vi.waitFor(() => {
+      expect(mockPanelRefresh).toHaveBeenCalledTimes(1);
+    });
+    // When the panel is open it owns the fetch — the launcher must not also
+    // fetch markers (that would race and clobber the panel's render).
+    expect(mockGetFeedbacks).not.toHaveBeenCalled();
+
+    instance.destroy();
+  });
+
+  it("does not patch History or re-fetch when watchNavigation is false", async () => {
+    const nativePushState = window.history.pushState;
+
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope, watchNavigation: false }));
+    await settleInitialLoad();
+
+    // History is left untouched.
+    expect(window.history.pushState).toBe(nativePushState);
+
+    currentScope = { url: "/page-6", urlPattern: null };
+    window.history.pushState(null, "", "/page-6");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mockGetFeedbacks).not.toHaveBeenCalled();
+
+    instance.destroy();
+  });
+
+  it("ignores a stale in-flight fetch when a newer navigation supersedes it", async () => {
+    // A->B->C burst where B's fetch resolves AFTER C's. B (the older request)
+    // must not clobber the markers C already rendered. Mirrors the panel's
+    // AbortController staleness guard for the closed-panel marker path.
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+    // Wait for the initial render to land, then reset the render spy so we only
+    // count navigation-driven renders.
+    await vi.waitFor(() => {
+      expect(mockMarkersRender).toHaveBeenCalled();
+    });
+    mockMarkersRender.mockClear();
+
+    let resolveSlow: (v: { feedbacks: unknown[]; total: number }) => void = () => {};
+    const slow = new Promise<{ feedbacks: unknown[]; total: number }>((r) => {
+      resolveSlow = r;
+    });
+    mockGetFeedbacks.mockReturnValueOnce(slow).mockResolvedValueOnce({ feedbacks: [], total: 0 });
+
+    // Nav to page-2 (slow fetch), then immediately to page-3 (fast fetch).
+    currentScope = { url: "/page-2", urlPattern: null };
+    window.history.pushState(null, "", "/page-2");
+    currentScope = { url: "/page-3", urlPattern: null };
+    window.history.pushState(null, "", "/page-3");
+
+    // page-3 resolves first and renders.
+    await vi.waitFor(() => {
+      expect(mockMarkersRender).toHaveBeenCalledTimes(1);
+    });
+
+    // Now the older page-2 fetch resolves — it is stale and must be dropped.
+    resolveSlow({ feedbacks: [], total: 0 });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mockMarkersRender).toHaveBeenCalledTimes(1);
+
+    instance.destroy();
+  });
+
+  it("re-arms the dedup after a failed refresh so re-pushing the same route retries", async () => {
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    // Navigate to a page whose fetch fails.
+    currentScope = { url: "/page-fail", urlPattern: null };
+    mockGetFeedbacks.mockRejectedValueOnce(new Error("network down"));
+    window.history.pushState(null, "", "/page-fail");
+    await vi.waitFor(() => {
+      expect(mockGetFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/page-fail" }));
+    });
+    // Let the rejection + re-arm microtask settle.
+    await new Promise((r) => setTimeout(r, 20));
+    mockGetFeedbacks.mockClear();
+
+    // Re-push the SAME route. Without the re-arm, the dedup guard would suppress
+    // this (lastScopeKey still == /page-fail) and the stale markers would never
+    // recover via the watcher.
+    window.history.pushState(null, "", "/page-fail");
+    await vi.waitFor(() => {
+      expect(mockGetFeedbacks).toHaveBeenCalledWith("test-project", expect.objectContaining({ url: "/page-fail" }));
+    });
+
+    instance.destroy();
+  });
+
+  it("restores History and stops watching after destroy()", async () => {
+    const nativePushState = window.history.pushState;
+    const nativeReplaceState = window.history.replaceState;
+
+    const instance = launch(defaultConfig({ getPageScope: () => currentScope }));
+    await settleInitialLoad();
+
+    // While alive, History is patched.
+    expect(window.history.pushState).not.toBe(nativePushState);
+    expect(window.history.replaceState).not.toBe(nativeReplaceState);
+
+    instance.destroy();
+
+    // After destroy, the originals are restored…
+    expect(window.history.pushState).toBe(nativePushState);
+    expect(window.history.replaceState).toBe(nativeReplaceState);
+
+    // …and a subsequent navigation triggers no fetch.
+    currentScope = { url: "/page-7", urlPattern: null };
+    window.history.pushState(null, "", "/page-7");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(mockGetFeedbacks).not.toHaveBeenCalled();
+  });
+});

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -304,6 +304,13 @@ export function launch(config: SitepingConfig): SitepingInstance {
   let panelInstance: PanelType | null = null;
   let panelPromise: Promise<PanelType> | null = null;
   let destroyed = false;
+  // Monotonic token guarding the launcher's own marker renders (initial load +
+  // doRefresh). The panel guards its own renders with an AbortController; the
+  // two direct launcher paths share this counter so the *last-issued* fetch
+  // wins, never the last to resolve. Without it, an SPA nav burst (or an
+  // initial load racing the first navigation) could render a stale page's
+  // markers out of order, since markers.render() is a full clear-and-rebuild.
+  let markerGeneration = 0;
   async function loadPanel(): Promise<PanelType | null> {
     if (destroyed) return null;
     if (panelInstance) return panelInstance;
@@ -478,13 +485,17 @@ export function launch(config: SitepingConfig): SitepingInstance {
   const initialScope = getScope();
   const initialOptions = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: initialScope.url } : { limit: PAGE_SIZE };
   const deepLinkOpts = normaliseDeepLinkOptions(config.deepLink);
+  // Claim a generation for the initial load so a navigation that fires while
+  // this fetch is in flight (doRefresh bumps the counter) supersedes it — the
+  // old page's markers must never clobber the page the user navigated to.
+  const initialLoadGeneration = ++markerGeneration;
   // Render markers only once both the feedbacks and the locale dictionary are
   // ready. Marker aria-labels are built via `t(...)` at render time — without
   // this `Promise.all`, a fast HTTP response could outrun a slow locale chunk
   // and freeze marker labels in the English fallback for non-English locales.
   Promise.all([client.getFeedbacks(config.projectName, initialOptions), localeReady])
     .then(([{ feedbacks }]) => {
-      if (destroyed) return;
+      if (destroyed || markerGeneration !== initialLoadGeneration) return;
       // Defensive client-side filter — backend may not yet support the `url` query.
       const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === initialScope.url) : feedbacks;
       markers.render(visible);
@@ -516,11 +527,102 @@ export function launch(config: SitepingConfig): SitepingInstance {
       .catch(() => {});
   }
 
+  // Re-fetch feedbacks for the *current* scope and update the UI. Shared by the
+  // public `instance.refresh()` and the SPA navigation watcher below.
+  //
+  // When the panel is open, its own `refresh()` already runs `loadFeedbacks()`
+  // which re-renders markers — a second fetch here would race with it (the
+  // loser overwrites the winner's markers, off by a generation). So we delegate
+  // when open, and fetch markers ourselves when closed (the panel won't, but
+  // SPA hosts still need the new page's markers after a route change).
+  //
+  // Returns the in-flight promise (rejecting on fetch failure) so callers can
+  // react — `instance.refresh()` swallows it (the public API never rejects onto
+  // the host), the navigation watcher uses it to re-arm its dedup on failure.
+  const doRefresh = (): Promise<void> => {
+    // Bump first, before the open/closed split, so switching to panel-driven
+    // rendering also invalidates any closed-panel fetch still in flight.
+    const generation = ++markerGeneration;
+    if (panelInstance?.isCurrentlyOpen) {
+      return panelInstance.refresh();
+    }
+    const scope = getScope();
+    const opts = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: scope.url } : { limit: PAGE_SIZE };
+    return client.getFeedbacks(config.projectName, opts).then(({ feedbacks }) => {
+      // Drop the result if a newer refresh superseded us (out-of-order
+      // resolution), the widget was torn down, or the panel opened mid-flight
+      // and now owns marker rendering itself.
+      if (destroyed || generation !== markerGeneration || panelInstance?.isCurrentlyOpen) return;
+      const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === scope.url) : feedbacks;
+      markers.render(visible);
+    });
+  };
+
+  // SPA route-change watcher. The widget is normally mounted once (singleton)
+  // inside a persistent layout — e.g. a Next.js App Router `layout.tsx`, which
+  // does NOT remount on client-side navigation. Without this, init runs once and
+  // the panel list + markers stay frozen on the page where the widget first
+  // mounted. We patch the History API (SPA routers call pushState/replaceState
+  // rather than triggering popstate) and listen for popstate/hashchange, then
+  // re-fetch only when the scope key actually changes. This re-fetches data
+  // only — it deliberately does NOT re-focus/re-scroll (deep-link focus stays
+  // initial-load only; see `deepLink`). Opt out with `watchNavigation: false`.
+  let teardownNavigation: (() => void) | null = null;
+  if (config.watchNavigation !== false && typeof window !== "undefined" && typeof history !== "undefined") {
+    const scopeKey = (s: PageScope): string => `${s.url}\n${s.urlPattern ?? ""}`;
+    let lastScopeKey = scopeKey(initialScope);
+    const onLocationChange = (): void => {
+      if (destroyed) return;
+      const key = scopeKey(getScope());
+      // Same scope (e.g. query-only or hash-only nav under the default pathname
+      // scope) — nothing to re-fetch. Guards against pushState storms too.
+      if (key === lastScopeKey) return;
+      const prevKey = lastScopeKey;
+      lastScopeKey = key;
+      log("SPA navigation detected — refreshing feedbacks for new scope");
+      doRefresh().catch(() => {
+        // The refresh failed (network error). Roll the dedup key back so a
+        // later nav *back* to this same scope retries instead of being
+        // silently suppressed — unless a newer navigation already moved on.
+        if (lastScopeKey === key) lastScopeKey = prevKey;
+      });
+    };
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+    // Call through to the original first so `location` is already updated by the
+    // time onLocationChange() reads getScope().
+    const patchedPushState: typeof history.pushState = function (this: History, ...args) {
+      originalPushState.apply(this, args);
+      onLocationChange();
+    };
+    const patchedReplaceState: typeof history.replaceState = function (this: History, ...args) {
+      originalReplaceState.apply(this, args);
+      onLocationChange();
+    };
+    history.pushState = patchedPushState;
+    history.replaceState = patchedReplaceState;
+    window.addEventListener("popstate", onLocationChange);
+    window.addEventListener("hashchange", onLocationChange);
+
+    teardownNavigation = () => {
+      window.removeEventListener("popstate", onLocationChange);
+      window.removeEventListener("hashchange", onLocationChange);
+      // Restore only if nobody patched on top of us — otherwise we'd clobber
+      // another library's History wrapper. If a library did wrap on top, our
+      // patch stays in the chain (and keeps its closure alive), but it's inert:
+      // `destroyed` is already true above, so onLocationChange() is a no-op.
+      if (history.pushState === patchedPushState) history.pushState = originalPushState;
+      if (history.replaceState === patchedReplaceState) history.replaceState = originalReplaceState;
+    };
+  }
+
   instance = {
     destroy: () => {
       log("Destroying widget");
       destroyed = true;
       pendingOpen = false;
+      teardownNavigation?.();
       unsubAnnotation();
       unsubToggle();
       fab.destroy();
@@ -560,27 +662,9 @@ export function launch(config: SitepingConfig): SitepingInstance {
       // can retry, or trigger focus from a user gesture instead.
       return markers.focusFeedback(feedbackId);
     },
+    // Public API must never reject onto the host — swallow the promise.
     refresh: () => {
-      // When the panel is open, its `refresh()` already runs `loadFeedbacks()`
-      // which renders markers. Doing a second fetch here would race with that
-      // one — the loser overwrites the winner's markers, off by a generation.
-      // So: when the panel is open, delegate. When it's closed, fetch markers
-      // ourselves (the panel won't, but SPA hosts still need the new page's
-      // markers after a route change).
-      if (panelInstance?.isCurrentlyOpen) {
-        panelInstance.refresh();
-        return;
-      }
-
-      const scope = getScope();
-      const opts = scopeAnnotationsByUrl ? { limit: PAGE_SIZE, url: scope.url } : { limit: PAGE_SIZE };
-      client
-        .getFeedbacks(config.projectName, opts)
-        .then(({ feedbacks }) => {
-          const visible = scopeAnnotationsByUrl ? feedbacks.filter((f) => f.url === scope.url) : feedbacks;
-          markers.render(visible);
-        })
-        .catch(() => {});
+      void doRefresh().catch(() => {});
     },
     // `PublicWidgetEvents` is a structural alias of `SitepingPublicEvents`, so
     // these on/off forwarders compose without any runtime cast.


### PR DESCRIPTION
## Problem

The widget captured the page URL **once** at init and listened to **no** navigation events. Mounted once (singleton) in a persistent layout — e.g. a Next.js **App Router** `layout.tsx`, which does not remount on client-side navigation — it stayed frozen on the first page: **the panel list and the page markers never followed client-side route changes.**

Reported against a Next.js App Router app where the widget is mounted in `app/[locale]/layout.tsx` via the `useSiteping()` hook (`useEffect([])`, single init). Navigating between pages left the open panel showing the previous page's feedbacks.

## Fix

Add a framework-agnostic **SPA navigation watcher** (on by default, opt out via the new `watchNavigation` option):

- Patches `history.pushState`/`replaceState` (SPA routers call these instead of firing `popstate`) and listens for `popstate`/`hashchange`.
- Re-fetches when the **page scope key** (`getPageScope().url` + template) actually changes — dedupes query-only/hash-only navs and `pushState` storms.
- **Panel open → delegates to `panel.refresh()`** (reloads the list); **panel closed → reloads markers**.
- **Data only — no auto re-scroll.** Deep-link focus stays initial-load only, so normal browsing is never interrupted.
- `destroy()` removes the listeners and restores the History API.

**Zero config for consumers** — the fix is active by default; existing integrations need no change.

## Hardening (from an adversarial review of the watcher)

- **Shared generation token** for the launcher's two direct marker-render paths (initial load + `doRefresh`) so the *last-issued* fetch wins, never the *last to resolve* — prevents an SPA nav burst (`A→B→C`, prefetch, back/forward) or an initial-load-vs-first-nav race from rendering a stale page's markers out of order. Mirrors the panel's existing `AbortController` staleness guard.
- **Dedup re-arm on failure**: a failed refresh rolls the scope key back so navigating *back* to the same route retries instead of being silently suppressed.
- Teardown leaves the patch inert (not clobbering a wrapper installed on top) — documented; `destroyed=true` makes the handler a no-op.

## API

New `SitepingConfig.watchNavigation?: boolean` (default `true`). Set `false` to keep the History API untouched and drive updates manually via `instance.refresh()`. Documented in both READMEs.

## Tests & checks

- New `launcher-spa-navigation.test.ts` (9 tests): pushState / replaceState / popstate re-fetch, no-op on unchanged scope, **open-panel delegation**, `watchNavigation: false`, **generation guard (stale fetch dropped)**, **failure re-arm**, destroy teardown/restore.
- `turbo check` ✅ · `turbo build` ✅ · biome lint ✅ · full widget suite **1093 passed** ✅

> Note: `@siteping/core` is internal (no changelog entry / no publish). The release-please entry lands under `@siteping/widget`; a release is needed after merge for consumers (`@siteping/widget@0.9.13`) to pick it up.