### PR TITLE
fix(widget): target the last focused page element for FAB-launched keyboard annotation (fixes #162)

### DIFF
--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -250,6 +250,60 @@ test.describe("Annotation mode", () => {
   });
 });
 
+test.describe("Keyboard-only annotation", () => {
+  test("FAB-launched Enter annotation targets the last focused page element", async ({ page }) => {
+    const s = shadow(page);
+
+    // 1. Focus a real page element — the fixture has no native button, so
+    //    inject one (the focus tracker needs a focusin from page content).
+    await page.evaluate(() => {
+      const btn = document.createElement("button");
+      btn.id = "kbd-target";
+      btn.textContent = "Focus me";
+      document.getElementById("target-element")?.after(btn);
+      btn.focus();
+    });
+
+    // 2. Open the FAB via keyboard (Enter on the focused button = click).
+    await page.evaluate(() => {
+      const host = document.querySelector("siteping-widget");
+      (host?.shadowRoot?.querySelector(".sp-fab") as HTMLElement)?.focus();
+    });
+    await page.keyboard.press("Enter");
+    await s.waitFor(".sp-radial-item--open");
+
+    // 3. The first radial item (chat) receives focus after the open animation
+    //    — ArrowDown to the annotate item, then Enter to activate it.
+    await page.waitForFunction(() => {
+      const host = document.querySelector("siteping-widget");
+      return host?.shadowRoot?.activeElement?.classList.contains("sp-radial-item") ?? false;
+    });
+    await page.keyboard.press("ArrowDown");
+    await page.waitForFunction(() => {
+      const host = document.querySelector("siteping-widget");
+      return host?.shadowRoot?.activeElement?.getAttribute("data-item-id") === "annotate";
+    });
+    await page.keyboard.press("Enter");
+
+    // 4. The overlay is up and focused — Enter annotates the tracked button
+    //    (the FAB stole focus, so only the tracker knows the real target).
+    await page.waitForFunction(() => !!document.querySelector("div[style*='crosshair']"));
+    await page.keyboard.press("Enter");
+
+    // 5. The feedback popup appears...
+    await page.waitForSelector("button[data-type='bug']");
+
+    // ...and the keyboard highlight rect (fixed-position, screenshot-ignored)
+    // covers the target element.
+    const hasHighlight = await page.evaluate(() => {
+      const overlay = document.querySelector("div[style*='crosshair']");
+      const rect = overlay?.querySelector("div[data-siteping-ignore]") as HTMLElement | null;
+      return !!rect && rect.style.position === "fixed" && parseFloat(rect.style.width) > 0;
+    });
+    expect(hasHighlight).toBe(true);
+  });
+});
+
 test.describe("Full annotation flow", () => {
   test("draw → popup → submit → marker + API persist", async ({ page }) => {
     const s = shadow(page);

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -110,6 +110,7 @@ vi.mock(new URL("../../src/dom/anchor.js", import.meta.url).pathname, () => ({
 }));
 
 import { Annotator } from "../../src/annotator.js";
+import { generateAnchor } from "../../src/dom/anchor.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -657,6 +658,158 @@ describe("Annotator", () => {
       expect(completeListener).not.toHaveBeenCalled();
 
       target.remove();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Keyboard annotation — FAB-launched fallback target + highlight (issue #162)
+  // -------------------------------------------------------------------------
+
+  describe("keyboard: Enter with fallback target", () => {
+    /**
+     * The chrome decoys below carry data-siteping-ignore + tabindex, which
+     * collides with findOverlay()'s selector — the overlay's unique
+     * role="application" disambiguates.
+     */
+    function findOverlayByRole(): HTMLElement | null {
+      return document.body.querySelector<HTMLElement>('div[role="application"]');
+    }
+
+    /** Annotator with a fallback getter — the shared beforeEach one has none. */
+    function createFallbackAnnotator(getFallbackTarget?: () => HTMLElement | null) {
+      const fbBus = new EventBus<WidgetEvents>();
+      const fbAnnotator = new Annotator(colors, fbBus, t, false, getFallbackTarget);
+      return { fbAnnotator, fbBus };
+    }
+
+    it("annotates the fallback target when widget chrome holds focus at activation", async () => {
+      // FAB-launched flow: focus sits on widget chrome when the annotator
+      // activates — the fallback getter supplies the real page element.
+      const chrome = document.createElement("div");
+      chrome.setAttribute("data-siteping-ignore", "true");
+      chrome.setAttribute("tabindex", "0");
+      document.body.appendChild(chrome);
+
+      const pageButton = document.createElement("button");
+      document.body.appendChild(pageButton);
+      vi.spyOn(pageButton, "getBoundingClientRect").mockReturnValue(new DOMRect(10, 20, 100, 40));
+
+      const { fbAnnotator, fbBus } = createFallbackAnnotator(() => pageButton);
+      try {
+        const completeListener = vi.fn();
+        fbBus.on("annotation:complete", completeListener);
+
+        chrome.focus();
+        fbBus.emit("annotation:start");
+        const overlay = findOverlayByRole()!;
+
+        overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+        await vi.waitFor(() => {
+          expect(completeListener).toHaveBeenCalledOnce();
+        });
+
+        const data = completeListener.mock.calls[0][0];
+        expect(data.annotation.rect).toEqual({ xPct: 0, yPct: 0, wPct: 1, hPct: 1 });
+        expect(generateAnchor).toHaveBeenLastCalledWith(pageButton);
+      } finally {
+        fbAnnotator.destroy();
+        chrome.remove();
+        pageButton.remove();
+      }
+    });
+
+    it("Enter no-ops when widget chrome holds focus and the fallback returns null", async () => {
+      const chrome = document.createElement("div");
+      chrome.setAttribute("data-siteping-ignore", "true");
+      chrome.setAttribute("tabindex", "0");
+      document.body.appendChild(chrome);
+
+      const { fbAnnotator, fbBus } = createFallbackAnnotator(() => null);
+      try {
+        const completeListener = vi.fn();
+        fbBus.on("annotation:complete", completeListener);
+
+        chrome.focus();
+        fbBus.emit("annotation:start");
+        const overlay = findOverlayByRole()!;
+
+        overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(completeListener).not.toHaveBeenCalled();
+      } finally {
+        fbAnnotator.destroy();
+        chrome.remove();
+      }
+    });
+
+    it("targets the directly focused page element without consulting the fallback", async () => {
+      const decoy = document.createElement("button");
+      document.body.appendChild(decoy);
+      const getFallback = vi.fn(() => decoy);
+
+      const pageButton = document.createElement("button");
+      document.body.appendChild(pageButton);
+      vi.spyOn(pageButton, "getBoundingClientRect").mockReturnValue(new DOMRect(10, 20, 100, 40));
+
+      const { fbAnnotator, fbBus } = createFallbackAnnotator(getFallback);
+      try {
+        const completeListener = vi.fn();
+        fbBus.on("annotation:complete", completeListener);
+
+        pageButton.focus();
+        fbBus.emit("annotation:start");
+        const overlay = findOverlayByRole()!;
+
+        overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+        await vi.waitFor(() => {
+          expect(completeListener).toHaveBeenCalledOnce();
+        });
+
+        expect(getFallback).not.toHaveBeenCalled();
+        expect(generateAnchor).toHaveBeenLastCalledWith(pageButton);
+      } finally {
+        fbAnnotator.destroy();
+        decoy.remove();
+        pageButton.remove();
+      }
+    });
+
+    it("shows a fixed-position highlight over the target and removes it on deactivate", async () => {
+      // Keep show() pending so the popup stays "open" — the window in which
+      // the highlight must persist, exactly like a pointer-drawn rect.
+      popupMocks.keepShowPending = true;
+
+      const pageButton = document.createElement("button");
+      document.body.appendChild(pageButton);
+      vi.spyOn(pageButton, "getBoundingClientRect").mockReturnValue(new DOMRect(10, 20, 100, 40));
+
+      const { fbAnnotator, fbBus } = createFallbackAnnotator();
+      try {
+        pageButton.focus();
+        fbBus.emit("annotation:start");
+        const overlay = findOverlayByRole()!;
+
+        overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+        // Screenshot-excluded (data-siteping-ignore) and positioned over the
+        // target's bounding box.
+        const highlight = overlay.querySelector<HTMLElement>("div[data-siteping-ignore]");
+        expect(highlight).not.toBeNull();
+        expect(highlight!.style.position).toBe("fixed");
+        expect(highlight!.style.left).toBe("10px");
+        expect(highlight!.style.top).toBe("20px");
+        expect(highlight!.style.width).toBe("100px");
+        expect(highlight!.style.height).toBe("40px");
+
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        expect(highlight!.isConnected).toBe(false);
+      } finally {
+        fbAnnotator.destroy();
+        pageButton.remove();
+      }
     });
   });
 

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -659,6 +659,35 @@ describe("Annotator", () => {
 
       target.remove();
     });
+
+    it("Enter during an active pointer drag is ignored (drawingRect not hijacked)", async () => {
+      const target = document.createElement("button");
+      target.textContent = "Focus me";
+      document.body.appendChild(target);
+      vi.spyOn(target, "getBoundingClientRect").mockReturnValue(new DOMRect(10, 20, 100, 40));
+      target.focus();
+
+      const completeListener = vi.fn();
+      bus.on("annotation:complete", completeListener);
+
+      bus.emit("annotation:start");
+      const overlay = findOverlay()!;
+
+      // Start a pointer drag, then press Enter mid-drag: the keyboard path
+      // must not replace the in-progress drawingRect with its highlight.
+      overlay.dispatchEvent(new MouseEvent("mousedown", { clientX: 50, clientY: 50, bubbles: true }));
+      const dragRect = overlay.querySelector("div[data-siteping-ignore]");
+      expect(dragRect).not.toBeNull();
+
+      overlay.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(completeListener).not.toHaveBeenCalled();
+      // The drag's rectangle is still the one in the overlay
+      expect(overlay.querySelector("div[data-siteping-ignore]")).toBe(dragRect);
+
+      target.remove();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/widget/__tests__/widget/focus-tracker.test.ts
+++ b/packages/widget/__tests__/widget/focus-tracker.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { createFocusTracker, type FocusTracker } from "../../src/focus-tracker.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Elements appended during a test, removed in afterEach. */
+const appended: Element[] = [];
+
+function append<T extends HTMLElement>(el: T): T {
+  document.body.appendChild(el);
+  appended.push(el);
+  return el;
+}
+
+/** jsdom only focuses elements attached to the document. */
+function pageButton(): HTMLButtonElement {
+  return append(document.createElement("button"));
+}
+
+function makeHost(): HTMLElement {
+  return append(document.createElement("siteping-widget"));
+}
+
+describe("createFocusTracker", () => {
+  let tracker: FocusTracker | null = null;
+
+  afterEach(() => {
+    tracker?.destroy();
+    tracker = null;
+    for (const el of appended.splice(0)) el.remove();
+  });
+
+  it("tracks focus on a page element", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+
+    btn.focus();
+
+    expect(tracker.getLastPageFocus()).toBe(btn);
+  });
+
+  it("ignores widget chrome carrying data-siteping-ignore (previous target retained)", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+    btn.focus();
+
+    const chrome = append(document.createElement("div"));
+    chrome.setAttribute("data-siteping-ignore", "true");
+    chrome.setAttribute("tabindex", "0");
+    chrome.focus();
+
+    expect(tracker.getLastPageFocus()).toBe(btn);
+  });
+
+  it("ignores markers inside the #siteping-markers container (previous target retained)", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+    btn.focus();
+
+    // Markers are focusable (tabindex=0) and do NOT carry
+    // data-siteping-ignore — only the container id identifies them.
+    const container = append(document.createElement("div"));
+    container.id = "siteping-markers";
+    const marker = document.createElement("div");
+    marker.setAttribute("tabindex", "0");
+    container.appendChild(marker);
+    marker.focus();
+
+    expect(tracker.getLastPageFocus()).toBe(btn);
+  });
+
+  it("ignores focus inside a <siteping-widget> element (previous target retained)", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+    btn.focus();
+
+    const widget = append(document.createElement("siteping-widget"));
+    const inner = document.createElement("button");
+    widget.appendChild(inner);
+    inner.focus();
+
+    expect(tracker.getLastPageFocus()).toBe(btn);
+  });
+
+  it("ignores focus inside the #sp-tooltip element (previous target retained)", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+    btn.focus();
+
+    const tooltip = append(document.createElement("div"));
+    tooltip.id = "sp-tooltip";
+    tooltip.setAttribute("tabindex", "0");
+    tooltip.focus();
+
+    expect(tracker.getLastPageFocus()).toBe(btn);
+  });
+
+  it("returns null once the tracked element leaves the DOM", () => {
+    tracker = createFocusTracker(makeHost());
+    const btn = pageButton();
+    btn.focus();
+    expect(tracker.getLastPageFocus()).toBe(btn);
+
+    btn.remove();
+
+    expect(tracker.getLastPageFocus()).toBeNull();
+  });
+
+  it("destroy() removes the focusin listener — later focus is not tracked", () => {
+    tracker = createFocusTracker(makeHost());
+    const before = pageButton();
+    before.focus();
+
+    tracker.destroy();
+
+    const after = pageButton();
+    after.focus();
+
+    expect(tracker.getLastPageFocus()).toBeNull();
+    tracker = null;
+  });
+});

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -327,6 +327,9 @@ export class Annotator {
     // A submission is already running with the popup open — ignore so we
     // can't orphan the first `popup.show()` / `runSubmission` pair.
     if (this.submissionInFlight) return;
+    // Mid-pointer-drag: the user is drawing — hijacking `drawingRect` for the
+    // keyboard highlight here would corrupt the drag's geometry updates.
+    if (this.isDrawing) return;
 
     const target = this.keyboardTarget;
     if (!target || !(target instanceof HTMLElement)) return;

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -3,6 +3,7 @@ import { INSTANT_ANNOTATION_SIZE, Z_INDEX_MAX } from "./constants.js";
 import { findAnchorElement, generateAnchor, rectToPercentages } from "./dom/anchor.js";
 import { el, setText } from "./dom-utils.js";
 import type { EventBus, WidgetEvents } from "./events.js";
+import { isWidgetChrome } from "./focus-tracker.js";
 import type { TFunction } from "./i18n/index.js";
 import { Popup } from "./popup.js";
 import { type AnnotatedScreenshot, captureAnnotatedScreenshot } from "./screenshot.js";
@@ -50,6 +51,13 @@ export class Annotator {
   private popup: Popup;
   private savedOverflow = "";
   private preActiveFocusElement: Element | null = null;
+  /**
+   * Target of the keyboard (Enter) annotation path — the page element focused
+   * at activation, or the focus tracker's fallback when activation came from
+   * the widget's own chrome (FAB menu). Distinct from `preActiveFocusElement`,
+   * which keeps its focus-restore role untouched. See issue #162.
+   */
+  private keyboardTarget: HTMLElement | null = null;
   private rafId: number | null = null;
   private pendingMoveEvent: MouseEvent | Touch | null = null;
   /**
@@ -66,6 +74,7 @@ export class Annotator {
     private readonly bus: EventBus<WidgetEvents>,
     private readonly t: TFunction,
     private readonly enableScreenshot: boolean = false,
+    private readonly getFallbackTarget?: () => HTMLElement | null,
   ) {
     this.popup = new Popup(colors, t);
 
@@ -119,6 +128,19 @@ export class Annotator {
 
     // Capture the focused element before activation for keyboard annotation
     this.preActiveFocusElement = document.activeElement;
+
+    // Keyboard (Enter) target. FAB-launched sessions re-focus the FAB before
+    // activation, so the active element here is only the widget's 0x0 shadow
+    // host — fall back to the last page element the focus tracker recorded
+    // instead of silently dead-ending the Enter path. See issue #162.
+    const active = document.activeElement;
+    this.keyboardTarget =
+      active instanceof HTMLElement &&
+      active !== document.body &&
+      active !== document.documentElement &&
+      !isWidgetChrome(active)
+        ? active
+        : (this.getFallbackTarget?.() ?? null);
 
     // Lock page scroll
     this.savedOverflow = document.body.style.overflow;
@@ -230,7 +252,7 @@ export class Annotator {
       this.overlay.addEventListener("touchmove", this.onTouchMove, { passive: false });
       this.overlay.addEventListener("touchend", this.onTouchEnd);
 
-      // Keyboard annotation: Enter selects the pre-activation focused element
+      // Keyboard annotation: Enter selects the captured keyboard target
       this.overlay.addEventListener("keydown", this.onOverlayKeyDown);
     }
 
@@ -244,11 +266,11 @@ export class Annotator {
     if (this.toolbar) document.body.appendChild(this.toolbar);
 
     // Move focus to the overlay so the keyboard-annotation path (Enter →
-    // annotate the element that was focused before activation) actually
-    // receives keydown — onOverlayKeyDown only fires when the overlay itself
-    // is focused. The overlay has tabindex=0, and preActiveFocusElement was
-    // captured at the top of activate(), before the overlay existed, so
-    // focusing here doesn't clobber the keyboard target. (WCAG 2.1.1 Level A)
+    // annotate the captured keyboard target) actually receives keydown —
+    // onOverlayKeyDown only fires when the overlay itself is focused. The
+    // overlay has tabindex=0, and the keyboard target was captured at the top
+    // of activate(), before the overlay existed, so focusing here doesn't
+    // clobber it. (WCAG 2.1.1 Level A)
     this.overlay.focus({ preventScroll: true });
   }
 
@@ -259,6 +281,7 @@ export class Annotator {
     this.instantMode = false;
     const previouslyFocused = this.preActiveFocusElement;
     this.preActiveFocusElement = null;
+    this.keyboardTarget = null;
 
     // Cancel any pending rAF to prevent stale callbacks
     if (this.rafId !== null) {
@@ -294,8 +317,9 @@ export class Annotator {
 
   /**
    * Keyboard annotation: pressing Enter while the overlay is active selects
-   * the element that was focused before activation and creates a full-bounds
-   * annotation covering that element (WCAG 2.1.1 Level A).
+   * the keyboard target captured at activation (the focused page element, or
+   * the focus tracker's fallback for FAB-launched sessions) and creates a
+   * full-bounds annotation covering that element (WCAG 2.1.1 Level A).
    */
   private onOverlayKeyDown = async (e: KeyboardEvent): Promise<void> => {
     if (e.key !== "Enter") return;
@@ -304,13 +328,26 @@ export class Annotator {
     // can't orphan the first `popup.show()` / `runSubmission` pair.
     if (this.submissionInFlight) return;
 
-    const target = this.preActiveFocusElement;
+    const target = this.keyboardTarget;
     if (!target || !(target instanceof HTMLElement)) return;
 
     const bounds = target.getBoundingClientRect();
     if (bounds.width <= 0 || bounds.height <= 0) return;
 
     const rectBounds = new DOMRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+    // Highlight the target like a pointer-drawn rectangle so keyboard users
+    // see what they're about to comment. Assigned to `drawingRect` so every
+    // existing cleanup path (deactivate, screenshot exclusion, removal once
+    // the popup closes) treats it exactly like the mouse path's rect.
+    this.drawingRect?.remove();
+    const highlight = this.createDrawingRect();
+    highlight.style.left = `${bounds.x}px`;
+    highlight.style.top = `${bounds.y}px`;
+    highlight.style.width = `${bounds.width}px`;
+    highlight.style.height = `${bounds.height}px`;
+    this.drawingRect = highlight;
+    this.overlay?.appendChild(highlight);
 
     const anchor = generateAnchor(target);
     const annotation: AnnotationPayload = {
@@ -330,6 +367,8 @@ export class Annotator {
       this.runSubmission(annotation, formResult, rectBounds, screenshotCache),
     );
 
+    this.drawingRect?.remove();
+    this.drawingRect = null;
     if (result) this.deactivate();
   };
 
@@ -356,7 +395,17 @@ export class Annotator {
     this.startY = clientY;
 
     this.drawingRect?.remove();
-    this.drawingRect = el("div", {
+    this.drawingRect = this.createDrawingRect();
+    this.overlay?.appendChild(this.drawingRect);
+  }
+
+  /**
+   * The accent-colored selection rectangle — shared by pointer drawing and
+   * the keyboard (Enter) highlight so the two paths can't drift visually.
+   * Excluded from screenshot capture (see overlay creation in activate()).
+   */
+  private createDrawingRect(): HTMLElement {
+    const rect = el("div", {
       style: `
         position:fixed;
         border:2px solid ${this.colors.accent};
@@ -367,9 +416,8 @@ export class Annotator {
         transition:box-shadow 0.15s ease;
       `,
     });
-    // Excluded from screenshot capture (see overlay creation in activate()).
-    this.drawingRect.setAttribute("data-siteping-ignore", "true");
-    this.overlay?.appendChild(this.drawingRect);
+    rect.setAttribute("data-siteping-ignore", "true");
+    return rect;
   }
 
   private onMouseMove = (e: MouseEvent): void => {

--- a/packages/widget/src/fab.ts
+++ b/packages/widget/src/fab.ts
@@ -273,9 +273,9 @@ export class Fab {
         this.bus.emit("panel:toggle", true);
         break;
       case "annotate": {
-        // close() above re-focused the FAB, so the annotator can only capture
-        // the shadow host as its pre-activation element — restoring focus is
-        // on us: put keyboard users back on the FAB when the session ends.
+        // close() above re-focused the FAB, so the annotator resolves its
+        // keyboard target via the focus tracker's last page element — but
+        // putting keyboard users back on the FAB when the session ends is on us.
         const unsubscribe = this.bus.on("annotation:end", () => {
           unsubscribe();
           this.fab.focus();

--- a/packages/widget/src/focus-tracker.ts
+++ b/packages/widget/src/focus-tracker.ts
@@ -18,6 +18,11 @@ export interface FocusTracker {
  * tooltip. Host-independent (tagName/closest checks only) so the annotator
  * can share it without holding a host reference — mirrors the screenshot
  * `ignoreElements` predicate.
+ *
+ * Host pages may put `data-siteping-ignore` on their own elements to mask
+ * them from screenshots — those are deliberately excluded from keyboard
+ * annotation targeting too: an element opted out of capture shouldn't become
+ * an annotation target through the Enter path.
  */
 export function isWidgetChrome(el: Element): boolean {
   return (

--- a/packages/widget/src/focus-tracker.ts
+++ b/packages/widget/src/focus-tracker.ts
@@ -1,0 +1,61 @@
+/**
+ * Tracks the last *page* element the user focused, so FAB-launched keyboard
+ * annotation has a real target: opening the radial menu moves focus into the
+ * shadow root, which retargets `document.activeElement` to the 0x0
+ * `<siteping-widget>` host — by the time the annotator activates, the element
+ * the user actually cares about is no longer the active one. See issue #162.
+ */
+export interface FocusTracker {
+  getLastPageFocus(): HTMLElement | null;
+  destroy(): void;
+}
+
+/**
+ * True when `el` belongs to the widget's own chrome rather than the host
+ * page: the shadow host, body-level annotation overlay / toolbar / drawing
+ * rect / popup (all carry `data-siteping-ignore`), the markers container
+ * (whose markers are focusable but carry no ignore attribute), or the
+ * tooltip. Host-independent (tagName/closest checks only) so the annotator
+ * can share it without holding a host reference — mirrors the screenshot
+ * `ignoreElements` predicate.
+ */
+export function isWidgetChrome(el: Element): boolean {
+  return (
+    el.tagName === "SITEPING-WIDGET" ||
+    el.closest("siteping-widget") !== null ||
+    el.closest('[data-siteping-ignore="true"]') !== null ||
+    el.closest("#siteping-markers") !== null ||
+    el.closest("#sp-tooltip") !== null
+  );
+}
+
+export function createFocusTracker(host: HTMLElement): FocusTracker {
+  let lastPageFocus: HTMLElement | null = null;
+
+  const onFocusIn = (e: FocusEvent): void => {
+    const target = e.target;
+    if (!(target instanceof HTMLElement)) return;
+    // <body> / <html> receive focus as a side effect of blurs and overlay
+    // teardown — never something the user chose to annotate.
+    if (target === document.body || target === document.documentElement) return;
+    if (target === host || isWidgetChrome(target)) return;
+    lastPageFocus = target;
+  };
+
+  document.addEventListener("focusin", onFocusIn);
+
+  return {
+    getLastPageFocus(): HTMLElement | null {
+      // Drop detached elements — annotating a node that left the DOM would
+      // produce a dead anchor (and retaining it would leak the subtree).
+      if (lastPageFocus && !lastPageFocus.isConnected) lastPageFocus = null;
+      return lastPageFocus;
+    },
+    destroy(): void {
+      // Both the listener and the reference must go: a retained document
+      // listener would keep the tracked element alive past widget destroy.
+      document.removeEventListener("focusin", onFocusIn);
+      lastPageFocus = null;
+    },
+  };
+}

--- a/packages/widget/src/i18n/de.ts
+++ b/packages/widget/src/i18n/de.ts
@@ -56,7 +56,8 @@ export const de: Translations = {
   "fab.annotations": "Markierungen ein- oder ausblenden",
 
   // Annotator
-  "annotator.instruction": "Zeichne ein Rechteck um den Bereich, den du kommentieren möchtest",
+  "annotator.instruction":
+    "Zeichne ein Rechteck um den Bereich, den du kommentieren möchtest — oder drücke die Eingabetaste, um das zuletzt fokussierte Element zu kommentieren",
   "annotator.instantInstruction": "Kommentar zur angeklickten Stelle",
   "annotator.cancel": "Abbrechen",
 

--- a/packages/widget/src/i18n/en.ts
+++ b/packages/widget/src/i18n/en.ts
@@ -55,7 +55,8 @@ export const en: Translations = {
   "fab.annotations": "Show or hide markers",
 
   // Annotator
-  "annotator.instruction": "Draw a rectangle on the area to comment",
+  "annotator.instruction":
+    "Draw a rectangle on the area to comment — or press Enter to comment on the last focused element",
   "annotator.instantInstruction": "Comment on the clicked spot",
   "annotator.cancel": "Cancel",
 

--- a/packages/widget/src/i18n/es.ts
+++ b/packages/widget/src/i18n/es.ts
@@ -56,7 +56,8 @@ export const es: Translations = {
   "fab.annotations": "Mostrar u ocultar marcadores",
 
   // Annotator
-  "annotator.instruction": "Dibuja un rectángulo sobre el área que quieres comentar",
+  "annotator.instruction":
+    "Dibuja un rectángulo sobre el área que quieres comentar — o pulsa Intro para comentar el último elemento enfocado",
   "annotator.instantInstruction": "Comentar el punto seleccionado",
   "annotator.cancel": "Cancelar",
 

--- a/packages/widget/src/i18n/fr.ts
+++ b/packages/widget/src/i18n/fr.ts
@@ -55,7 +55,8 @@ export const fr: Translations = {
   "fab.annotations": "Afficher ou masquer les marqueurs",
 
   // Annotator
-  "annotator.instruction": "Tracez un rectangle sur la zone \u00e0 commenter",
+  "annotator.instruction":
+    "Tracez un rectangle sur la zone \u00e0 commenter \u2014 ou appuyez sur Entr\u00e9e pour commenter le dernier \u00e9l\u00e9ment actif",
   "annotator.instantInstruction": "Commenter l'endroit cliqu\u00e9",
   "annotator.cancel": "Annuler",
 

--- a/packages/widget/src/i18n/it.ts
+++ b/packages/widget/src/i18n/it.ts
@@ -57,7 +57,8 @@ export const it: Translations = {
   "fab.annotations": "Mostra o nascondi i marcatori",
 
   // Annotator
-  "annotator.instruction": "Disegna un rettangolo sull'area da commentare",
+  "annotator.instruction":
+    "Disegna un rettangolo sull'area da commentare — oppure premi Invio per commentare l'ultimo elemento attivo",
   "annotator.instantInstruction": "Commenta il punto selezionato",
   "annotator.cancel": "Annulla",
 

--- a/packages/widget/src/i18n/pt.ts
+++ b/packages/widget/src/i18n/pt.ts
@@ -56,7 +56,8 @@ export const pt: Translations = {
   "fab.annotations": "Exibir ou ocultar marcadores",
 
   // Annotator
-  "annotator.instruction": "Desenhe um retângulo na área que deseja comentar",
+  "annotator.instruction":
+    "Desenhe um retângulo na área que deseja comentar — ou pressione Enter para comentar o último elemento em foco",
   "annotator.instantInstruction": "Comentar o ponto clicado",
   "annotator.cancel": "Cancelar",
 

--- a/packages/widget/src/i18n/ru.ts
+++ b/packages/widget/src/i18n/ru.ts
@@ -55,7 +55,8 @@ export const ru: Translations = {
   "fab.annotations": "Показать или скрыть метки",
 
   // Annotator
-  "annotator.instruction": "Выделите область для комментария",
+  "annotator.instruction":
+    "Выделите область для комментария — или нажмите Enter, чтобы прокомментировать последний активный элемент",
   "annotator.instantInstruction": "Комментарий к выбранной точке",
   "annotator.cancel": "Отмена",
 

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -14,6 +14,7 @@ import { ConsoleBuffer } from "./diagnostics/console-buffer.js";
 import { NetworkBuffer } from "./diagnostics/network-buffer.js";
 import { EventBus, type PublicWidgetEvents, type WidgetEvents } from "./events.js";
 import { Fab } from "./fab.js";
+import { createFocusTracker } from "./focus-tracker.js";
 import { createT, loadLocale, type TFunction } from "./i18n/index.js";
 import { getIdentity, type Identity, saveIdentity } from "./identity.js";
 import { MarkerManager } from "./markers.js";
@@ -276,6 +277,12 @@ export function launch(config: SitepingConfig): SitepingInstance {
 
   document.body.appendChild(host);
 
+  // Track the last page element the user focused. FAB-launched annotation
+  // moves focus into the shadow root before the annotator activates, so its
+  // own activeElement capture only sees the 0x0 shadow host — the tracker
+  // supplies the real keyboard (Enter) target instead. See issue #162.
+  const focusTracker = createFocusTracker(host);
+
   // Screen reader live region for feedback submission announcements
   const liveRegion = document.createElement("div");
   liveRegion.setAttribute("role", "status");
@@ -362,7 +369,9 @@ export function launch(config: SitepingConfig): SitepingInstance {
     }
   });
 
-  const annotator = new Annotator(colors, bus, t, config.enableScreenshot ?? false);
+  const annotator = new Annotator(colors, bus, t, config.enableScreenshot ?? false, () =>
+    focusTracker.getLastPageFocus(),
+  );
 
   let onContextMenu: ((e: MouseEvent) => void) | null = null;
   if (config.enableRightClickComment) {
@@ -660,6 +669,7 @@ export function launch(config: SitepingConfig): SitepingInstance {
       destroyed = true;
       pendingOpen = false;
       teardownNavigation?.();
+      focusTracker.destroy();
       unsubAnnotation();
       unsubToggle();
       fab.destroy();


### PR DESCRIPTION
## Summary

Fixes #162. The Enter keyboard-annotation path was dead from its only production entry point: opening the FAB moves focus into the closed shadow root (retargeted to the 0×0 `<siteping-widget>` host), and `close()` re-focuses the FAB before `annotation:start` — so the annotator captured the host, failed the 0×0 bounds check, and Enter silently did nothing. Unit tests passed because they bypass the FAB.

## What changed

- **`focus-tracker.ts`**: one document-level `focusin` listener records the last *page* element focused, ignoring all widget chrome (shadow host, `data-siteping-ignore` surfaces, the focusable markers in `#siteping-markers`, tooltip) plus `<body>`/`<html>`. Disconnected elements are dropped on read; `destroy()` removes the listener and the reference. Registered by the launcher after mount, torn down in `instance.destroy()`.
- **Annotator**: new `keyboardTarget`, separate from `preActiveFocusElement` — focus-restore semantics (and the FAB's test-locked self-refocus) are untouched. At activation: the focused element if it's a real page element, else the tracker's fallback. Enter pressed mid-pointer-drag is ignored (it would have hijacked the in-progress rectangle).
- **Visual affordance** (issue's gap b): Enter now draws the same accent rectangle as the pointer path over the target before the composer opens — shared element factory, so the two paths can't drift visually; all existing cleanup paths apply.
- **Discoverability** (gap a): `annotator.instruction` in all 7 locales now mentions the Enter path.
- **E2E**: new keyboard-only flow — focus a page button, open the FAB and pick "annotate" with the keyboard, press Enter on the overlay, composer opens with the highlight present. No Enter-path E2E existed.

Rebased on `main` post-#191 (right-click instant comments): union-resolved — instant mode keeps its own aria-label/no-toolbar behavior, keyboard targeting applies to the draw mode where the Enter listener lives.

## Behavior note

Host elements carrying the documented screenshot-masking attribute (`data-siteping-ignore`) are deliberately excluded from keyboard targeting — an element opted out of capture shouldn't become an annotation target through the Enter path (pointer drawing over it still works).

## Verification

- Full vitest suite: 1870 passed. New: focus-tracker suite (7 tests), annotator fallback/highlight/mid-drag tests; the locked contracts (FAB self-refocus, Enter-without-target, 0×0 bounds, focus restore) pass unchanged.
- Playwright: full chromium suite 30/30 including the new keyboard-only flow; also green on firefox. (WebKit not runnable on this WSL host — missing system libs; CI matrix arbitrates.)