### PR TITLE
ci: revive the silently dead auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,39 +1,36 @@
 version: 1
 
+# srvaroa/labeler schema: conditions live DIRECTLY on the label entry.
+# A `matcher:` sub-object is silently ignored (the engine logs "title is
+# not set in config" and applies nothing) — that exact mistake kept this
+# file dead while the job stayed green.
+#
+# The engine is Go/RE2: no lookaheads. `type:chore` excludes deps scopes
+# via explicit alternation (any scope not starting with "deps"); the only
+# real-world deps scopes are dependabot's `chore(deps)` / `chore(deps-dev)`.
+
 labels:
   - label: "enhancement"
-    matcher:
-      title: "^feat(\\(.+\\))?!?:.*"
+    title: "^feat(\\(.+\\))?!?:.*"
   - label: "bug"
-    matcher:
-      title: "^fix(\\(.+\\))?!?:.*"
+    title: "^fix(\\(.+\\))?!?:.*"
   - label: "documentation"
-    matcher:
-      title: "^docs(\\(.+\\))?!?:.*"
+    title: "^docs(\\(.+\\))?!?:.*"
   - label: "type:performance"
-    matcher:
-      title: "^perf(\\(.+\\))?!?:.*"
+    title: "^perf(\\(.+\\))?!?:.*"
   - label: "type:refactor"
-    matcher:
-      title: "^refactor(\\(.+\\))?!?:.*"
+    title: "^refactor(\\(.+\\))?!?:.*"
   - label: "type:test"
-    matcher:
-      title: "^test(\\(.+\\))?!?:.*"
+    title: "^test(\\(.+\\))?!?:.*"
   - label: "type:ci"
-    matcher:
-      title: "^ci(\\(.+\\))?!?:.*"
+    title: "^ci(\\(.+\\))?!?:.*"
   - label: "type:build"
-    matcher:
-      title: "^build(\\(.+\\))?!?:.*"
+    title: "^build(\\(.+\\))?!?:.*"
   - label: "dependencies"
-    matcher:
-      title: "^(chore\\(deps(-dev)?\\)|deps)(\\(.+\\))?!?:.*"
+    title: "^(chore\\(deps(-dev)?\\)|deps)(\\(.+\\))?!?:.*"
   - label: "type:chore"
-    matcher:
-      title: "^chore(?!\\(deps(-dev)?\\))(\\(.+\\))?!?:.*"
+    title: "^chore(\\((?:[^d][^)]*|d(?:[^e][^)]*)?|de(?:[^p][^)]*)?|dep(?:[^s][^)]*)?)\\))?!?:.*"
   - label: "type:i18n"
-    matcher:
-      title: "(?i).*(i18n|locale|translation|translate).*"
+    title: "(?i).*(i18n|locale|translation|translate).*"
   - label: "type:breaking"
-    matcher:
-      title: "^[a-z]+(\\(.+\\))?!:.*"
+    title: "^[a-z]+(\\(.+\\))?!:.*"


### PR DESCRIPTION
Third silent-green gate found today (after the size gates and the welcome bot): **the auto-labeler has never labelled a single PR**.

## Root cause
`.github/labeler.yml` nested every condition under a `matcher:` key — but srvaroa/labeler's schema puts conditions **directly on the label entry**. The engine logged `[Title matches regex] skip, title is not set in config` for every label of every PR and applied nothing, exiting green (`fail_on_error: false`). Verified across today's and yesterday's merged PRs: zero labels everywhere.

## Fix
- Flattened to the documented schema (conditions on the label entry).
- `type:chore` rewritten **without negative lookahead** — the engine is Go/RE2 which rejects `(?!...)` — using explicit alternation to exclude `deps`-prefixed scopes. Verified against the real title corpus: 9/9 (release/demo/docs/dev/deploy → `type:chore`; `chore(deps)` / `chore(deps-dev)` / `deps` → `dependencies` only).

## Living proof
This PR's own title is `ci: …` — **the `type:ci` label appearing on this PR is the integration test**. (Runs from the base branch's workflow but reads this branch's config? No — the labeler reads the config from the default branch, so the proof lands on the first PR opened or edited *after* this merges; I'll backfill today's merged PRs manually.)