### PR TITLE
fix: ship fully resolvable type declarations for every published package

### DIFF
--- a/.attw.json
+++ b/.attw.json
@@ -1,4 +1,3 @@
 {
-  "profile": "node16",
-  "ignoreRules": ["internal-resolution-error", "false-esm", "cjs-resolves-to-esm"]
+  "profile": "node16"
 }

--- a/packages/adapter-localstorage/package.json
+++ b/packages/adapter-localstorage/package.json
@@ -6,9 +6,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/adapter-memory/package.json
+++ b/packages/adapter-memory/package.json
@@ -6,9 +6,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -6,9 +6,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -6,10 +6,17 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/dashboard/tsup.config.ts
+++ b/packages/dashboard/tsup.config.ts
@@ -14,7 +14,9 @@ const pureCalls = ["console.debug", "console.info"] as const;
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm"],
+  // CJS twin is a single file (splitting is ESM-only): require() consumers
+  // lose lazy locale chunks but keep full functionality (#220).
+  format: ["esm", "cjs"],
   platform: "browser",
   target: "es2022",
   dts: true,

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -6,15 +6,28 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "script": "./dist/index.global.js"
+      "script": "./dist/index.global.js",
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./react": {
-      "types": "./dist/react.d.ts",
-      "import": "./dist/react.js"
+      "import": {
+        "types": "./dist/react.d.ts",
+        "default": "./dist/react.js"
+      },
+      "require": {
+        "types": "./dist/react.d.cts",
+        "default": "./dist/react.cjs"
+      }
     }
   },
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/widget/scripts/verify-dist-guard.mjs
+++ b/packages/widget/scripts/verify-dist-guard.mjs
@@ -28,15 +28,18 @@ const esbuild = resolveEsbuild();
 const distDir = new URL("../dist", import.meta.url).pathname;
 const LITERAL = "process.env.NODE_ENV";
 
-const jsFiles = readdirSync(distDir).filter((f) => f.endsWith(".js"));
+const jsFiles = readdirSync(distDir).filter((f) => f.endsWith(".js") || f.endsWith(".cjs"));
 const sources = new Map(jsFiles.map((f) => [f, readFileSync(join(distDir, f), "utf8")]));
 
 // The IIFE bundle is self-contained; ESM entries may carry the launcher in a
-// shared chunk — check bundle *groups*, not individual files.
+// shared chunk — check bundle *groups*, not individual files. The CJS twins
+// are single-file bundles and must carry the literal too.
 const groups = {
   "index.global.js (iife)": ["index.global.js"],
   "index.js (+chunks)": jsFiles.filter((f) => f === "index.js" || f.startsWith("chunk-")),
   "react.js (+chunks)": jsFiles.filter((f) => f === "react.js" || f.startsWith("chunk-")),
+  "index.cjs (cjs)": ["index.cjs"],
+  "react.cjs (cjs)": ["react.cjs"],
 };
 
 const errors = [];

--- a/packages/widget/tsup.config.ts
+++ b/packages/widget/tsup.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from "tsup";
 
 // Three parallel builds:
-//  - ESM main: code-split so dynamic imports (Panel, locale chunks) ship as
-//    separate files and only load when actually used.
+//  - ESM+CJS main: ESM is code-split so dynamic imports (Panel, locale
+//    chunks) ship as separate files and only load when actually used; the
+//    CJS twin is a single file (splitting is ESM-only) for require()
+//    consumers — Jest setups, legacy bundlers (#220).
 //  - IIFE main: single global script for <script src> consumers — splitting is
 //    incompatible with IIFE, so everything is inlined.
-//  - ESM React entry (`@siteping/widget/react`): React stays external so
+//  - ESM+CJS React entry (`@siteping/widget/react`): React stays external so
 //    consumers pin their own version.
 //
 // `esbuildOptions.pure` strips `console.debug` / `console.info` calls in the
