### PR TITLE
ci(deps): restrict the docker ecosystem to digest refreshes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,19 @@ updates:
   # The demo image pins its bases by digest (supply-chain: a tag is mutable).
   # Without this entry the digests would never move again and the images would
   # silently rot — pinning is only safe when something bumps the pins.
+  #
+  # Digest refreshes only. The tags themselves are deliberate and coupled to
+  # things this file cannot see: `node:20-alpine` matches the oldest Node major
+  # the packages support (and the version the publish jobs run), and the bun tag
+  # must stay in lockstep with `packageManager` and the `oven-sh/setup-bun` pin
+  # in the workflows. Left alone, Dependabot proposed node 20 -> 26 and bumped
+  # bun on its own, which would have split that agreement silently.
+  #
+  # Ignoring the three semver update-types does NOT also mute digest updates:
+  # each one expands to a version RANGE strictly above the current version
+  # (`> x.y.z`, `>= x.(y+1)`, `>= (x+1)`), and a digest refresh keeps the same
+  # tag, so it never falls inside them. Moving a tag is a manual, coordinated
+  # change.
   - package-ecosystem: docker
     directory: /apps/demo
     schedule:
@@ -59,4 +72,10 @@ updates:
       include: scope
     cooldown:
       default-days: 7
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+          - version-update:semver-patch
     open-pull-requests-limit: 5


### PR DESCRIPTION
Follow-up to #242, which added the `docker` package-ecosystem so the digests pinned in `apps/demo/Dockerfile` would not freeze. It worked — and within the hour it also proposed moving the tags themselves:

- **#243** `node:20-alpine` → `26-alpine`
- **#244** `oven/bun:1.3.11-alpine` → `1.3.14-alpine`

Both tags are deliberate and coupled to things `dependabot.yml` cannot see. Node 20 is the oldest major the packages support and the version the npm publish jobs run on. The bun tag has to stay in lockstep with `packageManager` and the `oven-sh/setup-bun` pin in the workflows. Either PR would have split that agreement quietly, in a Dockerfile nobody reads on the way to a release.

Ignoring the three semver update-types leaves digest refreshes flowing, which is the entire point of pinning by hash.

## Why that does not also mute digest updates

This is a property of how the rules are evaluated, not a convention worth trusting on reputation — getting it wrong would freeze the digests forever and quietly trade a mutable-tag risk for a stale-base one. GitHub's own options reference does not cover the interaction, so I checked dependabot-core:

`config/ignore_condition.rb` turns each `update-type` into a version **range** rather than a blanket block, and `version.rb` builds those ranges strictly above the current version:

```ruby
ignored_patch_versions  # "> x.y.z, < x.(y+1)"
ignored_minor_versions  # ">= x.(y+1).0-<pre>, < (x+1)"
ignored_major_versions  # ">= (x+1).0-<pre>"
```

Their union covers everything above the current version and never the current version itself. A digest refresh keeps the same tag, so it resolves to the same version and falls outside all three.

Moving a tag stays a manual, coordinated change. #243 and #244 are closed with a pointer here.