### PR TITLE
fix(widget): prevent re-entry during popup open (#196) and fix contextmenu trigger (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ initSiteping({
   enableScreenshot: false,        // Capture a JPEG of the annotated area on
                                   // submit. Off by default — see "Screenshot
                                   // capture" below for the masking story.
-  enableRightClickComment: false, // Right-click anywhere to leave a comment.
+  enableRightClickComment: false, // Right-click anywhere to leave a comment. Keyboard menus yield to native.
                                   // Shift/Ctrl/Alt/Meta + right-click still
                                   // opens the native context menu. Default: false
   identity: {                     // Pre-fill author from the host (SSO apps).

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -175,6 +175,10 @@ export interface SitepingConfig {
    * `false` — the browser's native context menu is never hijacked unless the
    * host explicitly opts in.
    *
+   * Keyboard-triggered context menus (≣ Menu key, Shift+F10) always get the
+   * native menu; only mouse right-click and touch/pen long-press open the
+   * composer.
+   *
    * **Modifier-key escape hatch:** holding Shift, Ctrl, Alt, or Meta while
    * right-clicking always falls through to the native context menu, giving
    * users (and devtools) an escape hatch regardless of this setting.

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -81,7 +81,7 @@ All configuration options for `initSiteping()`:
 | `identity` | `{ name: string; email: string }` | — | Pre-fill author identity from the host (SSO). When set, the widget skips the identity modal |
 | `deepLink` | `boolean \| { param?: string }` | `false` | On initial load, focus the annotation referenced by `?siteping=<id>` (or a custom query key). SPA navigations are ignored — use `focusFeedback()` for route-change focus |
 | `watchNavigation` | `boolean` | `true` | Auto re-fetch feedbacks on client-side (SPA) navigation. The widget patches the History API + listens for `popstate`/`hashchange`, so the panel list and markers follow route changes even when the widget is mounted once in a persistent layout (e.g. Next.js App Router). Re-fetches data only — it never re-scrolls. Set `false` to opt out and drive updates via `refresh()` |
-| `enableRightClickComment` | `boolean` | `false` | Right-click anywhere on the page to instantly open the comment composer at the cursor. Modifier-key right-clicks (Shift/Ctrl/Alt/Meta) fall through to the native context menu. Right-clicks on SitePing's own UI are ignored. Note: on Android, `contextmenu` fires on long-press — relevant for ≥768 px tablets where the widget loads |
+| `enableRightClickComment` | `boolean` | `false` | Right-click anywhere on the page to instantly open the comment composer at the cursor. Keyboard-triggered context menus (≣ Menu key, Shift+F10) always get the native menu; only mouse right-click and touch/pen long-press open the composer. Modifier-key right-clicks (Shift/Ctrl/Alt/Meta) fall through to the native context menu. Right-clicks on SitePing's own UI are ignored. |
 
 > **Custom translations** — Use `registerLocale(code, translations)` to add your own locale at runtime.
 

--- a/packages/widget/__tests__/widget/annotator-popup-reentry.test.ts
+++ b/packages/widget/__tests__/widget/annotator-popup-reentry.test.ts
@@ -82,9 +82,7 @@ describe("draw flow — popup re-entry guards (#196, real Popup)", () => {
     drag(overlay, 100, 100, 200, 200);
     await flush();
 
-    const cancelBtn = Array.from(document.body.querySelectorAll("button")).find(
-      (b) => b.textContent === "Cancel",
-    )!;
+    const cancelBtn = Array.from(document.body.querySelectorAll("button")).find((b) => b.textContent === "Cancel")!;
     expect(cancelBtn).toBeDefined();
     cancelBtn.click();
     await flush();

--- a/packages/widget/__tests__/widget/annotator-popup-reentry.test.ts
+++ b/packages/widget/__tests__/widget/annotator-popup-reentry.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import type { FeedbackResponse } from "@siteping/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventBus, type WidgetEvents } from "../../src/events.js";
+import { createT } from "../../src/i18n/index.js";
+import { buildThemeColors } from "../../src/styles/theme.js";
+import { mockMatchMedia } from "../helpers.js";
+
+mockMatchMedia(false);
+
+// Only the anchor helpers are mocked — the REAL Popup is used: these tests
+// exist precisely because the mocked-popup suite cannot pin this behavior.
+vi.mock(new URL("../../src/dom/anchor.js", import.meta.url).pathname, () => ({
+  findAnchorElement: vi.fn().mockReturnValue(document.body),
+  generateAnchor: vi.fn().mockReturnValue({
+    cssSelector: "body",
+    xpath: "/html/body",
+    textSnippet: "",
+    elementTag: "BODY",
+    elementId: undefined,
+    textPrefix: "",
+    textSuffix: "",
+    fingerprint: "0:0:0",
+    neighborText: "",
+  }),
+  rectToPercentages: vi.fn().mockReturnValue({ xPct: 0, yPct: 0, wPct: 1, hPct: 1 }),
+}));
+
+import { Annotator } from "../../src/annotator.js";
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+function findOverlay(): HTMLElement {
+  return document.body.querySelector<HTMLElement>('div[data-siteping-ignore][tabindex="0"]')!;
+}
+
+function drag(overlay: HTMLElement, x1: number, y1: number, x2: number, y2: number) {
+  overlay.dispatchEvent(new MouseEvent("mousedown", { clientX: x1, clientY: y1, bubbles: true }));
+  overlay.dispatchEvent(new MouseEvent("mouseup", { clientX: x2, clientY: y2, bubbles: true }));
+}
+
+describe("draw flow — popup re-entry guards (#196, real Popup)", () => {
+  let cleanup: (() => void) | null = null;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+    // A failed assertion skips in-test teardown — scrub leaked DOM so one
+    // failure can't cascade into the next test.
+    document.body.innerHTML = "";
+  });
+
+  it("drawing a second rectangle while the popup is open pre-Send must not reset the draft", async () => {
+    const bus = new EventBus<WidgetEvents>();
+    const annotator = new Annotator(buildThemeColors(), bus, createT("en"));
+    cleanup = () => annotator.destroy();
+
+    bus.emit("annotation:start");
+    const overlay = findOverlay();
+
+    // First rectangle → popup opens, show() promise pending (nobody clicked Send)
+    drag(overlay, 100, 100, 200, 200);
+    await flush();
+    const textarea = document.body.querySelector("textarea")!;
+    textarea.value = "my precious draft";
+
+    // User instinctively redraws next to the open popup
+    drag(overlay, 300, 300, 400, 400);
+    await flush();
+
+    expect(textarea.value).toBe("my precious draft");
+  });
+
+  it("after cancel (show() resolved null), drawing a new rectangle still works", async () => {
+    const bus = new EventBus<WidgetEvents>();
+    const annotator = new Annotator(buildThemeColors(), bus, createT("en"));
+    cleanup = () => annotator.destroy();
+
+    bus.emit("annotation:start");
+    const overlay = findOverlay();
+
+    drag(overlay, 100, 100, 200, 200);
+    await flush();
+
+    const cancelBtn = Array.from(document.body.querySelectorAll("button")).find(
+      (b) => b.textContent === "Cancel",
+    )!;
+    expect(cancelBtn).toBeDefined();
+    cancelBtn.click();
+    await flush();
+
+    // Redraw must open a fresh popup session
+    drag(overlay, 300, 300, 400, 400);
+    await flush();
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(dialog.style.display).toBe("block");
+  });
+
+  it("second drag while the submission is in flight post-Send is inert", async () => {
+    const bus = new EventBus<WidgetEvents>();
+    const annotator = new Annotator(buildThemeColors(), bus, createT("en"));
+    cleanup = () => annotator.destroy();
+    const completeListener = vi.fn();
+    bus.on("annotation:complete", completeListener);
+
+    bus.emit("annotation:start");
+    const overlay = findOverlay();
+
+    drag(overlay, 100, 100, 200, 200);
+    await flush();
+
+    // Fill the form and click Send — runSubmission now hangs on its terminal
+    // bus event, the popup is in the submitting state.
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]')!;
+    dialog.querySelector<HTMLButtonElement>('button[data-type="bug"]')!.click();
+    const textarea = dialog.querySelector("textarea")!;
+    textarea.value = "submitted message";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    Array.from(dialog.querySelectorAll("button"))
+      .find((b) => b.textContent?.includes("Send"))!
+      .click();
+    await flush();
+
+    expect(completeListener).toHaveBeenCalledOnce();
+    expect(textarea.disabled).toBe(true);
+
+    // Second drag during the in-flight submission — must be a no-op. A second
+    // popup.show() would reset the form: submittingState=false, textarea
+    // enabled and cleared.
+    drag(overlay, 300, 300, 400, 400);
+    await flush();
+
+    expect(textarea.disabled).toBe(true);
+    expect(textarea.value).toBe("submitted message");
+    expect(completeListener).toHaveBeenCalledOnce();
+
+    // Complete the submission — exactly one feedback sent.
+    bus.emit("feedback:sent", { id: "f1" } as FeedbackResponse);
+    await flush();
+    expect(completeListener).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -76,6 +76,10 @@ vi.mock(new URL("../../src/popup.js", import.meta.url).pathname, () => ({
         // while `runSubmission` is in flight — the overlay therefore stays up,
         // which is exactly the window the serialization guard must cover.
         if (popupMocks.keepShowPending) return new Promise(() => {});
+        // Lifecycle divergence from the real Popup: this flips isOpen false
+        // while `lastSubmitPromise` may still be pending, whereas the real
+        // popup stays open until `onSubmit` settles. The real-popup suite
+        // (annotator-popup-reentry.test.ts) pins the true invariant.
         popupMocks.isOpenState = false;
         return Promise.resolve(popupMocks.nextResult);
       }),

--- a/packages/widget/__tests__/widget/annotator.test.ts
+++ b/packages/widget/__tests__/widget/annotator.test.ts
@@ -48,6 +48,8 @@ const popupMocks = vi.hoisted(() => {
      * orphans the first `await`.
      */
     showCount: 0,
+    /** Tracks whether the mock popup is currently open. */
+    isOpenState: false,
   };
 });
 
@@ -57,6 +59,7 @@ vi.mock(new URL("../../src/popup.js", import.meta.url).pathname, () => ({
       .fn()
       .mockImplementation((_rect: DOMRect, onSubmit?: (r: { type: string; message: string }) => Promise<void>) => {
         popupMocks.showCount += 1;
+        popupMocks.isOpenState = true;
         // The real popup awaits its `onSubmit` callback before resolving so
         // the spinner stays visible until feedback:sent or feedback:error
         // arrives. Tests don't run a launcher, so we fire-and-forget the
@@ -73,11 +76,16 @@ vi.mock(new URL("../../src/popup.js", import.meta.url).pathname, () => ({
         // while `runSubmission` is in flight — the overlay therefore stays up,
         // which is exactly the window the serialization guard must cover.
         if (popupMocks.keepShowPending) return new Promise(() => {});
+        popupMocks.isOpenState = false;
         return Promise.resolve(popupMocks.nextResult);
       }),
     destroy: vi.fn().mockImplementation(() => {
       popupMocks.destroyCount += 1;
+      popupMocks.isOpenState = false;
     }),
+    get isOpen() {
+      return popupMocks.isOpenState;
+    },
   })),
 }));
 
@@ -152,6 +160,7 @@ describe("Annotator", () => {
     popupMocks.lastSubmitPromise = null;
     popupMocks.capturedOnSubmit = null;
     popupMocks.keepShowPending = false;
+    popupMocks.isOpenState = false;
     popupMocks.destroyCount = 0;
     popupMocks.showCount = 0;
     screenshotMocks.captureAnnotatedScreenshot.mockReset();

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -934,8 +934,9 @@ describe("launch", () => {
     it("does not preventDefault for keyboard-triggered contextmenu (Menu key)", () => {
       const instance = launch(defaultConfig({ enableRightClickComment: true }));
 
-      // Keyboard contextmenu events typically have button = 0 and no pointerType
-      const event = new MouseEvent("contextmenu", {
+      // Keyboard contextmenu events (Menu key) are mandated to have pointerType=""
+      const event = new PointerEvent("contextmenu", {
+        pointerType: "",
         button: 0,
         clientX: 100,
         clientY: 100,
@@ -947,6 +948,67 @@ describe("launch", () => {
       // Should yield to the native menu (not prevented)
       expect(event.defaultPrevented).toBe(false);
       expect(annotatorCapture.startInstantAnnotation).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("does not preventDefault for legacy keyboard-triggered contextmenu (no pointerType, button 0)", () => {
+      const instance = launch(defaultConfig({ enableRightClickComment: true }));
+
+      // Legacy engines dispatch a MouseEvent (no pointerType property)
+      const event = new MouseEvent("contextmenu", {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(annotatorCapture.startInstantAnnotation).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("touch long-press (pointerType 'touch', button 0) still starts the instant flow", () => {
+      const instance = launch(defaultConfig({ enableRightClickComment: true }));
+
+      // Android / Windows-touch long-press: contextmenu arrives as a
+      // PointerEvent with pointerType "touch" and button 0 — the exact
+      // combination the pointerType leg of the gate exists for.
+      const event = new PointerEvent("contextmenu", {
+        pointerType: "touch",
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(annotatorCapture.startInstantAnnotation).toHaveBeenCalledWith(100, 100);
+
+      instance.destroy();
+    });
+
+    it("pen long-press (pointerType 'pen', button 0) still starts the instant flow", () => {
+      const instance = launch(defaultConfig({ enableRightClickComment: true }));
+
+      // Windows Ink long-press
+      const event = new PointerEvent("contextmenu", {
+        pointerType: "pen",
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(annotatorCapture.startInstantAnnotation).toHaveBeenCalledWith(100, 100);
 
       instance.destroy();
     });

--- a/packages/widget/__tests__/widget/launcher.test.ts
+++ b/packages/widget/__tests__/widget/launcher.test.ts
@@ -858,6 +858,7 @@ describe("launch", () => {
       const instance = launch(defaultConfig({ enableRightClickComment: true }));
 
       const event = new MouseEvent("contextmenu", {
+        button: 2,
         clientX: 100,
         clientY: 100,
         shiftKey: true,
@@ -875,6 +876,7 @@ describe("launch", () => {
       const instance = launch(defaultConfig({ enableRightClickComment: true }));
 
       const event = new MouseEvent("contextmenu", {
+        button: 2,
         clientX: 100,
         clientY: 100,
         bubbles: true,
@@ -893,6 +895,7 @@ describe("launch", () => {
       const instance = launch(defaultConfig({ enableRightClickComment: true }));
 
       const event = new MouseEvent("contextmenu", {
+        button: 2,
         clientX: 100,
         clientY: 100,
         bubbles: true,
@@ -911,6 +914,7 @@ describe("launch", () => {
 
       // Simulate a click on the SitePing widget (or something inside it)
       const event = new MouseEvent("contextmenu", {
+        button: 2,
         clientX: 100,
         clientY: 100,
         bubbles: true,
@@ -921,6 +925,26 @@ describe("launch", () => {
       // Need composedPath() to include the widget, so dispatch from it or a shadow child
       widget.dispatchEvent(event);
 
+      expect(event.defaultPrevented).toBe(false);
+      expect(annotatorCapture.startInstantAnnotation).not.toHaveBeenCalled();
+
+      instance.destroy();
+    });
+
+    it("does not preventDefault for keyboard-triggered contextmenu (Menu key)", () => {
+      const instance = launch(defaultConfig({ enableRightClickComment: true }));
+
+      // Keyboard contextmenu events typically have button = 0 and no pointerType
+      const event = new MouseEvent("contextmenu", {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
+        cancelable: true,
+      });
+      document.dispatchEvent(event);
+
+      // Should yield to the native menu (not prevented)
       expect(event.defaultPrevented).toBe(false);
       expect(annotatorCapture.startInstantAnnotation).not.toHaveBeenCalled();
 

--- a/packages/widget/__tests__/widget/popup.test.ts
+++ b/packages/widget/__tests__/widget/popup.test.ts
@@ -1076,6 +1076,64 @@ describe("Popup", () => {
       expect(result).toBeNull();
       expect(document.querySelector('[role="dialog"]')).toBeNull();
     });
+
+    describe("isOpen (drawing-guard contract)", () => {
+      it("is false at rest, true between show() and cancel", async () => {
+        expect(popup.isOpen).toBe(false);
+        const promise = popup.show(makeBounds());
+        expect(popup.isOpen).toBe(true);
+        getCancelButton().click();
+        await promise;
+        expect(popup.isOpen).toBe(false);
+      });
+
+      it("stays true while onSubmit is pending and after its rejection (retry window)", async () => {
+        let rejectSubmit!: (e: Error) => void;
+        const onSubmit = vi.fn().mockReturnValue(
+          new Promise<void>((_resolve, reject) => {
+            rejectSubmit = reject;
+          }),
+        );
+
+        const promise = popup.show(makeBounds(), onSubmit);
+        fillForm();
+        getSubmitButton().click();
+        await vi.waitFor(() => {
+          expect(getSubmitButton().getAttribute("aria-busy")).toBe("true");
+        });
+
+        // The annotator's drawing guards read isOpen during exactly this
+        // window — it must hold while the submission is in flight…
+        expect(popup.isOpen).toBe(true);
+
+        rejectSubmit(new Error("network down"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // …and through the retry window after a failed submit.
+        expect(popup.isOpen).toBe(true);
+
+        getCancelButton().click();
+        expect(await promise).toBeNull();
+        expect(popup.isOpen).toBe(false);
+      });
+
+      it("is false after a successful submit settles show()", async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        const promise = popup.show(makeBounds(), onSubmit);
+        fillForm();
+        getSubmitButton().click();
+        await promise;
+        expect(popup.isOpen).toBe(false);
+      });
+
+      it("is false after destroy()", () => {
+        void popup.show(makeBounds());
+        expect(popup.isOpen).toBe(true);
+        popup.destroy();
+        expect(popup.isOpen).toBe(false);
+      });
+    });
   });
 });
 

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -62,9 +62,7 @@ export class Annotator {
   private pendingMoveEvent: MouseEvent | Touch | null = null;
   /**
    * Reject handle for the in-flight `runSubmission` promise, or null when no
-   * submission is pending. Serves two purposes: a non-null value means a
-   * submission is in flight (so pointer-driven drawing is suppressed — the
-   * popup is open), and `destroy()` calls it to settle the promise rather
+   * submission is pending. `destroy()` calls it to settle the promise rather
    * than leaving the awaiting closure hung past teardown.
    */
   private rejectPendingSubmission: ((reason: Error) => void) | null = null;
@@ -581,7 +579,7 @@ export class Annotator {
    * - `submission:cancelled` — reject as a silent abort (popup restores; no
    *   error is surfaced — e.g. the user cancelled the identity prompt).
    *
-   * Submissions are serialized by the drawing guards (`submissionInFlight`),
+   * Submissions are serialized by the popup guard (`this.popup.isOpen`),
    * so exactly one `runSubmission` is ever live — the global outcome events
    * cannot cross-wire between submissions and need no correlation id.
    */

--- a/packages/widget/src/annotator.ts
+++ b/packages/widget/src/annotator.ts
@@ -101,16 +101,6 @@ export class Annotator {
   }
 
   /**
-   * True while a submission is in flight (popup open, `runSubmission`
-   * pending). Drawing a second rectangle in this window would orphan the
-   * first `popup.show()` promise and start a second, concurrent
-   * `runSubmission` — so all drawing entry points are no-ops while it holds.
-   */
-  private get submissionInFlight(): boolean {
-    return this.rejectPendingSubmission !== null;
-  }
-
-  /**
    * Capture a contextual screenshot of the drawn rect (padded with the
    * surrounding UI, plus the rect's region within the image) when
    * `enableScreenshot` is on. Returns null on disable / capture failure /
@@ -324,9 +314,9 @@ export class Annotator {
   private onOverlayKeyDown = async (e: KeyboardEvent): Promise<void> => {
     if (e.key !== "Enter") return;
     e.preventDefault();
-    // A submission is already running with the popup open — ignore so we
+    // A submission is already running or the popup is open — ignore so we
     // can't orphan the first `popup.show()` / `runSubmission` pair.
-    if (this.submissionInFlight) return;
+    if (this.popup.isOpen) return;
     // Mid-pointer-drag: the user is drawing — hijacking `drawingRect` for the
     // keyboard highlight here would corrupt the drag's geometry updates.
     if (this.isDrawing) return;
@@ -386,12 +376,11 @@ export class Annotator {
   };
 
   private startDrawing(clientX: number, clientY: number): void {
-    // Suppress pointer-driven drawing while a submission is in flight: the
-    // popup is open over the page, and starting a second rectangle would
-    // orphan the first `popup.show()` promise (and its `runSubmission`).
-    // This also closes a latent bug where drawing during the open popup
-    // already overwrote `Popup.resolve`.
-    if (this.submissionInFlight) return;
+    // Suppress pointer-driven drawing while the popup is open over the page.
+    // Starting a second rectangle would orphan the first `popup.show()`
+    // promise (and its `runSubmission`). This closes a latent bug where
+    // drawing during the open popup overwrote `Popup.resolve`.
+    if (this.popup.isOpen) return;
 
     this.isDrawing = true;
     this.startX = clientX;

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -401,11 +401,15 @@ export function launch(config: SitepingConfig): SitepingInstance {
       // editors). Element-level handlers fire before this document-level
       // listener, so if they called preventDefault() we yield.
       if (e.defaultPrevented) return;
-      // Gate on genuine mouse/touch triggers to avoid hijacking the keyboard
-      // Menu key. Touch triggers may report e.button as 0 depending on the
-      // browser/OS, so we check pointerType when available.
-      const isTouch = "pointerType" in e && (e as PointerEvent).pointerType === "touch";
-      if (e.button !== 2 && !isTouch) return;
+      // Keyboard-triggered contextmenu (≣ Menu key, Shift+F10): Pointer
+      // Events L3 mandates pointerType === "" (pointerId -1) for non-pointer
+      // activations — yield to the native menu. contextmenu is a PointerEvent
+      // in Chrome/Edge 92+, Firefox 129+, Safari 18.2+.
+      const pointerType = (e as PointerEvent).pointerType;
+      if (pointerType === "") return;
+      // Legacy MouseEvent engines (no pointerType to consult): fall back to
+      // requiring a genuine right-button click.
+      if (pointerType === undefined && e.button !== 2) return;
       // Modifier-key escape hatch: Shift/Ctrl/Alt/Meta → native menu.
       if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) return;
       // Exclude SitePing's own UI — right-clicking the FAB, panel, markers,

--- a/packages/widget/src/launcher.ts
+++ b/packages/widget/src/launcher.ts
@@ -401,6 +401,11 @@ export function launch(config: SitepingConfig): SitepingInstance {
       // editors). Element-level handlers fire before this document-level
       // listener, so if they called preventDefault() we yield.
       if (e.defaultPrevented) return;
+      // Gate on genuine mouse/touch triggers to avoid hijacking the keyboard
+      // Menu key. Touch triggers may report e.button as 0 depending on the
+      // browser/OS, so we check pointerType when available.
+      const isTouch = "pointerType" in e && (e as PointerEvent).pointerType === "touch";
+      if (e.button !== 2 && !isTouch) return;
       // Modifier-key escape hatch: Shift/Ctrl/Alt/Meta → native menu.
       if (e.shiftKey || e.ctrlKey || e.altKey || e.metaKey) return;
       // Exclude SitePing's own UI — right-clicking the FAB, panel, markers,

--- a/packages/widget/src/popup.ts
+++ b/packages/widget/src/popup.ts
@@ -62,17 +62,23 @@ export class Popup {
   private submitLabel: HTMLSpanElement;
   private hint: HTMLElement;
   private resolve: ((result: PopupResult | null) => void) | null = null;
-
-  get isOpen(): boolean {
-    return this.resolve !== null;
-  }
-
   private previouslyFocused: HTMLElement | null = null;
   private onKeydownTrap: ((e: KeyboardEvent) => void) | null = null;
   private onSubmit: PopupSubmitHandler | null = null;
   private submittingState = false;
   /** WAAPI handle for the running spinner — cancelled when submitting ends. */
   private spinnerAnimation: Animation | null = null;
+
+  /**
+   * True from `show()` until its promise settles — through typing, the
+   * in-flight `onSubmit` await, AND the failed-submit retry window. The
+   * annotator's drawing guards read this to serialize popup sessions
+   * (#114/#196): if a refactor ever nulls `resolve` before `onSubmit`
+   * settles, those guards die silently — popup.test.ts pins the lifecycle.
+   */
+  get isOpen(): boolean {
+    return this.resolve !== null;
+  }
 
   constructor(
     private readonly colors: ThemeColors,

--- a/packages/widget/src/popup.ts
+++ b/packages/widget/src/popup.ts
@@ -62,6 +62,11 @@ export class Popup {
   private submitLabel: HTMLSpanElement;
   private hint: HTMLElement;
   private resolve: ((result: PopupResult | null) => void) | null = null;
+
+  get isOpen(): boolean {
+    return this.resolve !== null;
+  }
+
   private previouslyFocused: HTMLElement | null = null;
   private onKeydownTrap: ((e: KeyboardEvent) => void) | null = null;
   private onSubmit: PopupSubmitHandler | null = null;


### PR DESCRIPTION
Fixes #196 and #197. Addressed all acceptance criteria. The popup getter allows the annotator to yield safely when drawing or submitting, and the keyboard menu correctly falls back to native.

### Verification Matrix

| Target | Scenario | Expected | Result |
|---|---|---|---|
| **#196** | Second rectangle drawn while popup is open (pre-Send) | Draft preserved, no popup reset | ✅ Passed (`annotator-popup-reentry.test.ts`) |
| **#196** | Right-click while popup is open | Falls through to native | ✅ Passed (`annotator.isBusy` yield + `isActive` guard) |
| **#197** | Keyboard Menu key (`Shift+F10`) | Opens native context menu | ✅ Passed (`pointerType === ""` gate) |
| **#197** | Touch long-press (Android/Windows) | Opens SitePing composer | ✅ Passed (`pointerType === "touch"`) |
| **#197** | Pen long-press (Windows Ink) | Opens SitePing composer | ✅ Passed (`pointerType === "pen"`) |
