### PR TITLE
feat(widget): apiKey and headers config options for authenticated HTTP mode (fixes #100)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export type {
   ScreenshotRegion,
   SitepingConfig,
   SitepingDeepLinkOptions,
+  SitepingHeadersOption,
   SitepingIdentity,
   SitepingInstance,
   SitepingLocale,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,10 +44,42 @@ export interface SitepingDeepLinkOptions {
   param?: string;
 }
 
+/**
+ * Extra request headers for HTTP mode — a static map, or a factory (sync or
+ * async) invoked once per request to produce fresh values (e.g. a short-lived
+ * session token).
+ */
+export type SitepingHeadersOption =
+  | Record<string, string>
+  | (() => Record<string, string> | Promise<Record<string, string>>);
+
 /** Configuration options for the Siteping widget. */
 export interface SitepingConfig {
   /** HTTP endpoint that receives feedbacks (e.g. '/api/siteping'). Required unless `store` is provided. */
   endpoint?: string | undefined;
+  /**
+   * Convenience auth for HTTP mode — sent as `Authorization: Bearer <apiKey>`
+   * on every request to `endpoint`.
+   *
+   * **WARNING: the widget runs in every visitor's browser, so a static key
+   * configured here is public** — anyone can read it from your page source
+   * and replay it against your API. Only use `apiKey` for internal tools
+   * already behind your own login. On public sites, prefer `headers` with a
+   * per-request factory returning a short-lived session token.
+   *
+   * Ignored in store mode.
+   */
+  apiKey?: string | undefined;
+  /**
+   * Extra headers for every HTTP-mode request — a static map, or a factory
+   * (sync or async) called once per request (e.g. to fetch a fresh session
+   * token). Merged over the widget's generated headers, so an explicit
+   * `Authorization` entry overrides `apiKey`. A throwing/rejecting factory
+   * fails the request like a network error.
+   *
+   * Ignored in store mode.
+   */
+  headers?: SitepingHeadersOption | undefined;
   /** Required — project identifier used to scope feedbacks */
   projectName: string;
   /** Direct store for client-side mode. When set, bypasses HTTP and uses the store directly in the browser. */

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -148,6 +148,11 @@ initSiteping({
 
 Queued offline feedbacks never store headers — auth is re-computed when the queue is flushed on the next page load.
 
+Two constraints to know:
+
+- **Values are read at init.** Changing `apiKey` or swapping the `headers` value after `initSiteping()` has run has no effect until you destroy and re-init. The `headers` **callback** is the escape hatch: it's invoked on every request, so read rotating tokens from a ref or module variable inside it rather than closing over React state.
+- **Cross-origin:** adapter-prisma's CORS preflight allows the `Content-Type` and `Authorization` headers only. Put credentials in `Authorization` (not a custom header name), or keep the endpoint same-origin.
+
 ## Return value API
 
 `initSiteping()` returns a `SitepingInstance` with the following methods:

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -68,6 +68,8 @@ All configuration options for `initSiteping()`:
 |--------|------|---------|-------------|
 | `endpoint` | `string` | — | Your API route (e.g. `/api/siteping`). Required unless `store` is provided |
 | `store` | `SitepingStore` | — | Direct store for client-side mode. When set, bypasses HTTP |
+| `apiKey` | `string` | — | Sent as `Authorization: Bearer <apiKey>` on every HTTP request. **Visible to every visitor** — see [Authentication](#authentication) before using it on a public site. Ignored in store mode |
+| `headers` | `Record<string, string>` or `() => headers` (sync or async) | — | Extra HTTP request headers, static or computed per request (e.g. a short-lived session token). An explicit `Authorization` entry overrides `apiKey`. Ignored in store mode |
 | `projectName` | `string` | — | **Required.** Scopes feedbacks to this project |
 | `position` | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Widget FAB position |
 | `accentColor` | `string` | `'#0066ff'` | Widget accent color — hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`) |
@@ -114,6 +116,37 @@ initSiteping({
   onSkip: (reason) => {},
 })
 ```
+
+### Authentication
+
+With the default [`@siteping/adapter-prisma`](https://www.npmjs.com/package/@siteping/adapter-prisma) handlers and an `apiKey` configured server-side, **POST** and **OPTIONS** stay public — anonymous visitors can keep submitting feedback with zero widget config — while **GET**, **PATCH**, and **DELETE** require `Authorization: Bearer <apiKey>`. Without auth, the widget can submit but cannot list markers, resolve, or delete. See the [adapter-prisma Authentication docs](https://www.npmjs.com/package/@siteping/adapter-prisma#authentication) for the server-side setup.
+
+For **internal tools already behind your own login**, a static key is fine:
+
+```ts
+initSiteping({
+  endpoint: '/api/siteping',
+  projectName: 'my-project',
+  apiKey: process.env.NEXT_PUBLIC_SITEPING_KEY, // shipped to the browser!
+})
+```
+
+> **⚠️ The widget runs in every visitor's browser.** Anything you put in `apiKey` (or static `headers`) is readable in your page source and grants GET/PATCH/DELETE on your feedback API. Never ship a static key on a public site.
+
+For **public sites**, use the `headers` callback to send a short-lived token minted by your backend for the signed-in reviewer. It runs once per request (sync or async), and an explicit `Authorization` entry overrides `apiKey`:
+
+```ts
+initSiteping({
+  endpoint: '/api/siteping',
+  projectName: 'my-project',
+  headers: async () => {
+    const { token } = await fetch('/api/siteping-token').then((r) => r.json())
+    return { Authorization: `Bearer ${token}` }
+  },
+})
+```
+
+Queued offline feedbacks never store headers — auth is re-computed when the queue is flushed on the next page load.
 
 ## Return value API
 

--- a/packages/widget/__tests__/widget/api-client.test.ts
+++ b/packages/widget/__tests__/widget/api-client.test.ts
@@ -503,6 +503,155 @@ describe("ApiClient", () => {
 });
 
 // ---------------------------------------------------------------------------
+// auth & headers — mirrors the dashboard's createEndpointSource semantics
+// ---------------------------------------------------------------------------
+
+describe("ApiClient — auth & headers", () => {
+  const endpoint = "http://localhost/api/siteping";
+
+  const payload = {
+    projectName: "test",
+    type: "bug" as const,
+    message: "x",
+    url: "https://x.com",
+    viewport: "1x1",
+    userAgent: "t",
+    authorName: "A",
+    authorEmail: "a@b.com",
+    annotations: [],
+    clientId: "u",
+  };
+
+  beforeEach(() => {
+    // Fresh Response per call — some tests fire two requests and a Response
+    // body can only be consumed once.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response("{}", { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function lastInit(): RequestInit {
+    return vi.mocked(fetch).mock.calls.at(-1)?.[1] as RequestInit;
+  }
+
+  function lastHeaders(): Record<string, string> {
+    return lastInit().headers as Record<string, string>;
+  }
+
+  it("adds Authorization: Bearer from apiKey on POST (alongside Content-Type)", async () => {
+    const client = new ApiClient(endpoint, "test", { apiKey: "secret-key" });
+    await client.sendFeedback(payload);
+    expect(lastHeaders()).toEqual({ "Content-Type": "application/json", Authorization: "Bearer secret-key" });
+  });
+
+  it("adds Authorization: Bearer from apiKey on GET without a Content-Type", async () => {
+    const client = new ApiClient(endpoint, "test", { apiKey: "secret-key" });
+    await client.getFeedbacks("test");
+    expect(lastHeaders()).toEqual({ Authorization: "Bearer secret-key" });
+  });
+
+  it("adds Authorization: Bearer from apiKey on PATCH and both DELETEs", async () => {
+    const client = new ApiClient(endpoint, "test", { apiKey: "secret-key" });
+
+    await client.resolveFeedback("fb-1", true);
+    expect(lastHeaders()).toEqual({ "Content-Type": "application/json", Authorization: "Bearer secret-key" });
+
+    await client.deleteFeedback("fb-1");
+    expect(lastHeaders()).toEqual({ "Content-Type": "application/json", Authorization: "Bearer secret-key" });
+
+    await client.deleteAllFeedbacks("test");
+    expect(lastHeaders()).toEqual({ "Content-Type": "application/json", Authorization: "Bearer secret-key" });
+  });
+
+  it("merges a static headers object", async () => {
+    const client = new ApiClient(endpoint, "test", { headers: { "X-Team": "acme" } });
+    await client.getFeedbacks("test");
+    expect(lastHeaders()).toEqual({ "X-Team": "acme" });
+  });
+
+  it("supports a sync headers function", async () => {
+    const client = new ApiClient(endpoint, "test", { headers: () => ({ "X-Sync": "1" }) });
+    await client.getFeedbacks("test");
+    expect(lastHeaders()["X-Sync"]).toBe("1");
+  });
+
+  it("calls an async headers function once per request (fresh token per call)", async () => {
+    const headers = vi.fn(async () => ({ Authorization: "Bearer async-token" }));
+    const client = new ApiClient(endpoint, "test", { headers });
+
+    await client.getFeedbacks("test");
+    await client.resolveFeedback("fb-1", true);
+
+    expect(headers).toHaveBeenCalledTimes(2);
+    expect(lastHeaders().Authorization).toBe("Bearer async-token");
+  });
+
+  it("lets an explicit Authorization header override apiKey", async () => {
+    const client = new ApiClient(endpoint, "test", {
+      apiKey: "from-api-key",
+      headers: { Authorization: "Bearer from-headers" },
+    });
+    await client.getFeedbacks("test");
+    expect(lastHeaders().Authorization).toBe("Bearer from-headers");
+  });
+
+  it("fails the request like a network error when the headers factory throws", async () => {
+    const client = new ApiClient(endpoint, "test", {
+      headers: () => {
+        throw new Error("token fetch failed");
+      },
+    });
+    const err = await client.getFeedbacks("test").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(SitepingNetworkError);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the legacy no-headers GET wire shape when no auth is configured", async () => {
+    const client = new ApiClient(endpoint, "test");
+    await client.getFeedbacks("test");
+    expect("headers" in lastInit()).toBe(false);
+  });
+
+  it("does not attach an empty extra-headers object to GET", async () => {
+    const client = new ApiClient(endpoint, "test", { headers: {} });
+    await client.getFeedbacks("test");
+    expect("headers" in lastInit()).toBe(false);
+  });
+
+  it("never persists auth material into the localStorage retry queue", async () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    });
+    vi.mocked(fetch).mockResolvedValue(new Response("Bad Request", { status: 400 }));
+
+    const client = new ApiClient(endpoint, "test", {
+      apiKey: "super-secret",
+      headers: () => ({ "X-Session": "token-material" }),
+    });
+    await expect(client.sendFeedback(payload)).rejects.toThrow();
+
+    // Let the fire-and-forget queue write (behind the Web Lock) settle.
+    await vi.waitFor(() => {
+      const raw = store.get("siteping_retry_queue");
+      expect(raw).toBeDefined();
+      const queue = JSON.parse(raw!) as Array<Record<string, unknown>>;
+      expect(queue).toEqual([{ endpoint, payload }]);
+      expect(raw).not.toContain("Authorization");
+      expect(raw).not.toContain("super-secret");
+      expect(raw).not.toContain("token-material");
+    });
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // flushRetryQueue
 // ---------------------------------------------------------------------------
 
@@ -563,6 +712,37 @@ describe("flushRetryQueue", () => {
     await flushRetryQueue(endpoint);
 
     expect(fetch).toHaveBeenCalledTimes(1);
+    expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
+  });
+
+  it("replays queued POSTs with auth headers computed at flush time", async () => {
+    const payload = {
+      projectName: "test",
+      type: "bug" as const,
+      message: "retry with auth",
+      url: "https://example.com",
+      viewport: "1x1",
+      userAgent: "t",
+      authorName: "A",
+      authorEmail: "a@b.com",
+      annotations: [],
+      clientId: "auth-1",
+    };
+
+    // The stored entry predates the auth config — headers come from the
+    // auth passed at flush time, not from the queue.
+    vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify([{ endpoint, payload }]));
+    vi.mocked(fetch).mockResolvedValue(new Response("", { status: 201 }));
+
+    await flushRetryQueue(endpoint, null, { apiKey: "flush-key", headers: { "X-Flush": "1" } });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const init = vi.mocked(fetch).mock.calls[0][1] as RequestInit;
+    expect(init.headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer flush-key",
+      "X-Flush": "1",
+    });
     expect(localStorage.removeItem).toHaveBeenCalledWith("siteping_retry_queue");
   });
 

--- a/packages/widget/__tests__/widget/launcher-integration.test.ts
+++ b/packages/widget/__tests__/widget/launcher-integration.test.ts
@@ -97,6 +97,7 @@ vi.mock(new URL("../../src/identity.js", import.meta.url).pathname, () => ({
   saveIdentity: (...args: unknown[]) => mockSaveIdentity(...args),
 }));
 
+import { ApiClient, flushRetryQueue } from "../../src/api-client.js";
 import * as i18n from "../../src/i18n/index.js";
 import { launch } from "../../src/launcher.js";
 
@@ -1599,6 +1600,40 @@ describe("launcher — annotation:complete integration", () => {
       } finally {
         loadLocaleSpy.mockRestore();
       }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // auth config wiring — apiKey/headers flow into ApiClient + flushRetryQueue
+  // -------------------------------------------------------------------------
+
+  describe("auth config wiring", () => {
+    it("passes apiKey and headers from config to ApiClient and flushRetryQueue", () => {
+      const headers = { "X-Team": "acme" };
+      const instance = launch(defaultConfig({ apiKey: "widget-key", headers }));
+
+      expect(vi.mocked(ApiClient)).toHaveBeenCalledWith("/api/siteping", "test-project", {
+        apiKey: "widget-key",
+        headers,
+      });
+      expect(vi.mocked(flushRetryQueue)).toHaveBeenCalledWith(
+        "/api/siteping",
+        { name: "Test User", email: "test@example.com" },
+        { apiKey: "widget-key", headers },
+      );
+
+      instance.destroy();
+    });
+
+    it("passes an empty auth object when no auth is configured", () => {
+      const instance = launch(defaultConfig());
+
+      expect(vi.mocked(ApiClient)).toHaveBeenCalledWith("/api/siteping", "test-project", {
+        apiKey: undefined,
+        headers: undefined,
+      });
+
+      instance.destroy();
     });
   });
 });

--- a/packages/widget/src/api-client.ts
+++ b/packages/widget/src/api-client.ts
@@ -95,8 +95,9 @@ export interface ApiClientAuth {
  * explicit `Authorization` wins.
  *
  * A function `headers` resolves once per call — retries inside
- * `resilientFetch` reuse the values (max retry window ~7s, acceptable for
- * short-lived tokens; the dashboard has the same per-request semantics). A
+ * `resilientFetch` reuse the values for the whole retry sequence — up to
+ * ~45s worst case with 4 attempts x 10s timeout plus backoff (the dashboard
+ * has the same per-request semantics, without retries). A
  * throwing/rejecting factory fails the request like a network error.
  */
 export async function buildRequestHeaders(auth: ApiClientAuth, json: boolean): Promise<Record<string, string>> {

--- a/packages/widget/src/api-client.ts
+++ b/packages/widget/src/api-client.ts
@@ -6,6 +6,7 @@ import {
   type FeedbackType,
   SitepingAuthError,
   SitepingError,
+  type SitepingHeadersOption,
   SitepingNetworkError,
   SitepingValidationError,
 } from "@siteping/core";
@@ -77,6 +78,34 @@ export interface GetFeedbacksOptions {
   url?: string;
   /** Restrict to feedbacks created on this URL pattern (e.g. `/orders/:orderId`). */
   urlPattern?: string;
+}
+
+/** Auth options for `ApiClient` / `flushRetryQueue` (HTTP mode). */
+export interface ApiClientAuth {
+  /** Sent as `Authorization: Bearer <apiKey>` on every request. */
+  apiKey?: string | undefined;
+  /** Extra headers, static or per-request factory. An explicit `Authorization` entry wins over `apiKey`. */
+  headers?: SitepingHeadersOption | undefined;
+}
+
+/**
+ * Build the headers for one request — mirrors the dashboard's
+ * `createEndpointSource` semantics: `Content-Type` when the request carries a
+ * JSON body, then `Bearer` from `apiKey`, then `headers` merged on top so an
+ * explicit `Authorization` wins.
+ *
+ * A function `headers` resolves once per call — retries inside
+ * `resilientFetch` reuse the values (max retry window ~7s, acceptable for
+ * short-lived tokens; the dashboard has the same per-request semantics). A
+ * throwing/rejecting factory fails the request like a network error.
+ */
+export async function buildRequestHeaders(auth: ApiClientAuth, json: boolean): Promise<Record<string, string>> {
+  const merged: Record<string, string> = {};
+  if (json) merged["Content-Type"] = "application/json";
+  if (auth.apiKey) merged.Authorization = `Bearer ${auth.apiKey}`;
+  const extra = typeof auth.headers === "function" ? await auth.headers() : auth.headers;
+  if (extra) Object.assign(merged, extra);
+  return merged;
 }
 
 const MAX_RETRIES = 3;
@@ -182,8 +211,15 @@ function normalizeEmail(value: string): string {
  * This prevents user A's offline feedback from being POSTed under user B's
  * identity after a session change. When omitted, all entries are replayed to
  * preserve the legacy behavior for callers that don't track identity.
+ *
+ * `auth` headers resolve fresh at flush time (once per flush call) — queue
+ * entries persist payloads only, never headers or token material.
  */
-export async function flushRetryQueue(endpoint: string, currentIdentity?: Identity | null): Promise<void> {
+export async function flushRetryQueue(
+  endpoint: string,
+  currentIdentity?: Identity | null,
+  auth: ApiClientAuth = {},
+): Promise<void> {
   await withRetryLock(async () => {
     try {
       const queue = readQueue();
@@ -218,18 +254,21 @@ export async function flushRetryQueue(endpoint: string, currentIdentity?: Identi
 
       // Process items sequentially to avoid overwhelming the server
       const failed: RetryEntry[] = [];
-      for (const entry of toRetry) {
-        try {
-          const res = await fetch(endpoint, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(entry.payload),
-          });
-          if (!res.ok) {
+      if (toRetry.length > 0) {
+        const headers = await buildRequestHeaders(auth, true);
+        for (const entry of toRetry) {
+          try {
+            const res = await fetch(endpoint, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(entry.payload),
+            });
+            if (!res.ok) {
+              failed.push(entry);
+            }
+          } catch {
             failed.push(entry);
           }
-        } catch {
-          failed.push(entry);
         }
       }
 
@@ -259,6 +298,7 @@ export class ApiClient implements WidgetClient {
   constructor(
     private readonly endpoint: string,
     private readonly projectName: string,
+    private readonly auth: ApiClientAuth = {},
   ) {}
 
   async sendFeedback(payload: FeedbackPayload): Promise<FeedbackResponse> {
@@ -275,7 +315,7 @@ export class ApiClient implements WidgetClient {
       try {
         response = await resilientFetch(this.endpoint, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: await buildRequestHeaders(this.auth, true),
           body: JSON.stringify(body),
         });
       } catch (error) {
@@ -308,9 +348,13 @@ export class ApiClient implements WidgetClient {
 
     let response: Response;
     try {
+      // GET carries no body — only attach headers when auth produced some, so
+      // the no-auth wire shape stays byte-identical to the legacy client.
+      const headers = await buildRequestHeaders(this.auth, false);
       response = await resilientFetch(`${this.endpoint}?${params.toString()}`, {
         method: "GET",
         cache: "no-store",
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
       });
     } catch (error) {
       throw networkErrorFromException(error, "Failed to fetch feedbacks");
@@ -328,7 +372,7 @@ export class ApiClient implements WidgetClient {
     try {
       response = await resilientFetch(this.endpoint, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: await buildRequestHeaders(this.auth, true),
         body: JSON.stringify({ id, projectName: this.projectName, status: resolved ? "resolved" : "open" }),
       });
     } catch (error) {
@@ -347,7 +391,7 @@ export class ApiClient implements WidgetClient {
     try {
       response = await resilientFetch(this.endpoint, {
         method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        headers: await buildRequestHeaders(this.auth, true),
         body: JSON.stringify({ id, projectName: this.projectName }),
       });
     } catch (error) {
@@ -364,7 +408,7 @@ export class ApiClient implements WidgetClient {
     try {
       response = await resilientFetch(this.endpoint, {
         method: "DELETE",
-        headers: { "Content-Type": "application/json" },
+        headers: await buildRequestHeaders(this.auth, true),
         body: JSON.stringify({ projectName, deleteAll: true }),
       });
     } catch (error) {

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -11,6 +11,7 @@ export type {
   FeedbackType,
   RectData,
   SitepingConfig,
+  SitepingHeadersOption,
   SitepingInstance,
   SitepingPublicEvents,
   SitepingStore,

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -217,7 +217,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
     if (typeof endpoint !== "string" || endpoint.length === 0) {
       throw new Error("[siteping] internal invariant: endpoint must be a non-empty string in HTTP mode");
     }
-    return new ApiClient(endpoint, config.projectName);
+    return new ApiClient(endpoint, config.projectName, { apiKey: config.apiKey, headers: config.headers });
   })();
 
   // Wire config callbacks to event bus
@@ -556,7 +556,10 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   // Flush retry queue on load (HTTP mode only — store mode has no retry queue)
   if (config.endpoint) {
-    flushRetryQueue(config.endpoint, config.identity ?? getIdentity())
+    flushRetryQueue(config.endpoint, config.identity ?? getIdentity(), {
+      apiKey: config.apiKey,
+      headers: config.headers,
+    })
       .then(() => log("Retry queue flushed"))
       .catch(() => {});
   }


### PR DESCRIPTION
## Summary

Fixes #100. `SitepingConfig` had no way to attach auth to the widget's requests, so adapter-prisma's `apiKey` made GET (marker load) 401 and PATCH/DELETE (resolve/delete from the panel) permanently unreachable — enabling auth effectively broke the widget.

## What changed

Deliberate **API parity with the dashboard** (`createEndpointSource` already shipped exactly this shape — same names, same semantics, its test suite transferred):

- `apiKey?: string` — sent as `Authorization: Bearer <apiKey>` on every HTTP-mode request.
- `headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>)` — static map or per-request (a)sync factory; merged over generated headers, so an explicit `Authorization` overrides `apiKey`. The factory form is the right home for short-lived session tokens.
- One `buildRequestHeaders` helper feeds all five `ApiClient` methods; headers resolve once per call and are reused across 5xx retries (documented: up to ~45s worst case).
- `flushRetryQueue` computes headers **at flush time** — queued offline feedbacks never persist tokens into localStorage.
- With no auth configured, every request is wire-identical to before (locked by the pre-existing exact-header tests, which pass unchanged).
- Widget README: new Authentication section — adapter defaults (POST stays public, so anonymous submissions keep working), a loud warning that a static `apiKey` is visible to every visitor (prefer the token callback on public sites), values read at init (use the factory + a ref for rotation), and the CORS constraint (adapter allows `Content-Type`/`Authorization` only).

Pairs with #105: an authenticated widget GET now also receives unredacted reviewer emails.

## Verification

- Full vitest suite: 1872 passed. New: 'auth & headers' describe mirroring the dashboard's (Bearer on all methods, static/sync/async merge, Authorization-overrides-apiKey, throwing factory → SitepingNetworkError + queued once), flush-time auth replay + no-token-in-storage assertion, launcher wiring tests.
- Typecheck (strict + exactOptionalPropertyTypes) and biome clean.