### PR TITLE
ci: enterprise-grade pipeline — security scanning, supply-chain pinning, quality gates, automation

### DIFF
--- a/.attw.json
+++ b/.attw.json
@@ -1,0 +1,4 @@
+{
+  "profile": "node16",
+  "ignoreRules": ["internal-resolution-error", "false-esm", "cjs-resolves-to-esm"]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Conventional title: the repo is squash-only, so the PR title must pass
+    # the PR-title check and be parseable by the auto-labeller.
+    commit-message:
+      prefix: chore
+      include: scope
+    # Wait a week before adopting a new release: a freshly compromised
+    # package version is usually yanked within days. Security advisories
+    # bypass the cooldown.
+    cooldown:
+      default-days: 7
     groups:
       dev-dependencies:
         dependency-type: development
@@ -21,4 +31,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,10 +27,10 @@ labels:
       title: "^build(\\(.+\\))?!?:.*"
   - label: "dependencies"
     matcher:
-      title: "^(chore\\(deps\\)|deps)(\\(.+\\))?!?:.*"
+      title: "^(chore\\(deps(-dev)?\\)|deps)(\\(.+\\))?!?:.*"
   - label: "type:chore"
     matcher:
-      title: "^chore(?!\\(deps\\))(\\(.+\\))?!?:.*"
+      title: "^chore(?!\\(deps(-dev)?\\))(\\(.+\\))?!?:.*"
   - label: "type:i18n"
     matcher:
       title: "(?i).*(i18n|locale|translation|translate).*"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -56,3 +56,16 @@
 - name: ignore-for-release
   color: e4e669
   description: Exclude this PR from auto-generated release notes
+
+# Triage-flow labels — the stale workflow only acts on the first two.
+- name: awaiting-response
+  color: e99695
+  description: Waiting for more information from the author
+
+- name: needs-reproduction
+  color: fbca04
+  description: Needs a minimal reproduction before triage can continue
+
+- name: stale
+  color: ededed
+  description: No recent activity — will be closed soon without an update

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -8,9 +8,7 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: auto-label-${{ github.event.pull_request.number }}
@@ -19,6 +17,10 @@ concurrency:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Apply labels from PR title
         uses: srvaroa/labeler@bf262763a8a8e191f5847873aecc0f29df84f957 # v1.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_call:
 
+# Read-only everywhere: publishing, labelling and greeting live in dedicated
+# workflows with their own scoped tokens.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -12,15 +17,18 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - name: Cache bun install
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -42,29 +50,56 @@ jobs:
         run: bun run test:run -- --coverage
 
       - name: Bundle size gate
-        run: bun --cwd packages/widget run size
+        shell: bash
+        run: |
+          {
+            echo '### Bundle size — @siteping/widget'
+            echo '```'
+            bun --cwd packages/widget run size
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Dashboard bundle size gate
-        run: bun --cwd packages/dashboard run size
+        shell: bash
+        run: |
+          {
+            echo '### Bundle size — @siteping/dashboard'
+            echo '```'
+            bun --cwd packages/dashboard run size
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage/
 
+      # Tokenless upload works for fork PRs; CODECOV_TOKEN covers pushes and
+      # same-repo branches. Never blocks CI — Codecov's own status checks are
+      # informational (see codecov.yml).
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - name: Cache bun install
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
           key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -81,7 +116,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
@@ -102,8 +137,114 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # The workflows themselves are an attack surface (pull_request_target,
+  # template injection, unpinned actions). actionlint checks syntax and the
+  # embedded shell; zizmor audits for security anti-patterns. Exceptions are
+  # documented in .github/zizmor.yml.
+  lint-workflows:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # go run verifies the module against the public checksum database —
+      # no curl-piped installer, no extra pinned action.
+      - name: actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
+
+      - name: zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pipx run zizmor==1.28.0 .
+
+  # What we publish must actually resolve for consumers: exports map, types,
+  # ESM/CJS duality. publint lints the packed tarball; attw type-checks it
+  # under every resolution mode. Known pre-existing debt (bundled d.ts files
+  # referencing modules that are not shipped) is ignored via .attw.json —
+  # see the tracking issue — so this gate only fails on NEW problem kinds.
+  pkg-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Cache bun install
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: publint
+        run: |
+          for pkg in widget adapter-prisma adapter-memory adapter-localstorage dashboard cli; do
+            echo "::group::publint @siteping/$pkg"
+            bun x publint@0.3.22 "packages/$pkg"
+            echo "::endgroup::"
+          done
+
+      - name: Are the types wrong
+        run: |
+          for pkg in widget adapter-prisma adapter-memory adapter-localstorage dashboard cli; do
+            echo "::group::attw @siteping/$pkg"
+            bun x @arethetypeswrong/cli@0.18.5 "packages/$pkg" --pack
+            echo "::endgroup::"
+          done
+
+  # bun only drives install/build — vitest and the published adapters run on
+  # the consumer's Node. Exercise the supported majors.
+  node-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Cache bun install
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-
+
+      - run: bun install --frozen-lockfile
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Build
+        run: bun run build
+
+      - name: Unit tests on Node ${{ matrix.node-version }}
+        run: ./node_modules/.bin/vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,12 @@ jobs:
       - name: Build
         run: bun run build
 
+      # Guards the `npx @siteping/cli` startup path: the ESM bundle once
+      # shipped without a require shim and crashed instantly under Node
+      # (fixed in #221). A --help run catches any bundle-init regression.
+      - name: CLI binary smoke test
+        run: node packages/cli/dist/index.js --help
+
       - name: publint
         run: |
           for pkg in widget adapter-prisma adapter-memory adapter-localstorage dashboard cli; do

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "41 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: codeql (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `actions` scans the workflow files themselves (untrusted-input
+        # flows), complementing zizmor's pattern-based audit in CI.
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs for minor/patch updates of DEVELOPMENT
+# dependencies once every required branch-protection check passes.
+# Production dependencies, majors and GitHub Actions bumps stay manual —
+# those deserve human eyes (supply-chain risk / runtime impact).
+#
+# Safe: the gate is the PR author (github.event.pull_request.user.login),
+# which cannot be spoofed by re-running the workflow, and `gh pr merge --auto`
+# only queues the merge behind the required status checks.
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'NeosiaNexus/SitePing'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for dev-dependency minor/patch bumps
+        if: >
+          steps.metadata.outputs.dependency-type == 'direct:development' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency review
+
+# Fails a PR that introduces a dependency with a known vulnerability
+# (moderate or worse). Reads the dependency graph diff computed by GitHub
+# from bun.lock.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/enrich-release.yml
+++ b/.github/workflows/enrich-release.yml
@@ -15,8 +15,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: enrich-release-${{ github.event.release.id || inputs.release_tag }}
@@ -25,9 +24,12 @@ concurrency:
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Append contributors section to release notes
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
           INPUT_FORCE: ${{ inputs.force }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,55 @@
+name: Preview packages
+
+# Publishes installable preview builds of every published package for each PR
+# via pkg.pr.new (StackBlitz, free for open source). No secrets involved —
+# auth is the pkg.pr.new GitHub App commenting install instructions on the PR.
+# Gated on the ENABLE_PKG_PR_NEW repository variable so the job stays skipped
+# until the app is installed: https://github.com/apps/pkg-pr-new
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pkg-pr-new-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: vars.ENABLE_PKG_PR_NEW == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Cache bun install
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish previews
+        run: >
+          bun x pkg-pr-new@0.0.80 publish --comment=update
+          ./packages/widget
+          ./packages/adapter-prisma
+          ./packages/adapter-memory
+          ./packages/adapter-localstorage
+          ./packages/dashboard
+          ./packages/cli

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR title
+
+# The repo is squash-only: the PR title becomes the commit message that
+# release-please and the auto-labeller parse. A malformed title silently
+# breaks changelogs and labels — validate it up front.
+#
+# Safe: reads only the PR title via the GitHub API; never checks out or
+# executes PR code. `pull_request_target` is required so the check also runs
+# with a token on PRs from forks.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate conventional commit title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,6 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -23,12 +18,21 @@ concurrency:
 jobs:
   ci:
     if: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
 
   release-please:
     if: ${{ github.event_name == 'push' }}
     needs: ci
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The action authenticates with RELEASE_PAT; these grants document what a
+    # fallback to GITHUB_TOKEN would need (release PRs, tags, labels).
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       widget-release_created: ${{ steps.release.outputs['packages/widget--release_created'] }}
@@ -38,7 +42,7 @@ jobs:
       dashboard-release_created: ${{ steps.release.outputs['packages/dashboard--release_created'] }}
       cli-release_created: ${{ steps.release.outputs['packages/cli--release_created'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           token: ${{ secrets.RELEASE_PAT }}
@@ -52,10 +56,15 @@ jobs:
       (needs.release-please.outputs.releases_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
@@ -65,7 +74,7 @@ jobs:
         run: bun run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-packages
           path: |
@@ -84,25 +93,28 @@ jobs:
       (needs.release-please.outputs.widget-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -120,25 +132,28 @@ jobs:
       (needs.release-please.outputs.adapter-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -156,25 +171,28 @@ jobs:
       (needs.release-please.outputs.cli-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -192,25 +210,28 @@ jobs:
       (needs.release-please.outputs.adapter-memory-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -228,25 +249,28 @@ jobs:
       (needs.release-please.outputs.dashboard-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -264,25 +288,28 @@ jobs:
       (needs.release-please.outputs.adapter-localstorage-release_created == 'true' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.11"
 
       - run: bun install --frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-packages
           path: packages/
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -314,10 +341,15 @@ jobs:
       (needs.release-please.result == 'success' ||
        (github.event_name == 'workflow_dispatch' && inputs.publish))
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+# Continuous supply-chain security score. publish_results feeds the public
+# badge and the scorecard.dev viewer; the SARIF upload surfaces findings in
+# the Security tab.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 2 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: Stale follow-up
+
+# Deliberately narrow: only issues/PRs explicitly labelled awaiting-response
+# or needs-reproduction go stale. Nothing else is ever touched — blanket
+# stale bots punish patient contributors.
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          any-of-labels: "awaiting-response,needs-reproduction"
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          remove-stale-when-updated: true
+          operations-per-run: 60
+          stale-issue-message: >-
+            This issue is waiting on a reply or a reproduction and hasn't had
+            activity for 14 days. It will be closed in 7 days if nothing
+            changes — a quick comment is enough to keep it open.
+          close-issue-message: >-
+            Closing for now since we didn't get the information needed to move
+            forward. Not a rejection! Comment with the missing details and
+            we'll happily reopen.
+          stale-pr-message: >-
+            This pull request is waiting on the author and hasn't had activity
+            for 14 days. It will be closed in 7 days if nothing changes — push
+            a commit or leave a comment to keep it open.
+          close-pr-message: >-
+            Closing for now since the requested changes didn't land. If you
+            want to pick it back up, reopen or open a fresh PR — happy to
+            review again.

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,18 +11,22 @@ on:
       - .github/workflows/sync-labels.yml
   workflow_dispatch:
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Sync labels
-        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v5.3.0
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yml

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -10,16 +10,18 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
       - name: Greet first-time contributors
-        uses: actions/first-interaction@v3
+        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# zizmor (workflow security audit) configuration.
+# Run in CI by the lint-workflows job; each ignore is a reviewed exception.
+
+rules:
+  dangerous-triggers:
+    ignore:
+      # These use pull_request_target deliberately so they work on fork PRs.
+      # None of them checks out or executes PR code, and no untrusted input
+      # reaches a `run:` step — see the header comment in each file.
+      - welcome.yml
+      - auto-label.yml
+      - pr-title.yml
+
+  use-trusted-publishing:
+    ignore:
+      # pkg.pr.new previews are not npm publishes — auth is its GitHub App,
+      # there is no trusted-publishing equivalent to switch to.
+      - pkg-pr-new.yml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Draw rectangles, leave comments, track bugs — directly on the live site.
 [![npm downloads](https://img.shields.io/npm/dm/@siteping/widget?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/@siteping/widget)
 [![license](https://img.shields.io/npm/l/@siteping/widget?style=flat&colorA=000000&colorB=000000)](./LICENSE)
 [![build](https://img.shields.io/github/actions/workflow/status/NeosiaNexus/SitePing/ci.yml?style=flat&colorA=000000&colorB=000000)](https://github.com/NeosiaNexus/SitePing/actions)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/NeosiaNexus/SitePing/codeql.yml?label=CodeQL&style=flat&colorA=000000&colorB=000000)](https://github.com/NeosiaNexus/SitePing/security/code-scanning)
+[![coverage](https://img.shields.io/codecov/c/github/NeosiaNexus/SitePing?style=flat&colorA=000000&colorB=000000)](https://app.codecov.io/gh/NeosiaNexus/SitePing)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/NeosiaNexus/SitePing?label=scorecard&style=flat&colorA=000000&colorB=000000)](https://scorecard.dev/viewer/?uri=github.com/NeosiaNexus/SitePing)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![Bundle Size](https://img.shields.io/badge/widget-%E2%89%A454%20KB%20gzip%20(ESM)-blue)](./packages/widget/.size-limit.json)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Codecov feedback is informational: the hard coverage gate lives in
+# vitest.config.ts thresholds (fails `bun run test:run -- --coverage` in CI).
+# Codecov adds the PR comment with the diff/patch view and the README badge.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, files"
+  require_changes: true
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
Upgrades the CI/CD surface to what large OSS repos run — everything free for public repos. Companion repo-settings changes (applied via API, not in this diff) are listed at the bottom.

## 🔒 Security

| What | How |
|---|---|
| **CodeQL** | `codeql.yml` — `javascript-typescript` **and** `actions` languages, `security-extended` suite, on PR + push + weekly. Results in the Security tab. |
| **OpenSSF Scorecard** | `scorecard.yml` — weekly + on push, `publish_results` feeds the public badge, SARIF into code scanning. |
| **Dependency review** | `dependency-review.yml` — fails any PR introducing a dependency with a known vulnerability (moderate+), comments on failure. |
| **Workflow audit in CI** | new `lint-workflows` job — `actionlint` (syntax + shellcheck) and `zizmor` (security anti-patterns). Exceptions reviewed and documented in `.github/zizmor.yml`. |
| **Full SHA pinning** | every action in every workflow is pinned to a commit SHA with a version comment (Dependabot keeps bumping them). Includes fixing the `ghaction-github-labeler` pin comment which claimed v5.3.0 while the SHA is v6.0.0. |
| **Token hygiene** | job-scoped least-privilege `permissions:` everywhere, `persist-credentials: false` on all checkouts, `timeout-minutes` on every job. |
| **Dependabot cooldown** | 7-day wait before adopting new releases (freshly-compromised versions are usually yanked within days; security advisories bypass it). |

## ✅ Quality

- **Codecov** upload after the coverage run — PR comment with diff coverage, README badge. Statuses are informational (`codecov.yml`): the hard gate stays vitest's thresholds.
- **publint + arethetypeswrong** (`pkg-checks` job) — the packed tarball of all 6 published packages must resolve correctly (exports map, types, ESM/CJS). Pre-existing debt is pinned in `.attw.json` so the gate only fails on **new** problem kinds → tracking issue follows.
- **Node compat matrix** (`node-compat` job) — unit suite on Node 20/22/24; bun only drives install/build, consumers run Node.
- **Bundle size gates** now also write their table to the job summary.

## 🤖 Automation

- **PR title validation** (`pr-title.yml`) — squash-only repo: the title *is* the commit release-please and the labeler parse. (Add it to required checks **after** this merges — `pull_request_target` runs from `main`.)
- **Dependabot auto-merge** (`dependabot-auto-merge.yml`) — dev-dependency minor/patch bumps auto-merge once all required checks pass. Production deps, majors and Actions bumps stay manual.
- **pkg.pr.new previews** (`pkg-pr-new.yml`) — installable preview packages on every PR; skipped until the GitHub App is installed and `ENABLE_PKG_PR_NEW=true` is set.
- **Scoped stale bot** (`stale.yml`) — only `awaiting-response` / `needs-reproduction` items, 14 d + 7 d, friendly messages. Never touches anything else.
- Dependabot now emits conventional titles (`chore(deps)` / `chore(deps-dev)`); labeler regex updated accordingly; new triage labels (`awaiting-response`, `needs-reproduction`, `stale`).

## ⚙️ Repo settings changed via API (already live)

- Secret scanning + push protection **enabled**
- Private vulnerability reporting **enabled**
- Default workflow token → **read-only**, PR approval by Actions disabled
- Branch protection: required checks now `ci`, `e2e`, `lint-workflows`, `pkg-checks`, `dependency-review` (strict, linear history and conversation resolution preserved)

## 🔍 Verified locally

- `actionlint` v1.7.12: clean on all 13 workflows
- `zizmor` v1.28.0 (with online audits): **0 findings**, 4 documented ignores
- `publint` + `attw`: exit 0 on all 6 packages with the committed `.attw.json`
- `bun run build` + `biome check`: green

## 👤 Manual follow-ups (owner-only)

1. **Codecov**: sign in at codecov.io with GitHub, add the `CODECOV_TOKEN` repo secret (upload is non-blocking meanwhile).
2. **pkg.pr.new**: install https://github.com/apps/pkg-pr-new on the repo, then `gh variable set ENABLE_PKG_PR_NEW --body true`.
3. After merge: add `pr-title` to required status checks.
