### PR TITLE
feat(adapter-prisma)!: migrate validation to zod 4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
       "name": "@siteping/adapter-prisma",
       "version": "0.4.9",
       "dependencies": {
-        "zod": "^3.24.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@siteping/core": "workspace:*",
@@ -889,7 +889,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -51,7 +51,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "zod": "^3.24.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@siteping/core": "workspace:*"

--- a/packages/adapter-prisma/src/validation.ts
+++ b/packages/adapter-prisma/src/validation.ts
@@ -82,7 +82,7 @@ export const feedbackCreateSchema = z.object({
   viewport: z.string().min(1).max(50),
   userAgent: z.string().min(1).max(500),
   authorName: z.string().min(1).max(200),
-  authorEmail: z.string().email().max(200),
+  authorEmail: z.email().max(200),
   annotations: z.array(annotationSchema).max(50),
   // Restrict to URL-safe identifiers. The widget generates UUIDs (or a
   // Date+Math.random fallback), both of which match. Anything outside this
@@ -274,8 +274,10 @@ export interface ValidationIssue {
  * Safe: does not leak input values or schema structure.
  */
 export function formatValidationErrors(error: zod.z.ZodError): ValidationIssue[] {
-  return error.issues.map((issue: { path: Array<string | number>; message: string }) => ({
-    field: issue.path.join("."),
+  // Zod 4 types `issue.path` as PropertyKey[] (symbols possible in theory);
+  // String() keeps the join total instead of throwing on non-string keys.
+  return error.issues.map((issue) => ({
+    field: issue.path.map(String).join("."),
     message: issue.message,
   }));
 }


### PR DESCRIPTION
Supersedes #156 (dependabot's zod 3.25.76 → 4.4.3 bump, red as-is: the v3 code needed migration).

## Changes
- `zod` dependency `^3.24.0` → `^4.4.3` (packages/adapter-prisma)
- `authorEmail`: `z.string().email()` → `z.email()` (v4 idiom; method form is deprecated in v4)
- `formatValidationErrors`: zod 4 types `issue.path` as `PropertyKey[]`; mapped through `String()` so the join stays total
- Lockfile regenerated with bun 1.3.11 (lockfileVersion 1, matches CI)

## Unchanged
- Public API: the hand-written input interfaces (`FeedbackCreateInput`, …) are decoupled from zod; bidirectional type assertions still enforce schema/interface sync
- All other schema APIs used (object/enum/coerce/union/literal/default/regex) are stable across v3→v4

## Breaking
- Validation error `message` strings in 400 responses now follow zod 4 wording
- Published package now depends on zod ^4

## Verification
- `bun run check` 10/10, biome 2.5.5 lint clean
- adapter-prisma tests: 127/127 under zod 4.4.3
- `bun install --frozen-lockfile` no-op locally under bun 1.3.11