### PR TITLE
ci(release): fail the run when a manifest version is missing from npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,3 +292,34 @@ jobs:
         working-directory: packages/adapter-localstorage
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Post-release guard (#184): every version in the release-please manifest
+  # must exist on npm once the publish fan-out settles. Catches a publish job
+  # that failed after tagging (run #166) and the tag-created-but-publish-
+  # skipped case (run #182), and keeps failing every push until the gap is
+  # repaired (rescue: workflow_dispatch with publish=true). Skipped when
+  # release-please itself did not run (CI failure): a merged-but-unreleased
+  # release PR would otherwise read as a false gap.
+  verify-publish:
+    needs:
+      - release-please
+      - publish-widget
+      - publish-adapter-prisma
+      - publish-cli
+      - publish-adapter-memory
+      - publish-dashboard
+      - publish-adapter-localstorage
+    if: |
+      !cancelled() &&
+      (needs.release-please.result == 'success' ||
+       (github.event_name == 'workflow_dispatch' && inputs.publish))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Verify npm versions match the release-please manifest
+        run: node scripts/verify-npm-publish.mjs

--- a/scripts/verify-npm-publish.mjs
+++ b/scripts/verify-npm-publish.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Post-release guard (issue #184): every version in the release-please
+// manifest must exist on npm. Catches both observed silent-failure modes —
+// a publish job that failed after its tag was created (release run #166),
+// and publish jobs skipped because releases_created came out false despite
+// the tag (run #182). Runs at the end of every release.yml push run, so a
+// gap keeps failing the workflow until it is repaired (rescue:
+// workflow_dispatch with publish=true).
+//
+// Usage: node verify-npm-publish.mjs [manifest-path]
+// Env:   VERIFY_PUBLISH_ATTEMPTS (default 4) and VERIFY_PUBLISH_DELAY_MS
+//        (default 20000) — the retries absorb npm read-after-publish lag.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const manifestPath = process.argv[2] ?? ".release-please-manifest.json";
+// CI-only knobs — this script never runs through a turbo task, so declaring
+// them in turbo.json (what noUndeclaredEnvVars asks for) would be wrong.
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: not a turbo task input
+const attempts = Number(process.env.VERIFY_PUBLISH_ATTEMPTS ?? 4);
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: not a turbo task input
+const delayMs = Number(process.env.VERIFY_PUBLISH_DELAY_MS ?? 20_000);
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** True when name@version is visible on the npm registry. */
+function isPublished(name, version) {
+  try {
+    const out = execFileSync("npm", ["view", `${name}@${version}`, "version", "--loglevel=error"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return out.trim() === version;
+  } catch {
+    // npm exits non-zero with E404 when the exact version does not exist —
+    // and a just-published version can 404 briefly, hence the retry loop.
+    return false;
+  }
+}
+
+const targets = Object.entries(manifest).flatMap(([pkgPath, version]) => {
+  const pkg = JSON.parse(readFileSync(join(pkgPath, "package.json"), "utf8"));
+  return pkg.private ? [] : [{ name: pkg.name, version }];
+});
+
+let missing = targets;
+for (let attempt = 1; attempt <= attempts && missing.length > 0; attempt++) {
+  if (attempt > 1) {
+    console.log(`Retrying ${missing.length} package(s) in ${delayMs / 1000}s (attempt ${attempt}/${attempts})…`);
+    await sleep(delayMs);
+  }
+  missing = missing.filter(({ name, version }) => !isPublished(name, version));
+}
+
+const rows = targets.map(({ name, version }) => {
+  const ok = !missing.some((m) => m.name === name);
+  console.log(`${ok ? "OK     " : "MISSING"} ${name}@${version}`);
+  return `| ${name} | ${version} | ${ok ? "✅ published" : "❌ missing"} |`;
+});
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions built-in, not a turbo task input
+const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+if (stepSummary) {
+  appendFileSync(
+    stepSummary,
+    `## npm publish verification\n\n| Package | Manifest version | npm |\n|---|---|---|\n${rows.join("\n")}\n`,
+  );
+}
+
+if (missing.length > 0) {
+  console.error(
+    `\n${missing.length} manifest version(s) missing from npm — a tag/release exists without its publication (issue #184).\n` +
+      "Rescue: re-run the Release workflow via workflow_dispatch with publish=true.",
+  );
+  process.exit(1);
+}
+console.log(`\nAll ${targets.length} manifest versions are live on npm.`);


### PR DESCRIPTION
Fixes #184.

## What

A `verify-publish` job at the end of `release.yml`: after the publish fan-out settles, every version in `.release-please-manifest.json` must be visible on npm, or the run fails with a per-package table in the step summary.

## Why this shape

#184 documented two distinct silent-failure modes, and this guard catches both **on the faulty run itself**:

- **Run #166** — one `publish-*` job failed after its tag was created. `verify-publish` `needs` all six publish jobs with `!cancelled()`, so it still runs and turns the buried job failure into an explicit "manifest version missing from npm" verdict.
- **Run #182** — `releases_created` came out `false` despite the tag, so build+publish were *skipped* and the run was green. `verify-publish` runs on **every** push run (not only when releases are created), so the manifest/npm gap fails that very run — and keeps failing every subsequent push to `main` until the gap is repaired (`workflow_dispatch` with `publish=true`, as documented in the failure message).

Skip conditions are deliberate: when `release-please` itself didn't run (CI failure on a merged release PR), the manifest is legitimately ahead of npm until the next successful run — verifying there would be a false alarm on an already-red run.

## Issue checklist mapping

- [x] Post-publish verification job comparing the manifest with `npm view`, failing on any gap (piste 1 — the direct guard).
- [x] Explicit per-package success/missing recap at the end of the run (piste 3, via `$GITHUB_STEP_SUMMARY`).
- [ ] Root-causing why `releases_created` was `false` at #182 — deliberately not attempted: unreproducible after the fact, and the guard converts any recurrence from silent to loud, which is the actionable part.
- [ ] Targeted single-package re-run — left out; `publish=true` republishes idempotently (existing versions 403 → those jobs fail visibly, the missing one goes through), and the guard now tells you exactly which package needs it.

## Verification (local, against the real registry)

- Happy path: `node scripts/verify-npm-publish.mjs` → 6/6 `OK`, exit 0, summary table written.
- Simulated #182 gap (doctored manifest with `widget@0.10.99`): retry loop engages (only the missing package is re-queried), then exit 1 with the rescue instruction.
- `node --check`, YAML parse, and `bun run lint` back to the repo baseline (0 warnings; the CI-only env knobs carry motivated `biome-ignore`s since they are not turbo task inputs).
- Retries (4 × 20 s by default, env-tunable) absorb npm read-after-publish replication lag, so a publish that succeeded seconds earlier can't false-positive.
