### PR TITLE
docs(readme): document CLI Node version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ Interactive setup that:
 2. Merges the Siteping models (idempotent — safe to run multiple times)
 3. Generates the Next.js App Router API route
 
+Requires Node ≥ 20 (also runs under `bun x`). CI exercises the CLI on Node 20, 22 and 24.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
One-line README addition under **## CLI**: the Node ≥ 20 requirement is now real (enforced by the `node-compat` matrix, fixed in cli@0.5.1).

Doubles as the **dress rehearsal of the full new pipeline** on a fresh PR:
- first tokened **Codecov** upload → activates the repo (fixes "tracked lines: deactivated")
- first run of the **`preview`** job → proves the pkg.pr.new app installation end-to-end
- first live run of the required **`pr-title`** check