### PR TITLE
ci: bump artifact actions to node24 majors (upload v7, download v8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: bun run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-packages
           path: |
@@ -95,7 +95,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: packages/
@@ -131,7 +131,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: packages/
@@ -167,7 +167,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: packages/
@@ -203,7 +203,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: packages/
@@ -239,7 +239,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist-packages
           path: packages/


### PR DESCRIPTION
Clears the remaining node20 deprecation warnings flagged by GitHub in CI runs (actions/upload-artifact@v4, actions/download-artifact@v4). Companion to the dependabot bumps of checkout v7 / setup-node v7 / cache v6 already merged.

## Audit (action.yml diff + major release notes)
- **upload-artifact v4→v7**: node24 runtime, ESM internals; only additive input (`archive`, default `true` = current behavior). Our inputs (`name`, `path`, `retention-days`) unchanged.
- **download-artifact v4→v8**: node24, ESM; additive inputs (`skip-decompress`, `digest-mismatch`). The v5 breaking path change only affects downloads **by artifact ID** — ours are by name. `digest-mismatch` now errors by default: security hardening we want for npm publish artifacts.
- Cross-compat upload@v7 → download@v8 (same artifact v2 backend).