### PR TITLE
fix(widget): production guard survives bundler NODE_ENV folding; add SSR guard (fixes #104)

### DIFF
--- a/e2e/server.mjs
+++ b/e2e/server.mjs
@@ -164,8 +164,15 @@ const server = createServer((req, res) => {
   // Serve HTML — accept ?project=xxx for per-browser isolation
   if (url.pathname === "/" || url.pathname === "/index.html") {
     const project = url.searchParams.get("project") || "e2e-test";
+    let html = HTML.replace("projectName: 'e2e-test'", `projectName: '${project}'`);
+    // ?noForceShow=1 omits forceShow from the init config so the production
+    // guard in the real dist bundle is exercised: NODE_ENV is 'test' (set in
+    // the page above), so the widget must still mount — see #104.
+    if (url.searchParams.get("noForceShow") === "1") {
+      html = html.replace("      forceShow: true,\n", "");
+    }
     res.writeHead(200, { "Content-Type": "text/html" });
-    res.end(HTML.replace("projectName: 'e2e-test'", `projectName: '${project}'`));
+    res.end(html);
     return;
   }
 

--- a/e2e/server.mjs
+++ b/e2e/server.mjs
@@ -169,7 +169,15 @@ const server = createServer((req, res) => {
     // guard in the real dist bundle is exercised: NODE_ENV is 'test' (set in
     // the page above), so the widget must still mount — see #104.
     if (url.searchParams.get("noForceShow") === "1") {
-      html = html.replace("      forceShow: true,\n", "");
+      const stripped = html.replace("      forceShow: true,\n", "");
+      if (stripped === html) {
+        // The exact-string replace missed (template reformatted?) — serving
+        // the forceShow page would make the #104 regression test vacuous.
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end("noForceShow=1: failed to strip forceShow from the page template");
+        return;
+      }
+      html = stripped;
     }
     res.writeHead(200, { "Content-Type": "text/html" });
     res.end(html);

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -932,6 +932,26 @@ test.describe("Touch annotation", () => {
   });
 });
 
+test.describe("Production guard at dist level (#104)", () => {
+  // Regression test against bundler constant-folding: esbuild's browser
+  // platform statically replaces the literal `process.env.NODE_ENV` in the
+  // dist bundle, which used to fold the production guard into an
+  // unconditional skip. Without forceShow and with NODE_ENV='test'
+  // (non-production, set by the page before loading the widget), the real
+  // dist bundle must still mount the widget.
+  test("widget mounts without forceShow when NODE_ENV is not production", async ({ page, browserName }) => {
+    const project = `e2e-${browserName}-noforce`;
+    await page.request.get(`http://localhost:3999/api/reset?projectName=${project}`);
+    await page.goto(`http://localhost:3999?project=${project}&noForceShow=1`);
+    await page.waitForSelector("siteping-widget", { state: "attached" });
+    await page.waitForFunction(() => {
+      const host = document.querySelector("siteping-widget");
+      return host?.shadowRoot?.querySelector(".sp-fab") !== null;
+    });
+    await expect(page.locator("siteping-widget")).toBeAttached();
+  });
+});
+
 test.describe("Cleanup", () => {
   test("destroy() removes all injected elements", async ({ page }) => {
     await expect(page.locator("siteping-widget")).toBeAttached();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,8 +21,11 @@ export type BuiltinLocale = (typeof BUILTIN_LOCALES)[number];
  */
 export type SitepingLocale = BuiltinLocale | (string & {});
 
-/** Reasons reported through `SitepingConfig.onSkip`. */
-export type SitepingSkipReason = "production" | "mobile";
+/**
+ * Reasons reported through `SitepingConfig.onSkip` — production environment,
+ * mobile viewport, or server-side rendering (no `window`/`document`).
+ */
+export type SitepingSkipReason = "production" | "mobile" | "ssr";
 
 /** Per-channel + per-buffer-size diagnostics configuration. */
 export interface DiagnosticsCaptureOptions {
@@ -73,6 +76,8 @@ export interface SitepingConfig {
   /**
    * Render the widget even when it would normally be skipped — this bypasses
    * BOTH the production-environment guard AND the mobile-viewport guard.
+   * It does NOT bypass the SSR guard: without `window`/`document` the widget
+   * never renders and `onSkip("ssr")` fires instead.
    * Defaults to false. Use it for dedicated review tools, staging environments,
    * or responsive testing where you always want the widget present.
    */
@@ -168,7 +173,7 @@ export interface SitepingConfig {
    * before enabling in environments where they might log sensitive values.
    */
   captureDiagnostics?: boolean | DiagnosticsCaptureOptions | undefined;
-  /** Called when the widget is skipped (production mode, mobile viewport) */
+  /** Called when the widget is skipped (production mode, mobile viewport, SSR — no DOM) */
   onSkip?: (reason: SitepingSkipReason) => void;
   /**
    * Auto-focus a specific annotation when its ID appears in the URL query

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -73,7 +73,7 @@ All configuration options for `initSiteping()`:
 | `accentColor` | `string` | `'#0066ff'` | Widget accent color — hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`) |
 | `theme` | `'light' \| 'dark' \| 'auto'` | `'light'` | Widget color theme |
 | `locale` | `'en' \| 'fr' \| 'de' \| 'es' \| 'it' \| 'pt' \| 'ru'` | `'en'` | Widget UI language. Unknown locales fall back to English |
-| `forceShow` | `boolean` | `false` | Render the widget even when it would normally be skipped — bypasses **both** the production guard and the mobile-viewport guard |
+| `forceShow` | `boolean` | `false` | Render the widget even when it would normally be skipped — bypasses **both** the production guard and the mobile-viewport guard. Does **not** bypass the SSR guard (the widget never renders without a DOM) |
 | `minViewportWidth` | `number` | `768` | Minimum viewport width (px) for the widget to render; below it `onSkip('mobile')` fires. Set `0` to allow mobile viewports |
 | `debug` | `boolean` | `false` | Enable debug logging to console |
 | `identity` | `{ name: string; email: string }` | — | Pre-fill author identity from the host (SSO). When set, the widget skips the identity modal |
@@ -93,7 +93,7 @@ All configuration options for `initSiteping()`:
 | `onError` | `(error) => void` | Called on API or internal errors |
 | `onAnnotationStart` | `() => void` | Called when annotation drawing starts |
 | `onAnnotationEnd` | `() => void` | Called when annotation drawing ends |
-| `onSkip` | `(reason) => void` | Called when widget is skipped (production/mobile) |
+| `onSkip` | `(reason) => void` | Called when widget is skipped (production/mobile/ssr) |
 
 ```ts
 initSiteping({

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -115,6 +115,20 @@ initSiteping({
 })
 ```
 
+### How production detection works
+
+The widget skips rendering when `NODE_ENV` is `production`. The shipped bundle
+keeps the literal `process.env.NODE_ENV` expression, so:
+
+- **Bundled apps** (Next.js, Vite, webpack…): your bundler inlines its
+  environment at build time — the widget auto-hides in production builds and
+  shows in dev builds.
+- **Node/SSR and test runners**: the real `process.env.NODE_ENV` is read at
+  runtime (server-side, the widget always skips with `onSkip('ssr')`).
+- **Plain `<script>` tags** with no bundler and no `process` global: there is
+  no environment signal, so the widget renders — gate the `<script>` tag
+  yourself, or use `onSkip`/`forceShow` to control visibility explicitly.
+
 ## Return value API
 
 `initSiteping()` returns a `SitepingInstance` with the following methods:

--- a/packages/widget/__tests__/widget/launcher.ssr.test.ts
+++ b/packages/widget/__tests__/widget/launcher.ssr.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { initSiteping } from "../../src/index.js";
+
+// SSR guard (#104) — Next.js/Remix hosts may run initSiteping() on the
+// server, where `window` and `document` do not exist. The widget must
+// return a no-op instance instead of throwing on DOM access.
+
+describe("SSR guard (node environment, no window/document)", () => {
+  it("returns a no-op instance and calls onSkip with 'ssr'", () => {
+    const onSkip = vi.fn();
+    const instance = initSiteping({ endpoint: "/api/siteping", projectName: "ssr-test", onSkip });
+
+    expect(onSkip).toHaveBeenCalledWith("ssr");
+
+    // Full no-op API surface — none of it may throw
+    expect(instance.destroy).toBeTypeOf("function");
+    expect(instance.open).toBeTypeOf("function");
+    expect(instance.close).toBeTypeOf("function");
+    expect(instance.refresh).toBeTypeOf("function");
+    expect(instance.on).toBeTypeOf("function");
+    expect(instance.off).toBeTypeOf("function");
+    expect(() => {
+      instance.open();
+      instance.close();
+      instance.refresh();
+      const unsub = instance.on("panel:open", () => {});
+      unsub();
+      instance.off("panel:open", () => {});
+      instance.destroy();
+    }).not.toThrow();
+    expect(instance.focusFeedback("any-id")).toBe(false);
+  });
+
+  it("forceShow does NOT bypass the SSR guard", () => {
+    const onSkip = vi.fn();
+    const instance = initSiteping({
+      endpoint: "/api/siteping",
+      projectName: "ssr-test",
+      forceShow: true,
+      onSkip,
+    });
+
+    expect(onSkip).toHaveBeenCalledWith("ssr");
+    expect(() => instance.destroy()).not.toThrow();
+  });
+});

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -185,6 +185,23 @@ describe("launch", () => {
         process.env.NODE_ENV = origEnv;
       }
     });
+
+    it("mounts without forceShow when NODE_ENV is 'development' (#104)", () => {
+      // Locks the bundler-folding regression at source level: the guard must
+      // compare the actual runtime NODE_ENV, not a build-time constant.
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = "development";
+
+      const onSkip = vi.fn();
+      const instance = launch({ endpoint: "/api", projectName: "test", onSkip });
+      try {
+        expect(document.querySelector("siteping-widget")).not.toBeNull();
+        expect(onSkip).not.toHaveBeenCalled();
+      } finally {
+        instance.destroy();
+        process.env.NODE_ENV = origEnv;
+      }
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -187,8 +187,9 @@ describe("launch", () => {
     });
 
     it("mounts without forceShow when NODE_ENV is 'development' (#104)", () => {
-      // Locks the bundler-folding regression at source level: the guard must
-      // compare the actual runtime NODE_ENV, not a build-time constant.
+      // Source-level sanity check only — vitest never applies bundler defines,
+      // so the real #104 lock is the dist-level E2E test plus
+      // scripts/verify-dist-guard.mjs at build time.
       const origEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
 

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup && node ../../scripts/fix-dts.mjs dist",
+    "build": "tsup && node ../../scripts/fix-dts.mjs dist && node scripts/verify-dist-guard.mjs",
     "check": "tsc --noEmit",
     "clean": "rm -rf dist",
     "size": "NODE_PATH=./node_modules size-limit"

--- a/packages/widget/scripts/verify-dist-guard.mjs
+++ b/packages/widget/scripts/verify-dist-guard.mjs
@@ -46,11 +46,12 @@ for (const [label, files] of Object.entries(groups)) {
     errors.push(`${label}: no files found in dist/`);
     continue;
   }
+  // Both guards read through the single readNodeEnv() helper, so the literal
+  // appears at least once per bundle (more if the minifier inlines the helper).
   const occurrences = files.reduce((n, f) => n + (sources.get(f)?.split(LITERAL).length - 1 || 0), 0);
-  // 2 uses in source: the production guard and the test-env shadow-mode check
-  if (occurrences < 2) {
+  if (occurrences < 1) {
     errors.push(
-      `${label}: found ${occurrences} occurrence(s) of \`${LITERAL}\` (expected >= 2) — ` +
+      `${label}: \`${LITERAL}\` not found — ` +
         "the build folded the guard again; check the identity define in tsup.config.ts",
     );
   }

--- a/packages/widget/scripts/verify-dist-guard.mjs
+++ b/packages/widget/scripts/verify-dist-guard.mjs
@@ -1,0 +1,81 @@
+// Post-build invariants for the production guard (issue #104).
+//
+// The guard's whole value depends on a build artifact property no unit test
+// can see: the literal `process.env.NODE_ENV` must survive our own
+// esbuild/minify pass (identity define in tsup.config.ts) so that a
+// consumer's bundler can inline THEIR environment into it. This script fails
+// the build when either invariant breaks:
+//   1. every shipped bundle still contains the literal (our build didn't
+//      fold it — the exact regression that produced #104), and
+//   2. a simulated consumer production build CAN fold it (the literal is
+//      still in a define-replaceable position).
+import { readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+// esbuild is a transitive dep (via tsup) — hoisted installs expose it at the
+// root, isolated installs (bun) only next to tsup's real location.
+function resolveEsbuild() {
+  try {
+    return require("esbuild");
+  } catch {
+    return createRequire(require.resolve("tsup"))("esbuild");
+  }
+}
+const esbuild = resolveEsbuild();
+
+const distDir = new URL("../dist", import.meta.url).pathname;
+const LITERAL = "process.env.NODE_ENV";
+
+const jsFiles = readdirSync(distDir).filter((f) => f.endsWith(".js"));
+const sources = new Map(jsFiles.map((f) => [f, readFileSync(join(distDir, f), "utf8")]));
+
+// The IIFE bundle is self-contained; ESM entries may carry the launcher in a
+// shared chunk — check bundle *groups*, not individual files.
+const groups = {
+  "index.global.js (iife)": ["index.global.js"],
+  "index.js (+chunks)": jsFiles.filter((f) => f === "index.js" || f.startsWith("chunk-")),
+  "react.js (+chunks)": jsFiles.filter((f) => f === "react.js" || f.startsWith("chunk-")),
+};
+
+const errors = [];
+
+for (const [label, files] of Object.entries(groups)) {
+  if (files.length === 0) {
+    errors.push(`${label}: no files found in dist/`);
+    continue;
+  }
+  const occurrences = files.reduce((n, f) => n + (sources.get(f)?.split(LITERAL).length - 1 || 0), 0);
+  // 2 uses in source: the production guard and the test-env shadow-mode check
+  if (occurrences < 2) {
+    errors.push(
+      `${label}: found ${occurrences} occurrence(s) of \`${LITERAL}\` (expected >= 2) — ` +
+        "the build folded the guard again; check the identity define in tsup.config.ts",
+    );
+  }
+}
+
+// Simulate a consumer bundling the shipped IIFE for production: the define
+// must be able to replace the literal (otherwise "dev-only by default" is
+// dead for bundled deployments).
+const iife = sources.get("index.global.js");
+if (iife) {
+  const folded = await esbuild.transform(iife, {
+    minify: true,
+    define: { [LITERAL]: '"production"' },
+  });
+  if (folded.code.includes(LITERAL)) {
+    errors.push(
+      "index.global.js: a consumer production define left the literal in place — " +
+        "the guard is no longer in a define-replaceable position",
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error("[verify-dist-guard] FAILED:");
+  for (const e of errors) console.error(`  - ${e}`);
+  process.exit(1);
+}
+console.log(`[verify-dist-guard] OK — ${LITERAL} literal intact and consumer-replaceable in all bundles`);

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -71,6 +71,29 @@ function skippedInstance(): SitepingInstance {
   };
 }
 
+/**
+ * Read NODE_ENV at runtime without the literal member expression
+ * `process.env.NODE_ENV`.
+ *
+ * The tsup builds run esbuild with `platform: "browser"`, whose define
+ * statically replaces that exact literal expression at build time — any
+ * comparison against it gets constant-folded, so the shipped bundle would
+ * skip (or never skip) the widget regardless of the host's actual
+ * environment (issue #104). The computed key dodges the define so detection
+ * stays at runtime — which E2E also relies on: tests set
+ * `globalThis.process = { env: { NODE_ENV: 'test' } }` to get an open
+ * Shadow DOM.
+ */
+function readNodeEnv(): string | undefined {
+  try {
+    if (typeof process === "undefined") return undefined;
+    return process.env?.["NODE_" + "ENV"];
+  } catch {
+    // Restricted environments may throw on `process` access
+    return undefined;
+  }
+}
+
 interface NormalisedDeepLink {
   enabled: boolean;
   param: string;
@@ -100,6 +123,14 @@ function normaliseDeepLinkOptions(value: SitepingConfig["deepLink"]): Normalised
  * - Overlay, markers, tooltips live outside (appended to document.body)
  */
 export function launch(config: SitepingConfig): SitepingInstance {
+  // Guard: no DOM, no widget — SSR frameworks (Next.js, Remix) may run the
+  // init on the server. Deliberately NOT bypassed by forceShow: the widget
+  // cannot render without a document.
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    config.onSkip?.("ssr");
+    return skippedInstance();
+  }
+
   // Debug helper — only logs when config.debug is true
   const log: (...args: unknown[]) => void = config.debug
     ? (...args: unknown[]) => console.debug("[siteping]", ...args)
@@ -111,20 +142,15 @@ export function launch(config: SitepingConfig): SitepingInstance {
     return instance;
   }
 
-  // Guard: only show in development (forceShow bypasses)
-  if (!config.forceShow) {
-    try {
-      // Check for Node/bundler production environment — avoid import.meta
-      // which causes "Critical dependency" warnings in Next.js webpack builds
-      if (typeof process !== "undefined" && process.env?.NODE_ENV === "production") {
-        const reason = "production";
-        console.info("[siteping] Widget not loaded: production mode detected. Use forceShow: true to override.");
-        config.onSkip?.(reason);
-        return skippedInstance();
-      }
-    } catch {
-      // Silently ignore — browser or restricted environment
-    }
+  // Guard: only show in development (forceShow bypasses). Uses readNodeEnv()
+  // instead of the literal `process.env.NODE_ENV` — avoids both bundler
+  // constant-folding (#104) and "Critical dependency" import.meta warnings
+  // in Next.js webpack builds.
+  if (!config.forceShow && readNodeEnv() === "production") {
+    const reason = "production";
+    console.info("[siteping] Widget not loaded: production mode detected. Use forceShow: true to override.");
+    config.onSkip?.(reason);
+    return skippedInstance();
   }
 
   // Guard: desktop only (viewport below the threshold = hidden). forceShow
@@ -247,19 +273,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
   host.style.cssText = `position:fixed;z-index:${Z_INDEX_MAX};`;
   // Use open mode only for testing — closed in production for CSS isolation.
   // Shadow DOM mode is determined by environment, never by public config.
-  let isTestEnv = false;
-  try {
-    // Dynamic key prevents bundlers (tsup/esbuild) from statically replacing
-    // process.env.NODE_ENV at build time — the widget needs runtime detection
-    // so E2E tests can set globalThis.process = { env: { NODE_ENV: 'test' } }
-    const envKey = "NODE_" + "ENV";
-    if (typeof process !== "undefined" && process.env?.[envKey] === "test") {
-      isTestEnv = true;
-    }
-  } catch {
-    // Silently ignore — browser or restricted environment
-  }
-  const shadowMode = isTestEnv ? ("open" as const) : ("closed" as const);
+  const shadowMode = readNodeEnv() === "test" ? ("open" as const) : ("closed" as const);
   const shadow = host.attachShadow({ mode: shadowMode });
 
   // Inject styles into Shadow DOM — adoptedStyleSheets with fallback for Safari < 16.4

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -72,24 +72,31 @@ function skippedInstance(): SitepingInstance {
 }
 
 /**
- * Read NODE_ENV at runtime without the literal member expression
- * `process.env.NODE_ENV`.
+ * Read NODE_ENV so that BOTH detection paths keep working:
  *
- * The tsup builds run esbuild with `platform: "browser"`, whose define
- * statically replaces that exact literal expression at build time — any
- * comparison against it gets constant-folded, so the shipped bundle would
- * skip (or never skip) the widget regardless of the host's actual
- * environment (issue #104). The computed key dodges the define so detection
- * stays at runtime — which E2E also relies on: tests set
- * `globalThis.process = { env: { NODE_ENV: 'test' } }` to get an open
- * Shadow DOM.
+ * - The literal `process.env.NODE_ENV` member expression must survive into
+ *   our own dist — an identity define in tsup.config.ts stops esbuild's
+ *   browser-platform auto-define from folding it to `"production"` and
+ *   deleting the guard from the shipped bundle (issue #104).
+ * - Shipping the literal lets the CONSUMER's bundler (webpack DefinePlugin,
+ *   Vite, esbuild) inline their real environment, so "dev-only by default"
+ *   works in bundled deployments even when no `process` global exists at
+ *   runtime. Computed-key dodges (`env["NODE_" + "ENV"]`) would defeat that
+ *   inlining — do not reintroduce them.
+ * - No `typeof process` gate: it would return before a consumer-inlined
+ *   constant is reached. Plain browsers without `process` (script-tag usage)
+ *   land in the catch instead. Runtime environments with a real `process`
+ *   (Node/SSR, E2E's `globalThis.process = { env: { NODE_ENV: 'test' } }`)
+ *   read it live.
+ *
+ * `scripts/verify-dist-guard.mjs` asserts these invariants against every
+ * built bundle after each build.
  */
 function readNodeEnv(): string | undefined {
   try {
-    if (typeof process === "undefined") return undefined;
-    return process.env?.["NODE_" + "ENV"];
+    return process.env.NODE_ENV;
   } catch {
-    // Restricted environments may throw on `process` access
+    // No `process` global (plain browser) or restricted access — no signal
     return undefined;
   }
 }

--- a/packages/widget/tsup.config.ts
+++ b/packages/widget/tsup.config.ts
@@ -14,6 +14,15 @@ import { defineConfig } from "tsup";
 // to see in their dashboards.
 const pureCalls = ["console.debug", "console.info"] as const;
 
+// Identity define: pins `process.env.NODE_ENV` to itself so esbuild's
+// browser-platform auto-define cannot fold it to `"production"` at our build
+// (issue #104 — the fold used to delete the production guard from dist).
+// The literal survives into the shipped bundles, where the consumer's own
+// bundler (webpack DefinePlugin, Vite, esbuild) can inline THEIR environment;
+// plain browsers without `process` fall through via readNodeEnv's try/catch.
+// `scripts/verify-dist-guard.mjs` asserts this after every build.
+const keepNodeEnvLiteral = { "process.env.NODE_ENV": "process.env.NODE_ENV" } as const;
+
 export default defineConfig([
   {
     entry: ["src/index.ts"],
@@ -29,6 +38,7 @@ export default defineConfig([
     noExternal: ["@medv/finder", "@siteping/core"],
     esbuildOptions(o) {
       o.pure = [...pureCalls];
+      o.define = { ...o.define, ...keepNodeEnvLiteral };
     },
   },
   {
@@ -46,6 +56,7 @@ export default defineConfig([
     noExternal: ["@medv/finder", "@siteping/core"],
     esbuildOptions(o) {
       o.pure = [...pureCalls];
+      o.define = { ...o.define, ...keepNodeEnvLiteral };
     },
   },
   {
@@ -63,6 +74,7 @@ export default defineConfig([
     external: ["react"],
     esbuildOptions(o) {
       o.pure = [...pureCalls];
+      o.define = { ...o.define, ...keepNodeEnvLiteral };
     },
   },
 ]);


### PR DESCRIPTION
## Summary

Fixes #104 — but the root cause was not the one the issue guessed. The source has always checked `process.env.NODE_ENV === "production"`; **our own build destroyed it**: esbuild's browser-platform auto-define statically replaces the literal `process.env.NODE_ENV` under `platform: "browser"` + `minify: true`, constant-folding the comparison so the shipped dist contained only `typeof process !== "undefined"` — the widget no-opted with a misleading `onSkip("production")` in dev, SSR, and any browser where `process` is polyfilled (the reporter's Next.js case).

## What changed

- **Identity define** (`process.env.NODE_ENV` → itself) in all three tsup builds pins the literal into dist. Consequences:
  - our guard is no longer folded away (the #104 bug), and
  - the **consumer's** bundler (webpack DefinePlugin, Vite, esbuild) can now inline *their* environment — "dev-only by default" finally works for bundled deployments even without a runtime `process` global (verified empirically with esbuild: a downstream production define folds the guard to a reachable skip).
- `readNodeEnv()` reads the literal in a `try/catch` with **no `typeof process` gate** (a gate would return before a consumer-inlined constant is reached); plain browsers without `process` land in the catch. The shadow-mode test-env check reuses the same helper (previously it survived only via a `"NODE_" + "ENV"` computed-key trick, which also defeated consumer inlining).
- **New SSR guard** before any DOM access: `initSiteping()` on the server returns a no-op instance and fires `onSkip("ssr")` (new `SitepingSkipReason` member) instead of throwing `ReferenceError` — deliberately **not** bypassed by `forceShow`. Previously, SSR either threw (with `forceShow: true`, or in dev via `window.innerWidth`) or accidentally leaned on the broken guard.
- **`scripts/verify-dist-guard.mjs` runs after every widget build** and fails it if the literal is missing from any bundle or is no longer define-replaceable — the #104 regression can't ship silently again.
- **Dist-level E2E test**: the E2E server gained a `?noForceShow=1` variant (with a 500 if the strip ever misses) and a Playwright test asserting the real dist mounts the widget without `forceShow` when `NODE_ENV` is not production. Unit tests import source and could never catch this; the pre-existing E2E masked it with `forceShow: true`.
- README: documented how production detection actually works per deployment style (bundled apps / SSR / plain script tags).

## Behavior notes

- Next.js-style apps (polyfilled `process`) will start **showing the widget in dev** without `forceShow` — the broken dist never did.
- A throwing `onSkip` callback now propagates from the production guard (previously swallowed by a `try/catch` that also skipped the skip-return); this matches the mobile guard's existing behavior.
- Plain script-tag pages with no bundler and no `process` global have no environment signal and render the widget — same as the source semantics always intended; now documented.

## Verification

- Full vitest suite: 1861 passed. New: node-environment SSR tests (fail on the old code), NODE_ENV=development mount test.
- `verify-dist-guard` green on all three bundles (ESM, IIFE, react); consumer-define simulation folds the literal as intended.
- Playwright: full chromium suite 30/30 including the new dist-level test; the new test also verified on firefox. (WebKit not runnable on this WSL host — missing system libs; CI matrix arbitrates.)