### PR TITLE
ci: fix silently bypassed bundle size gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,16 @@ jobs:
       - name: Test
         run: bun run test:run -- --coverage
 
+      # `bun --cwd <dir> run <script>` silently prints usage and exits 0 on
+      # current bun — the gate never ran and nothing failed. Use a subshell
+      # cd, which is what the mutation test in the PR verified end-to-end.
       - name: Bundle size gate
         shell: bash
         run: |
           {
             echo '### Bundle size — @siteping/widget'
             echo '```'
-            bun --cwd packages/widget run size
+            (cd packages/widget && bun run size)
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
@@ -65,7 +68,7 @@ jobs:
           {
             echo '### Bundle size — @siteping/dashboard'
             echo '```'
-            bun --cwd packages/dashboard run size
+            (cd packages/dashboard && bun run size)
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
       # cd, which is what the mutation test in the PR verified end-to-end.
       - name: Bundle size gate
         shell: bash
+        # NO_COLOR: size-limit force-colorizes under CI=1; the step summary
+        # renders ANSI codes as literal garbage.
+        env:
+          NO_COLOR: "1"
         run: |
           {
             echo '### Bundle size — @siteping/widget'
@@ -64,6 +68,8 @@ jobs:
 
       - name: Dashboard bundle size gate
         shell: bash
+        env:
+          NO_COLOR: "1"
         run: |
           {
             echo '### Bundle size — @siteping/dashboard'


### PR DESCRIPTION
## The bug (spotted by @NeosiaNexus in the step summary)

The summary showed bun's **usage screen** instead of the size-limit table. Cause: `bun --cwd packages/widget run size` doesn't run the script on current bun — it prints usage + the script list and **exits 0**. Both bundle-size gates were silent no-ops.

**This predates #219**: the same usage dump appears in the `Bundle size gate` logs of runs on the old ci.yml (checked on PR #221's run). The step summary added in #219 is what finally made it visible.

## Fix
`(cd packages/widget && bun run size)` — plain subshell cd, immune to bun flag-parsing changes.

## Empirical verification (GitHub-identical `bash -e -o pipefail`)
| Case | Result |
|---|---|
| Normal run | size-limit table rendered in summary, exit 0 |
| Mutation `--limit 1B` through the full construct (braces + subshell + tee) | **exit 1** — failure propagates, the gate bites |
| `actionlint` + `zizmor` | clean |

The summary of this PR's own run doubles as proof: it must show the real table, not the usage screen.