### PR TITLE
ci: prove the React 18 peer promise with a react-compat job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,50 @@ jobs:
             echo "::endgroup::"
           done
 
+  # peerDependencies promise `react >=18`, but the suite's devDeps pin React
+  # 19 — the oldest supported major was otherwise never exercised (same
+  # failure class as the Node 20 CLI bug, #221). Overrides pin the WHOLE tree
+  # to React 18 so RTL, react-dom internals and the components agree on one
+  # React; a vitest alias can't do that (mixed-React dispatcher errors).
+  react-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Cache bun install
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-
+
+      - name: Pin the dependency tree to React 18
+        run: |
+          node -e "
+          const fs = require('fs');
+          const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          p.overrides = { react: '18.3.1', 'react-dom': '18.3.1' };
+          fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+
+      # Not --frozen-lockfile: the override invalidates the lockfile by
+      # design, on an ephemeral runner.
+      - run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Unit tests on React 18
+        run: ./node_modules/.bin/vitest run
+
   # bun only drives install/build — vitest and the published adapters run on
   # the consumer's Node. Exercise the supported majors.
   node-compat:


### PR DESCRIPTION
Item 3 of the remaining hardening list: `peerDependencies` promise `react >=18`, but tests only ever ran on React 19 — an untested compatibility promise, the exact failure class that bit us with Node 20 and the CLI (#221).

## Approach
A `react-compat` job pins the **whole dependency tree** to React 18.3.1 via npm `overrides`, then runs the full unit suite. This is faithful to a real React 18 consumer: RTL, react-dom internals and the components all resolve one single React.

**Why not a vitest alias?** Tried first, empirically: aliasing `react`/`react-dom` only in the transform pipeline leaves RTL and react-dom's internal `require('react')` on React 19 → 116 mixed-React failures (`Cannot read properties of null (reading 'useMemo')`, “A React Element from an older version of React was rendered”). The overrides approach avoids the two-React trap entirely.

## Verification
- Isolated git worktree, exact CI flow (pinned bun 1.3.11, overrides, build): **1979/1979 tests pass on React 18.3.1** — the promise is true today.
- `react resolved: 18.3.1` confirmed from widget AND dashboard resolution before trusting the run.
- actionlint + zizmor clean.

Not a required check (same policy as `node-compat`). No product code changes → no release.