### PR TITLE
test(dashboard): unmount hooks in use-inbox tests — post-teardown debounce flake (fixes #206)

### DIFF
--- a/packages/dashboard/__tests__/unit/use-inbox.test.ts
+++ b/packages/dashboard/__tests__/unit/use-inbox.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { FeedbackPage, FeedbackRecord, SitepingStore } from "@siteping/core";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { InboxSource } from "../../src/types.js";
 import { useSitepingInbox } from "../../src/use-inbox.js";
@@ -58,6 +58,11 @@ function demoRecords(): FeedbackRecord[] {
 const ids = (items: readonly FeedbackRecord[]): string[] => items.map((r) => r.id);
 
 afterEach(() => {
+  // Unmount every rendered hook: RTL auto-cleanup is inactive without vitest
+  // globals, and an unmounted-never component keeps its 250ms search-debounce
+  // timer armed — firing after environment teardown as an unhandled
+  // "window is not defined" (issue #206).
+  cleanup();
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

Fixes #206. `use-inbox.test.ts` was the only React test file without `cleanup()` in its `afterEach` (RTL auto-cleanup needs vitest `globals`, which this repo doesn't enable — the other dashboard files call it manually). Rendered hooks were never unmounted, so the search-debounce `setTimeout` (250ms, properly cleared on unmount by the hook itself) stayed armed after the file finished; when the worker tore the jsdom environment down within that window, the timer fired into a dead environment — the roaming unhandled `ReferenceError: window is not defined` that vitest escalates to a failure.

This bit the release run for #211 (all 1898 tests passed; the unhandled error alone failed `ci`, skipping every npm publish job).

Test-only change: `cleanup()` before `vi.restoreAllMocks()`.

## Verification

- `use-inbox.test.ts` 42/42 across repeated runs; the hook's own timer-cleanup path is what `cleanup()` now exercises on every test.