### PR TITLE
ci: stop greeting bots as new contributors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,6 +14,10 @@ permissions: {}
 
 jobs:
   welcome:
+    # first-interaction's prior-contribution search never matches bot logins,
+    # so dependabot/allcontributors were greeted as "new" on every PR. Bots
+    # don't need a welcome — skip them at the job level.
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Bug (reported by @NeosiaNexus)

The 🎉 welcome comment fired on **every** dependabot and allcontributors PR (#228, #195, #194, #193, #192, #188, #187, #186, #185, … 15+ occurrences). Cause: `actions/first-interaction` decides *first contribution* by searching the author's prior issues/PRs — that search never matches bot logins, so bots are eternally *new*.

Humans were handled correctly (greeted exactly once: #217, #190, #157; owner never greeted).

## Fix
Job-level `if: github.event.sender.type != 'Bot'` — bots don't need onboarding. On bot PRs the `welcome` check now shows *skipped* instead of running the action at all.

Old spam comments on closed dependabot PRs are left untouched (deleting comments is destructive; say the word if you want them cleaned up).