### PR TITLE
ci(deps): group vitest-family dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,15 @@ updates:
     cooldown:
       default-days: 7
     groups:
+      # The coverage provider must ship the same major as vitest itself:
+      # separate major-bump PRs each fail CI alone (#223/#225). No
+      # update-types filter — majors included — so the family always
+      # arrives as one lockstep PR. Listed first: dependabot assigns each
+      # dependency to the first matching group.
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       dev-dependencies:
         dependency-type: development
         update-types:


### PR DESCRIPTION
vitest and its coverage provider must ship the same major — the separate dependabot PRs #223 (istanbul 4) and #225 (vitest 4) each fail CI alone because they only work together.

This adds a dedicated `vitest` group (patterns `vitest` + `@vitest/*`, no `update-types` filter so majors are included, listed first since dependabot assigns each dependency to the first matching group). Next cycle the family arrives as one lockstep PR; the actual vitest 4 migration (workspace→projects config, pool options) will be done deliberately on that PR.

#223 and #225 are closed in favor of this.