### PR TITLE
fix(cli): run under plain Node — createRequire shim + Object.groupBy polyfill

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,3 +1,5 @@
+// Must run before prisma-ast: chevrotain needs Object.groupBy (Node 21+).
+import "../utils/object-group-by-polyfill.js";
 import { type Dirent, existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import * as p from "@clack/prompts";

--- a/packages/cli/src/generators/prisma.ts
+++ b/packages/cli/src/generators/prisma.ts
@@ -1,3 +1,5 @@
+// Must run before prisma-ast: chevrotain needs Object.groupBy (Node 21+).
+import "../utils/object-group-by-polyfill.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { AttributeArgument, BlockAttribute, Field, Model, Property } from "@mrleebo/prisma-ast";
 import { getSchema, printSchema } from "@mrleebo/prisma-ast";

--- a/packages/cli/src/utils/object-group-by-polyfill.ts
+++ b/packages/cli/src/utils/object-group-by-polyfill.ts
@@ -1,0 +1,41 @@
+/**
+ * chevrotain@12 (bundled via @mrleebo/prisma-ast) calls `Object.groupBy` at
+ * parser-initialization time, but the API only exists from Node 21 while this
+ * package declares `engines.node >= 20`. Fill it in when missing — spec-shaped
+ * and a no-op from Node 21 onward.
+ *
+ * Imported for its side effect at the top of every module that (transitively)
+ * loads prisma-ast, so it runs before chevrotain regardless of entry point
+ * (CLI binary, tests, programmatic import).
+ */
+const patchable = Object as typeof Object & {
+  groupBy?: <T, K extends PropertyKey>(
+    items: Iterable<T>,
+    keySelector: (item: T, index: number) => K,
+  ) => Partial<Record<K, T[]>>;
+};
+
+if (typeof patchable.groupBy !== "function") {
+  Object.defineProperty(patchable, "groupBy", {
+    value: <T, K extends PropertyKey>(
+      items: Iterable<T>,
+      keySelector: (item: T, index: number) => K,
+    ): Partial<Record<K, T[]>> => {
+      const groups = Object.create(null) as Record<K, T[]>;
+      let index = 0;
+      for (const item of items) {
+        const key = keySelector(item, index);
+        index += 1;
+        const bucket = groups[key];
+        if (bucket === undefined) {
+          groups[key] = [item];
+        } else {
+          bucket.push(item);
+        }
+      }
+      return groups;
+    },
+    writable: true,
+    configurable: true,
+  });
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,7 +5,17 @@ export default defineConfig({
   format: ["esm"],
   platform: "node",
   target: "node18",
-  banner: { js: "#!/usr/bin/env node" },
+  banner: {
+    // The createRequire shim is load-bearing: bundled CJS deps (commander,
+    // prisma-ast) require() node builtins, and esbuild's ESM output resolves
+    // those through the ambient `require` — without it the binary throws
+    // "Dynamic require of \"events\" is not supported" at startup under Node.
+    js: [
+      "#!/usr/bin/env node",
+      'import { createRequire as __sitepingCreateRequire } from "node:module";',
+      "const require = __sitepingCreateRequire(import.meta.url);",
+    ].join("\n"),
+  },
   dts: false,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Two real-world startup crashes, found by #219's new `node-compat` matrix

### 1. `npx @siteping/cli` crashes at startup on **every** Node version 💥
The published `@siteping/cli@0.5.0` throws before doing anything:
```
Error: Dynamic require of "events" is not supported
```
tsup bundles CJS deps (commander, prisma-ast) into ESM output; esbuild converts their `require('events')` into a shim that needs an ambient `require` — which never existed. Only `bun x` users were unaffected (bun tolerates dynamic require in ESM). **The README's `npx @siteping/cli init` flow was broken for all Node users.** Fix: `createRequire` shim in the tsup banner.

### 2. Crash on Node 20 in the Prisma parser path
chevrotain@12 (via @mrleebo/prisma-ast) calls `Object.groupBy` at parser-init — a **Node 21+** API, while we declare `engines.node >= 20`. Fix: spec-shaped polyfill imported before every prisma-ast import site (covers binary, tests, programmatic use).

## Empirical verification
| Check | Before | After |
|---|---|---|
| `node dist/index.js --help` on Node 20.20.2 | ❌ instant crash | ✅ |
| `node dist/index.js --help` on Node 22 | ❌ instant crash | ✅ |
| cli test files on Node 20.20.2 | ❌ 4 failed (`Object.groupBy is not a function`) | ✅ 114/114 |
| cli test files on Node 22 | ✅ | ✅ 114/114 |
| `npx @siteping/cli@latest --help` on Node 20 | ❌ reproduces crash 1 | (fixed by next release) |

Other packages checked: no `Dynamic require` shim in any other dist.

## Merge order
**Merge this before #219** — #219's `node-compat (20)` job is red precisely because of bug 2, and `release.yml` gates releases on CI: merging #219 first would block releases until this lands. A `pkg-checks` smoke step guarding crash 1 forever is added on #219.