### PR TITLE
fix(adapter-prisma): redact authorEmail and strip clientId from unauthenticated HTTP responses (fixes #105)

### DIFF
--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -177,11 +177,11 @@ When the upload fails (transient S3 outage etc.), the adapter persists `screensh
 
 ## Authentication
 
-GET and POST are publicly accessible by default (read + widget-side submit). DELETE and PATCH are gated:
+Without `apiKey`, GET and POST are publicly accessible (read + widget-side submit) and the destructive methods are gated:
 
 - **No `apiKey` in production (`NODE_ENV === "production"`)** — `createSitepingHandler` throws at startup. This is intentional: without it, anyone could `DELETE { deleteAll: true }` against your endpoint.
 - **No `apiKey` in dev** — DELETE and PATCH return `401 { error: "apiKey required for destructive operations" }`. GET/POST stay open so the widget keeps working locally.
-- **`apiKey` set** — DELETE/PATCH require `Authorization: Bearer <apiKey>`; GET/POST stay public unless you override `publicEndpoints`.
+- **`apiKey` set** — every method not listed in `publicEndpoints` (default: `["POST", "OPTIONS"]`) requires `Authorization: Bearer <apiKey>`. That means **GET, PATCH, and DELETE all return 401** without a valid token.
 
 ```ts
 export const { GET, POST, PATCH, DELETE, OPTIONS } = createSitepingHandler({
@@ -195,6 +195,19 @@ When `apiKey` is set:
 
 - **POST** and **OPTIONS** remain public (the browser widget needs to submit feedback and perform CORS preflight without authentication).
 - **GET**, **PATCH**, and **DELETE** require a `Bearer <apiKey>` token in the `Authorization` header.
+- Add methods to `publicEndpoints` to open them up — e.g. `publicEndpoints: ["POST", "OPTIONS", "GET"]` when the widget itself needs to read feedbacks without a key.
+
+### PII redaction
+
+Responses are redacted at the HTTP edge, based on whether the request carried a valid Bearer token:
+
+- Responses **never** include `clientId`. It is a browser-local dedup secret — the POST dedup path returns the full existing record to whoever presents a known `clientId`, so exposing it in responses would let anyone steal records.
+- **Unauthenticated** requests get `authorEmail: ""` on every returned feedback. This applies to GET without `apiKey`, GET with `"GET"` in `publicEndpoints` and no token, and PATCH reached without a token (`requireAuthForDestructive: false` setups).
+- **Authenticated** requests (valid `Authorization: Bearer <apiKey>`) get the full `authorEmail` — a valid token on a public method still counts as authenticated. Consumers that need emails (the dashboard, scripts) must send the key; the widget will be able to send it via its upcoming `apiKey`/`headers` config ([#100](https://github.com/NeosiaNexus/SitePing/issues/100)).
+- POST responses keep `authorEmail` intact — the requester supplied it (or proved ownership via `clientId` on the dedup path).
+- Outgoing webhooks are host-configured push targets and receive the full record.
+
+Redaction applies to **any store** mounted through `createSitepingHandler` (`MemoryStore` from `@siteping/adapter-memory` included). Client-side store mode (localStorage adapter, or passing a `store` directly to the widget/dashboard) is in-process — no HTTP boundary, no redaction.
 
 ### Escape hatch: `requireAuthForDestructive: false`
 

--- a/packages/adapter-prisma/README.md
+++ b/packages/adapter-prisma/README.md
@@ -203,11 +203,13 @@ Responses are redacted at the HTTP edge, based on whether the request carried a 
 
 - Responses **never** include `clientId`. It is a browser-local dedup secret — the POST dedup path returns the full existing record to whoever presents a known `clientId`, so exposing it in responses would let anyone steal records.
 - **Unauthenticated** requests get `authorEmail: ""` on every returned feedback. This applies to GET without `apiKey`, GET with `"GET"` in `publicEndpoints` and no token, and PATCH reached without a token (`requireAuthForDestructive: false` setups).
-- **Authenticated** requests (valid `Authorization: Bearer <apiKey>`) get the full `authorEmail` — a valid token on a public method still counts as authenticated. Consumers that need emails (the dashboard, scripts) must send the key; the widget will be able to send it via its upcoming `apiKey`/`headers` config ([#100](https://github.com/NeosiaNexus/SitePing/issues/100)).
+- **Authenticated** requests (valid `Authorization: Bearer <apiKey>`) get the full `authorEmail` — a valid token on a public method still counts as authenticated. Consumers that need emails must send the key: the dashboard via its `apiKey`/`headers` props, the widget via its config options of the same names ([#100](https://github.com/NeosiaNexus/SitePing/issues/100)).
 - POST responses keep `authorEmail` intact — the requester supplied it (or proved ownership via `clientId` on the dedup path).
 - Outgoing webhooks are host-configured push targets and receive the full record.
 
 Redaction applies to **any store** mounted through `createSitepingHandler` (`MemoryStore` from `@siteping/adapter-memory` included). Client-side store mode (localStorage adapter, or passing a `store` directly to the widget/dashboard) is in-process — no HTTP boundary, no redaction.
+
+If the handler sits behind your **own auth layer that also covers GET**, you can opt out of the email redaction with `redactUnauthenticatedEmails: false` — the handler cannot see your middleware, so only set it when every route to the endpoint is authenticated (or you accept exposing reviewer emails). `clientId` stays stripped regardless.
 
 ### Escape hatch: `requireAuthForDestructive: false`
 
@@ -215,6 +217,8 @@ If SitePing sits behind your own session-based / OAuth middleware and you want d
 
 ```ts
 // Only safe when an upstream middleware authenticates DELETE/PATCH.
+// Add redactUnauthenticatedEmails: false only if that middleware covers GET
+// too — otherwise responses keep authorEmail blank for tokenless requests.
 createSitepingHandler({ prisma, requireAuthForDestructive: false })
 ```
 

--- a/packages/adapter-prisma/__tests__/auth-cors.test.ts
+++ b/packages/adapter-prisma/__tests__/auth-cors.test.ts
@@ -286,6 +286,45 @@ describe("Authentication", () => {
       const body = await res.json();
       expect(body.feedbacks[0].authorEmail).toBe("alice@example.com");
     });
+
+    it("multi-byte Authorization header of matching char length is rejected, not a 500", async () => {
+      // "é" makes char length equal to `Bearer ${API_KEY}` but byte length
+      // differ — timingSafeEqual would throw on the byte mismatch, turning an
+      // attacker-controlled header into a 500 (and an apiKey length oracle).
+      seedFindMany();
+      const wrongKey = `${API_KEY.slice(0, -1)}é`;
+      const handler = createSitepingHandler({
+        prisma,
+        apiKey: API_KEY,
+        publicEndpoints: ["POST", "OPTIONS", "GET"],
+      });
+      const res = await handler.GET(getRequest("projectName=test-project", { Authorization: `Bearer ${wrongKey}` }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks[0].authorEmail).toBe("");
+
+      // On a protected method the same header must yield 401, not 500
+      const protectedHandler = createSitepingHandler({ prisma, apiKey: API_KEY });
+      const res401 = await protectedHandler.GET(
+        getRequest("projectName=test-project", { Authorization: `Bearer ${wrongKey}` }),
+      );
+      expect(res401.status).toBe(401);
+    });
+
+    it("redactUnauthenticatedEmails: false keeps authorEmail for unauthenticated requests", async () => {
+      seedFindMany();
+      const handler = createSitepingHandler({
+        prisma,
+        requireAuthForDestructive: false,
+        redactUnauthenticatedEmails: false,
+      });
+      const res = await handler.GET(getRequest("projectName=test-project"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks[0].authorEmail).toBe("alice@example.com");
+      // clientId stays stripped regardless of the opt-out
+      expect("clientId" in body.feedbacks[0]).toBe(false);
+    });
   });
 
   describe("startup guard in production", () => {

--- a/packages/adapter-prisma/__tests__/auth-cors.test.ts
+++ b/packages/adapter-prisma/__tests__/auth-cors.test.ts
@@ -234,6 +234,60 @@ describe("Authentication", () => {
     });
   });
 
+  describe("PII redaction follows Bearer authentication (#105)", () => {
+    function seedFindMany() {
+      prisma.sitepingFeedback.findMany.mockResolvedValue([
+        {
+          id: "fb-1",
+          ...validPayloadNoAnnotations,
+          status: "open",
+          resolvedAt: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          annotations: [],
+        },
+      ]);
+      prisma.sitepingFeedback.count.mockResolvedValue(1);
+    }
+
+    it("GET with valid Bearer returns the full authorEmail (clientId still stripped)", async () => {
+      seedFindMany();
+      const handler = createSitepingHandler({ prisma, apiKey: API_KEY });
+      const res = await handler.GET(getRequest("projectName=test-project", { Authorization: `Bearer ${API_KEY}` }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks[0].authorEmail).toBe("alice@example.com");
+      expect("clientId" in body.feedbacks[0]).toBe(false);
+    });
+
+    it("public GET (via publicEndpoints) without a token blanks authorEmail", async () => {
+      seedFindMany();
+      const handler = createSitepingHandler({
+        prisma,
+        apiKey: API_KEY,
+        publicEndpoints: ["POST", "OPTIONS", "GET"],
+      });
+      const res = await handler.GET(getRequest("projectName=test-project"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks[0].authorEmail).toBe("");
+      expect("clientId" in body.feedbacks[0]).toBe(false);
+    });
+
+    it("public GET with a valid Bearer still counts as authenticated — full authorEmail", async () => {
+      seedFindMany();
+      const handler = createSitepingHandler({
+        prisma,
+        apiKey: API_KEY,
+        publicEndpoints: ["POST", "OPTIONS", "GET"],
+      });
+      const res = await handler.GET(getRequest("projectName=test-project", { Authorization: `Bearer ${API_KEY}` }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks[0].authorEmail).toBe("alice@example.com");
+    });
+  });
+
   describe("startup guard in production", () => {
     const originalEnv = process.env.NODE_ENV;
 

--- a/packages/adapter-prisma/__tests__/handler.test.ts
+++ b/packages/adapter-prisma/__tests__/handler.test.ts
@@ -595,4 +595,78 @@ describe("createSitepingHandler", () => {
       consoleSpy.mockRestore();
     });
   });
+
+  // clientId is a browser-local dedup secret and authorEmail is PII — the
+  // handler strips/redacts them at the HTTP edge (#105); stores stay raw.
+  describe("response redaction", () => {
+    function feedbackRow(overrides: Record<string, unknown> = {}) {
+      return {
+        id: "fb-1",
+        ...validPayloadNoAnnotations,
+        status: "open",
+        resolvedAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        annotations: [],
+        ...overrides,
+      };
+    }
+
+    it("GET without apiKey blanks authorEmail and strips clientId on every feedback", async () => {
+      prisma.sitepingFeedback.findMany.mockResolvedValue([
+        feedbackRow(),
+        feedbackRow({ id: "fb-2", clientId: "uuid-456", authorEmail: "bob@example.com" }),
+      ]);
+      prisma.sitepingFeedback.count.mockResolvedValue(2);
+      const res = await handler.GET(new Request("http://localhost/api/siteping?projectName=test-project"));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.feedbacks).toHaveLength(2);
+      for (const row of body.feedbacks) {
+        expect(row.authorEmail).toBe("");
+        expect("clientId" in row).toBe(false);
+      }
+    });
+
+    it("POST 201 strips clientId but keeps the submitter's own authorEmail", async () => {
+      const req = new Request("http://localhost/api/siteping", {
+        method: "POST",
+        body: JSON.stringify(validPayloadNoAnnotations),
+      });
+      const res = await handler.POST(req);
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect("clientId" in body).toBe(false);
+      expect(body.authorEmail).toBe("alice@example.com");
+    });
+
+    it("POST dedup response strips clientId (no record-theft oracle) and keeps authorEmail", async () => {
+      prisma.sitepingFeedback.create.mockRejectedValue({ code: "P2002" });
+      prisma.sitepingFeedback.findUnique.mockResolvedValue(feedbackRow());
+      const req = new Request("http://localhost/api/siteping", {
+        method: "POST",
+        body: JSON.stringify(validPayloadNoAnnotations),
+      });
+      const res = await handler.POST(req);
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect("clientId" in body).toBe(false);
+      expect(body.authorEmail).toBe("alice@example.com");
+    });
+
+    it("unauthenticated PATCH blanks authorEmail and strips clientId", async () => {
+      // handler has requireAuthForDestructive: false and no apiKey → PATCH is reachable unauthenticated
+      prisma.sitepingFeedback.findUnique.mockResolvedValue({ id: "fb-1", projectName: "test-project" });
+      prisma.sitepingFeedback.update.mockResolvedValue(feedbackRow({ status: "resolved" }));
+      const req = new Request("http://localhost/api/siteping", {
+        method: "PATCH",
+        body: JSON.stringify({ id: "fb-1", projectName: "test-project", status: "resolved" }),
+      });
+      const res = await handler.PATCH(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.authorEmail).toBe("");
+      expect("clientId" in body).toBe(false);
+    });
+  });
 });

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -471,6 +471,19 @@ export interface HandlerOptions {
    */
   requireAuthForDestructive?: boolean;
   /**
+   * Blank `authorEmail` in GET/PATCH responses to requests that do not carry
+   * a valid `Authorization: Bearer <apiKey>` header. Defaults to `true`:
+   * reviewer emails are PII and the widget needs GET to be reachable, so an
+   * unauthenticated response must not enumerate them (issue #105).
+   *
+   * Set to `false` ONLY when the handler sits behind your own auth layer
+   * that covers GET as well (e.g. `requireAuthForDestructive: false` behind
+   * session middleware) — the handler cannot see that layer, and without it
+   * every visitor who can reach the endpoint can read reviewer emails.
+   * `clientId` is stripped from responses regardless of this option.
+   */
+  redactUnauthenticatedEmails?: boolean;
+  /**
    * Outgoing webhooks fired after a feedback is successfully persisted.
    *
    * Pass a single config or an array — every entry receives a POST with a
@@ -540,10 +553,17 @@ function withCors(response: Response, corsHeaders: CorsHeaders): Response {
  * Perform a constant-time string comparison to prevent timing attacks on API key validation.
  * Returns `false` immediately when lengths differ (unavoidable length leak), but the
  * byte-level comparison itself is timing-safe.
+ *
+ * Length must be compared in BYTES: `timingSafeEqual` throws on byte-length
+ * mismatch, and multi-byte characters make equal `.length` strings differ in
+ * bytes — an attacker-controlled `Authorization` header must never turn that
+ * into a 500.
  */
 function safeCompare(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
 }
 
 /**
@@ -598,6 +618,7 @@ export function createSitepingHandler({
   allowedOrigins,
   caseInsensitiveSearch,
   requireAuthForDestructive = true,
+  redactUnauthenticatedEmails = true,
   webhooks,
 }: HandlerOptions): SitepingHandler {
   if (!providedStore && !prisma) {
@@ -641,6 +662,11 @@ export function createSitepingHandler({
     if (!apiKey) return false;
     const header = request.headers.get("Authorization");
     return header !== null && safeCompare(header, `Bearer ${apiKey}`);
+  }
+
+  /** Whether this request may see `authorEmail` (see `redactUnauthenticatedEmails`). */
+  function emailPermitted(request: Request): boolean {
+    return !redactUnauthenticatedEmails || isBearerAuthenticated(request);
   }
 
   /** Verify Bearer token when apiKey is configured. Skips methods listed in `publicEndpoints`. */
@@ -764,7 +790,7 @@ export function createSitepingHandler({
       try {
         // GET can be public (no apiKey, or "GET" in publicEndpoints for widget
         // hosts) — redact author emails unless the requester sent the key.
-        const authed = isBearerAuthenticated(request);
+        const authed = emailPermitted(request);
         const result = await store.getFeedbacks(parsed.data);
         const body = { ...result, feedbacks: result.feedbacks.map((f) => toWireFeedback(f, authed)) };
         return withCors(Response.json(body, { headers: { "Cache-Control": "private, max-age=5" } }), corsHeaders);
@@ -812,7 +838,7 @@ export function createSitepingHandler({
 
         // PATCH can be made public via publicEndpoints / requireAuthForDestructive:
         // false — don't leak the author's email through the update response.
-        return withCors(Response.json(toWireFeedback(feedback, isBearerAuthenticated(request))), corsHeaders);
+        return withCors(Response.json(toWireFeedback(feedback, emailPermitted(request))), corsHeaders);
       } catch (error) {
         if (isStoreNotFound(error)) {
           return withCors(Response.json({ error: "Feedback not found" }, { status: 404 }), corsHeaders);

--- a/packages/adapter-prisma/src/index.ts
+++ b/packages/adapter-prisma/src/index.ts
@@ -547,6 +547,21 @@ function safeCompare(a: string, b: string): boolean {
 }
 
 /**
+ * Serialize a feedback record for the HTTP wire (edge DTO — stores return raw
+ * records, redaction happens here).
+ *
+ * `clientId` is always stripped: it is a browser-local dedup secret, and the
+ * POST dedup path returns the full existing record for whoever presents it —
+ * exposing it via responses would turn that into a record-theft oracle.
+ * `authorEmail` is PII: blanked unless the requester is Bearer-authenticated.
+ * Never mutates the input — webhooks receive the same record object.
+ */
+function toWireFeedback(feedback: FeedbackRecord, includeEmail: boolean): Omit<FeedbackRecord, "clientId"> {
+  const { clientId: _clientId, ...wire } = feedback;
+  return includeEmail ? wire : { ...wire, authorEmail: "" };
+}
+
+/**
  * Create request handlers for the Siteping API endpoint.
  *
  * Accepts either a `store` (abstract) or a `prisma` client (backwards compatible).
@@ -617,6 +632,17 @@ export function createSitepingHandler({
       : [webhooks as WebhookConfig]
     : [];
 
+  /**
+   * True iff `apiKey` is configured AND the request carries a matching Bearer
+   * token. Distinct from `authenticate`: a valid token on a public method still
+   * counts as authenticated here (drives PII redaction, not access control).
+   */
+  function isBearerAuthenticated(request: Request): boolean {
+    if (!apiKey) return false;
+    const header = request.headers.get("Authorization");
+    return header !== null && safeCompare(header, `Bearer ${apiKey}`);
+  }
+
   /** Verify Bearer token when apiKey is configured. Skips methods listed in `publicEndpoints`. */
   function authenticate(request: Request, method: SitepingHttpMethod): Response | null {
     if (!apiKey) {
@@ -628,8 +654,7 @@ export function createSitepingHandler({
       return null;
     }
     if (publicMethods?.has(method)) return null;
-    const header = request.headers.get("Authorization");
-    if (!header || !safeCompare(header, `Bearer ${apiKey}`)) {
+    if (!isBearerAuthenticated(request)) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
     return null;
@@ -693,12 +718,14 @@ export function createSitepingHandler({
           void dispatchWebhooks(webhookList, feedback);
         }
 
-        return withCors(Response.json(feedback, { status: 201 }), corsHeaders);
+        // Email stays intact on POST responses: the requester supplied it.
+        return withCors(Response.json(toWireFeedback(feedback, true), { status: 201 }), corsHeaders);
       } catch (error) {
-        // Handle unique constraint violation (clientId dedup)
+        // Handle unique constraint violation (clientId dedup) — presenting the
+        // clientId proves ownership of the record, so the email stays intact.
         if (isStoreDuplicate(error)) {
           const existing = await store.findByClientId(data.clientId);
-          if (existing) return withCors(Response.json(existing, { status: 201 }), corsHeaders);
+          if (existing) return withCors(Response.json(toWireFeedback(existing, true), { status: 201 }), corsHeaders);
         }
 
         const message = actionableErrorMessage(error);
@@ -735,8 +762,12 @@ export function createSitepingHandler({
       }
 
       try {
+        // GET can be public (no apiKey, or "GET" in publicEndpoints for widget
+        // hosts) — redact author emails unless the requester sent the key.
+        const authed = isBearerAuthenticated(request);
         const result = await store.getFeedbacks(parsed.data);
-        return withCors(Response.json(result, { headers: { "Cache-Control": "private, max-age=5" } }), corsHeaders);
+        const body = { ...result, feedbacks: result.feedbacks.map((f) => toWireFeedback(f, authed)) };
+        return withCors(Response.json(body, { headers: { "Cache-Control": "private, max-age=5" } }), corsHeaders);
       } catch (error) {
         const message = actionableErrorMessage(error);
         console.error("[siteping] Failed to fetch feedbacks:", error);
@@ -779,7 +810,9 @@ export function createSitepingHandler({
           resolvedAt: isClosedStatus(parsed.data.status) ? new Date() : null,
         });
 
-        return withCors(Response.json(feedback), corsHeaders);
+        // PATCH can be made public via publicEndpoints / requireAuthForDestructive:
+        // false — don't leak the author's email through the update response.
+        return withCors(Response.json(toWireFeedback(feedback, isBearerAuthenticated(request))), corsHeaders);
       } catch (error) {
         if (isStoreNotFound(error)) {
           return withCors(Response.json({ error: "Feedback not found" }, { status: 404 }), corsHeaders);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -841,6 +841,10 @@ export interface FeedbackResponse {
   viewport: string;
   userAgent: string;
   authorName: string;
+  /**
+   * May be an empty string — HTTP adapters redact it for unauthenticated
+   * requests. The full value requires a Bearer-authenticated request.
+   */
   authorEmail: string;
   resolvedAt: string | null;
   createdAt: string;

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -186,7 +186,7 @@ In endpoint mode the inbox reads and mutates through your adapter route, which s
 <SitepingInbox endpoint="/api/siteping" projects="my-project" apiKey={process.env.NEXT_PUBLIC_SITEPING_KEY} />
 ```
 
-`apiKey` becomes `Authorization: Bearer <apiKey>` on every request. For cookie/session auth or custom schemes, use `headers` — it also accepts an async function, handy for refreshing tokens. The inbox is an **admin surface**: gate the page it renders on, and remember the widget's own submissions stay unauthenticated unless your adapter requires a key.
+`apiKey` becomes `Authorization: Bearer <apiKey>` on every request. For cookie/session auth or custom schemes, use `headers` — it also accepts an async function, handy for refreshing tokens. The inbox is an **admin surface**: gate the page it renders on, and remember the widget's own submissions stay unauthenticated unless your adapter requires a key. Without authentication the adapter redacts reviewer emails (`authorEmail: ""`) — see [`@siteping/adapter-prisma` › PII redaction](https://www.npmjs.com/package/@siteping/adapter-prisma#pii-redaction).
 
 > **Counts queries** — the status tab counts are fetched as five extra `limit=1` queries (one per status + all) after each list load. They are cheap `COUNT` queries for SQL adapters, but if your endpoint is rate-limited, budget for them.
 

--- a/packages/dashboard/__tests__/unit/drawer.test.tsx
+++ b/packages/dashboard/__tests__/unit/drawer.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Drawer } from "../../src/components/drawer.js";
+import { makeRecord } from "../helpers.js";
+import { renderWithUi } from "../render.js";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderDrawer(recordOverrides = {}) {
+  const record = makeRecord(recordOverrides);
+  const { container } = renderWithUi(
+    <Drawer
+      record={record}
+      overlay={false}
+      deepLinkParam="siteping"
+      onClose={vi.fn()}
+      onChangeStatus={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+  return { record, container };
+}
+
+describe("Drawer — author line", () => {
+  it("renders the author email in angle brackets when present", () => {
+    const { container } = renderDrawer({ authorName: "Alex Client", authorEmail: "alex@client.example" });
+    const author = container.querySelector(".spd-meta-value");
+    expect(author?.textContent).toContain("Alex Client");
+    expect(author?.textContent).toContain("<alex@client.example>");
+  });
+
+  it("renders no empty '<>' shell when authorEmail is redacted to an empty string", () => {
+    const { container } = renderDrawer({ authorName: "Alex Client", authorEmail: "" });
+    const author = container.querySelector(".spd-meta-value");
+    expect(author?.textContent).toContain("Alex Client");
+    expect(author?.textContent).not.toContain("<>");
+  });
+});

--- a/packages/dashboard/src/components/drawer.tsx
+++ b/packages/dashboard/src/components/drawer.tsx
@@ -129,7 +129,14 @@ export function Drawer({
           <dl className="spd-meta-grid">
             <dt className="spd-meta-label">{t("drawer.author")}</dt>
             <dd className="spd-meta-value">
-              {record.authorName} <span data-mono>&lt;{record.authorEmail}&gt;</span>
+              {/* Empty email = redacted by the adapter (unauthenticated request) — skip the <> shell. */}
+              {record.authorEmail ? (
+                <>
+                  {record.authorName} <span data-mono>&lt;{record.authorEmail}&gt;</span>
+                </>
+              ) : (
+                record.authorName
+              )}
             </dd>
             <dt className="spd-meta-label">{t("drawer.page")}</dt>
             <dd className="spd-meta-value" data-mono>


### PR DESCRIPTION
## Summary

Fixes #105. `GET /api/siteping` returned raw store records — `authorEmail` for every reviewer, plus `clientId`, which the `FeedbackResponse` type claims is omitted. Anyone knowing the endpoint + `projectName` could enumerate reviewer emails, and a leaked `clientId` could pull the full record back through the public POST dedup path (record-theft oracle).

## What changed

All at the HTTP edge (stores stay raw, per the project convention):

- **`toWireFeedback` edge DTO**: `clientId` is stripped from every feedback response (GET/POST/PATCH) unconditionally — the wire now matches `FeedbackResponse`, and the dedup oracle is closed. `authorEmail` is blanked (`""`) unless the request is authenticated.
- **`isBearerAuthenticated`** (distinct from access control): a valid `Bearer` on a *public* method still counts as authenticated — an apiKey-holding dashboard keeps full emails even with `"GET"` in `publicEndpoints`. `authenticate()` refactored to reuse it with identical 401 semantics.
- **POST responses keep the email** — the requester supplied it (create), or proved ownership via `clientId` (dedup).
- **`safeCompare` byte-length fix**: it compared char lengths but `timingSafeEqual` requires byte equality — a multi-byte `Authorization` header of matching char length threw, turning attacker-controlled input into a 500 (an apiKey length oracle, and on PATCH it fired *after* the DB write). Buffers are compared by byte length now.
- **`redactUnauthenticatedEmails: false` opt-out** for deployments whose own auth layer covers GET (the documented `requireAuthForDestructive: false` middleware setup) — without it those hosts would lose emails with no recourse. Default remains `true` (secure by default). `clientId` stays stripped regardless.
- **Dashboard**: the drawer no longer renders an empty `<>` shell when the email is redacted.
- **Docs**: the adapter's Authentication section was internally contradictory (claimed GET stays public when `apiKey` is set — the code default is `publicEndpoints: ["POST", "OPTIONS"]`); rewritten, with a new PII-redaction section.

## Behavior change (release-note worthy)

Deployments **without** `apiKey` (or with `"GET"` public) now receive `authorEmail: ""` on GET/PATCH — this is the fix, but it is visible: dashboards need the `apiKey` prop (or `redactUnauthenticatedEmails: false` behind their own auth) to see reviewer emails again. The widget can send the key via its new `apiKey`/`headers` config (#100). Residual note: `clientId`s leaked by responses *before* this release remain usable against the POST dedup path; rotating them requires clearing reviewers' local widget state.

BEGIN_NESTED_COMMIT
fix(dashboard): skip the empty author-email shell when the adapter redacts it
END_NESTED_COMMIT

## Verification

- Full vitest suite: 1869 passed. New coverage: GET/POST/PATCH response-body redaction (none existed), Bearer-on-public-method passthrough, multi-byte Authorization (200-redacted / 401, never 500), `redactUnauthenticatedEmails: false` passthrough, dashboard drawer with and without email.
- All pre-existing auth/CORS tests pass unchanged (401 semantics untouched).