@@ -26,7 +28,7 @@ const keepNodeEnvLiteral = { "process.env.NODE_ENV": "process.env.NODE_ENV" } as
 export default defineConfig([
   {
     entry: ["src/index.ts"],
-    format: ["esm"],
+    format: ["esm", "cjs"],
     platform: "browser",
     target: "es2022",
     dts: true,
@@ -61,7 +63,7 @@ export default defineConfig([
   },
   {
     entry: ["src/react.ts"],
-    format: ["esm"],
+    format: ["esm", "cjs"],
     platform: "browser",
     target: "es2022",
     dts: true,

--- a/scripts/fix-dts.mjs
+++ b/scripts/fix-dts.mjs
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 // Fixes .d.ts files that reference the unpublished @siteping/core package.
-// Rewrites imports to relative paths and copies core's type declarations.
+//
+// Core is an Internal Package: its JS is bundled into consumers via tsup
+// `noExternal`, but its type declarations are emitted per-module by `tsc`
+// (errors.d.ts, types.d.ts, ... with relative `./x.js` imports). Shipping a
+// subset used to leave dangling imports in the published tarballs — the
+// attw `internal-resolution-error` class tracked in #220. So:
+//
+//  1. copy EVERY core declaration file (except test-only testing.d.ts),
+//     renaming index.d.ts -> siteping-core.d.ts, so relative imports resolve;
+//  2. emit a .d.cts twin of each copy (specifiers rewritten .js -> .cjs) so
+//     the `require` condition resolves CJS-interpreted types end to end;
+//  3. rewrite '@siteping/core' imports in the consumer's own declarations to
+//     './siteping-core.js' (in .d.ts) or './siteping-core.cjs' (in .d.cts).
+//
 // Cross-platform replacement for fix-dts.sh (no sed/cp).
 
-import { copyFileSync, existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,38 +40,43 @@ if (!existsSync(coreDist)) {
   process.exit(1);
 }
 
-// 1. Rewrite '@siteping/core' imports to relative './siteping-core.js'
+// Relative specifiers in declaration files are always quoted import/export
+// paths — a global quoted-specifier rewrite is safe there.
+const toCjsSpecifiers = (content) => content.replace(/(["'])\.\/([^"']+)\.js\1/g, "$1./$2.cjs$1");
+
+// 1 + 2. Copy core declarations (and their .d.cts twins).
+const coreFiles = readdirSync(coreDist).filter((f) => f.endsWith(".d.ts") && f !== "testing.d.ts");
+
+for (const file of coreFiles) {
+  const content = readFileSync(join(coreDist, file), "utf8");
+  const base = file === "index.d.ts" ? "siteping-core" : file.slice(0, -".d.ts".length);
+  writeFileSync(join(targetDir, `${base}.d.ts`), content, "utf8");
+  writeFileSync(join(targetDir, `${base}.d.cts`), toCjsSpecifiers(content), "utf8");
+  console.log(`  Copied: ${file} -> ${base}.d.ts + ${base}.d.cts`);
+}
+
+// 3. Point the consumer's own declarations at the copies, per interpretation.
+// (The copies themselves never reference @siteping/core — no-op for them.)
 const dtsFiles = readdirSync(targetDir).filter((f) => f.endsWith(".d.ts") || f.endsWith(".d.cts"));
 
 for (const file of dtsFiles) {
   const filePath = join(targetDir, file);
   let content = readFileSync(filePath, "utf8");
   const original = content;
+  const replacement = file.endsWith(".d.cts") ? "./siteping-core.cjs" : "./siteping-core.js";
 
-  content = content.replaceAll("'@siteping/core'", "'./siteping-core.js'");
-  content = content.replaceAll('"@siteping/core"', '"./siteping-core.js"');
+  content = content.replaceAll("'@siteping/core'", `'${replacement}'`);
+  content = content.replaceAll('"@siteping/core"', `"${replacement}"`);
+
+  if (content.includes("@siteping/core")) {
+    console.error(`  UNRESOLVED reference to @siteping/core (subpath import?) in ${file}`);
+    process.exit(1);
+  }
 
   if (content !== original) {
     writeFileSync(filePath, content, "utf8");
     console.log(`  Patched: ${file}`);
   }
-}
-
-// 2. Copy core's .d.ts files, renaming index.d.ts to siteping-core.d.ts
-const copies = [
-  { src: "index.d.ts", dest: "siteping-core.d.ts" },
-  { src: "types.d.ts", dest: "types.d.ts" },
-  { src: "schema.d.ts", dest: "schema.d.ts" },
-];
-
-for (const { src, dest } of copies) {
-  const srcPath = join(coreDist, src);
-  if (!existsSync(srcPath)) {
-    console.error(`Missing core type file: ${srcPath}`);
-    process.exit(1);
-  }
-  copyFileSync(srcPath, join(targetDir, dest));
-  console.log(`  Copied: ${src} -> ${dest}`);
 }
 
 console.log("fix-dts: done");

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turborepo.dev/schema.v2.json",
-  "globalDependencies": ["tsconfig.base.json", "biome.json"],
+  "globalDependencies": ["tsconfig.base.json", "biome.json", "scripts/fix-dts.mjs"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Fixes #220 — and flips the `pkg-checks` attw gate to **strict** (profile node16, zero `ignoreRules`).

## What was broken
1. **`internal-resolution-error` (all packages)** — `fix-dts.mjs` copied only 3 of core's declaration files; the copies import `./errors.js`, `./type-utils.js`, `./filters.js`, `./screenshot-storage.js` which were never shipped → dangling type imports in every published tarball.
2. **`false-esm` (3 adapters)** — one `types` field served the ESM-interpreted `.d.ts` under the `require` condition (tsup already emitted `.d.cts`, the exports map just never pointed at it).
3. **`cjs-resolves-to-esm` (widget, dashboard)** — ESM-only packages half-resolvable from CJS.

## The fix
| Piece | Change |
|---|---|
| `scripts/fix-dts.mjs` | copies **every** core d.ts (index → `siteping-core`), emits a **`.d.cts` twin** of each (specifiers `.js`→`.cjs`), rewrites `@siteping/core` per host extension, and fails loudly on any unresolved reference |
| adapters ×3 | exports split into `import`/`require` conditions with their own `types` |
| widget & dashboard | dual **ESM+CJS** builds (CJS single-file; splitting is ESM-only), `require` conditions, `main` field |
| `verify-dist-guard` | NODE_ENV production-guard literal now asserted in the CJS bundles too |
| `turbo.json` | `fix-dts.mjs` in `globalDependencies` (cache-busts builds when it changes) |
| `.attw.json` | **`ignoreRules` removed** — the gate now fails on ANY problem kind |

## Empirical verification
| Check | Result |
|---|---|
| `attw --pack` strict, all 6 packages | ✅ |
| `publint` all 6 | ✅ "All good" (adapter warnings gone) |
| Unit tests | ✅ 1979/1979 |
| ESM bundle sizes | ✅ byte-identical (30.38 / 112.1 / 20.98 kB) |
| **Real consumer project** (`module: node16`, `skipLibCheck: false`) | ✅ typechecks **import AND require** sides, incl. deep core types (`FeedbackRecord`, `SitepingStore`) |
| Runtime `require()` on Node 20 | ✅ `MemoryStore` instantiates, widget & dashboard load |
| `verify-dist-guard` (incl. new CJS groups) | ✅ passes in build |

Release impact: patch bump + npm publish for the 5 touched packages.